### PR TITLE
Fix canOpenNotificationSettings when permissions not requested

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		43B4618F22A1EB54004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619922A20FDC004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
+		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
 		B731D0BCE8646D60DCD428A5 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
 		C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */; };
@@ -113,6 +114,7 @@
 		58899BE40E40447A87FDF2D8 /* Pods-AutomatedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.release.xcconfig"; sourceTree = "<group>"; };
 		58C2AA35CD060472CAC08059 /* Pods-Automated.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.debug.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.debug.xcconfig"; sourceTree = "<group>"; };
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = NotificationSettingsTests.m; sourceTree = "<group>"; };
 		90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DebugConfigurationTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -217,6 +219,7 @@
 				4358FF9D22541E550068A4FD /* Info.plist */,
 				43B4617422A1E10F004AC636 /* LogTests.m */,
 				90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */,
+				7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -533,6 +536,7 @@
 				43B4617522A1E10F004AC636 /* LogTests.m in Sources */,
 				4358FF9C22541E550068A4FD /* AutomatedTests.m in Sources */,
 				C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */,
+				7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/NotificationSettingsTests.m
+++ b/Automated/AutomatedTests/NotificationSettingsTests.m
@@ -18,9 +18,7 @@
 
 #pragma mark - Helpers
 
-// [[Teak alloc] init] bypasses initWithApplicationId:andSecret: and creates a
-// bare instance with nil properties. This is safe for unit testing because we
-// only set the properties under test. Production code must use [Teak sharedInstance].
+// See CLAUDE.md "Creating Teak instances for testing" for why bare init is safe here.
 - (Teak*)teakWithMockedPushState:(TeakState*)state {
   Teak* teak = [[Teak alloc] init];
   TeakPushState* mockPushState = mock([TeakPushState class]);

--- a/Automated/AutomatedTests/NotificationSettingsTests.m
+++ b/Automated/AutomatedTests/NotificationSettingsTests.m
@@ -11,18 +11,6 @@
 @property (strong, nonatomic) TeakPushState* _Nonnull pushState;
 @end
 
-// Helper to create completed NSInvocationOperations with a known result
-@interface TeakStateReturner : NSObject
-@property (strong, nonatomic) id stateToReturn;
-- (id)returnState;
-@end
-
-@implementation TeakStateReturner
-- (id)returnState {
-  return self.stateToReturn;
-}
-@end
-
 @interface NotificationSettingsTests : XCTestCase
 @end
 
@@ -30,20 +18,13 @@
 
 #pragma mark - Helpers
 
-- (NSInvocationOperation*)completedOperationReturning:(TeakState*)state {
-  TeakStateReturner* returner = [TeakStateReturner new];
-  returner.stateToReturn = state;
-  NSInvocationOperation* op = [[NSInvocationOperation alloc] initWithTarget:returner
-                                                                   selector:@selector(returnState)
-                                                                     object:nil];
-  [op start];
-  return op;
-}
-
+// [[Teak alloc] init] bypasses initWithApplicationId:andSecret: and creates a
+// bare instance with nil properties. This is safe for unit testing because we
+// only set the properties under test. Production code must use [Teak sharedInstance].
 - (Teak*)teakWithMockedPushState:(TeakState*)state {
   Teak* teak = [[Teak alloc] init];
   TeakPushState* mockPushState = mock([TeakPushState class]);
-  [given([mockPushState currentPushState]) willReturn:[self completedOperationReturning:state]];
+  [given([mockPushState cachedPushState]) willReturn:state];
   teak.pushState = mockPushState;
   return teak;
 }

--- a/Automated/AutomatedTests/NotificationSettingsTests.m
+++ b/Automated/AutomatedTests/NotificationSettingsTests.m
@@ -1,0 +1,83 @@
+#import <XCTest/XCTest.h>
+
+#import "../../Teak/TeakPushState.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose internal pushState property for testing
+@interface Teak ()
+@property (strong, nonatomic) TeakPushState* _Nonnull pushState;
+@end
+
+// Helper to create completed NSInvocationOperations with a known result
+@interface TeakStateReturner : NSObject
+@property (strong, nonatomic) id stateToReturn;
+- (id)returnState;
+@end
+
+@implementation TeakStateReturner
+- (id)returnState {
+  return self.stateToReturn;
+}
+@end
+
+@interface NotificationSettingsTests : XCTestCase
+@end
+
+@implementation NotificationSettingsTests
+
+#pragma mark - Helpers
+
+- (NSInvocationOperation*)completedOperationReturning:(TeakState*)state {
+  TeakStateReturner* returner = [TeakStateReturner new];
+  returner.stateToReturn = state;
+  NSInvocationOperation* op = [[NSInvocationOperation alloc] initWithTarget:returner
+                                                                   selector:@selector(returnState)
+                                                                     object:nil];
+  [op start];
+  return op;
+}
+
+- (Teak*)teakWithMockedPushState:(TeakState*)state {
+  Teak* teak = [[Teak alloc] init];
+  TeakPushState* mockPushState = mock([TeakPushState class]);
+  [given([mockPushState currentPushState]) willReturn:[self completedOperationReturning:state]];
+  teak.pushState = mockPushState;
+  return teak;
+}
+
+#pragma mark - canOpenNotificationSettings returns NO when NotDetermined
+
+- (void)testCanOpenNotificationSettingsReturnsFalseWhenNotDetermined {
+  Teak* teak = [self teakWithMockedPushState:[TeakPushState NotDetermined]];
+
+  XCTAssertFalse([teak canOpenNotificationSettings],
+                 @"canOpenNotificationSettings should return NO when push state is NotDetermined");
+}
+
+#pragma mark - canOpenNotificationSettings returns YES for all other states
+
+- (void)testCanOpenNotificationSettingsReturnsTrueWhenAuthorized {
+  Teak* teak = [self teakWithMockedPushState:[TeakPushState Authorized]];
+
+  XCTAssertTrue([teak canOpenNotificationSettings],
+                @"canOpenNotificationSettings should return YES when push state is Authorized");
+}
+
+- (void)testCanOpenNotificationSettingsReturnsTrueWhenDenied {
+  Teak* teak = [self teakWithMockedPushState:[TeakPushState Denied]];
+
+  XCTAssertTrue([teak canOpenNotificationSettings],
+                @"canOpenNotificationSettings should return YES when push state is Denied");
+}
+
+- (void)testCanOpenNotificationSettingsReturnsTrueWhenProvisional {
+  Teak* teak = [self teakWithMockedPushState:[TeakPushState Provisional]];
+
+  XCTAssertTrue([teak canOpenNotificationSettings],
+                @"canOpenNotificationSettings should return YES when push state is Provisional");
+}
+
+@end

--- a/Automated/generate_test
+++ b/Automated/generate_test
@@ -43,7 +43,7 @@ else
     @implementation #{test_class}
 
     - (void)testExample {
-      XCTAssertTrue(YES, @"Replace me with a real test");
+      XCTFail(@"Replace me with a real test");
     }
 
     @end

--- a/Automated/generate_test
+++ b/Automated/generate_test
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Generate a new XCTest file and add it to the Automated Xcode project.
+#
+# Usage:
+#   ./generate_test ClassName
+#
+# Example:
+#   ./generate_test NotificationSettings
+#   -> Creates AutomatedTests/NotificationSettingsTests.m
+#   -> Adds it to the AutomatedTests target in Automated.xcodeproj
+
+require 'xcodeproj'
+require 'fileutils'
+
+PROJ_PATH = File.expand_path('Automated.xcodeproj', __dir__)
+TESTS_DIR = File.expand_path('AutomatedTests', __dir__)
+
+abort "Usage: #{File.basename($PROGRAM_NAME)} ClassName" if ARGV.empty?
+
+class_name = ARGV[0].delete_suffix('Tests')
+test_class = "#{class_name}Tests"
+filename = "#{test_class}.m"
+file_path = File.join(TESTS_DIR, filename)
+
+if File.exist?(file_path)
+  puts "#{filename} already exists, skipping file creation"
+else
+  # --- Generate test file ---
+
+  template = <<~OBJC
+    #import <XCTest/XCTest.h>
+
+    #import <Teak/Teak.h>
+
+    @import OCHamcrest;
+    @import OCMockito;
+
+    @interface #{test_class} : XCTestCase
+    @end
+
+    @implementation #{test_class}
+
+    - (void)testExample {
+      XCTAssertTrue(YES, @"Replace me with a real test");
+    }
+
+    @end
+  OBJC
+
+  File.write(file_path, template)
+  puts "Created #{file_path}"
+end
+
+# --- Add to Xcode project ---
+
+project = Xcodeproj::Project.open(PROJ_PATH)
+
+# Find the AutomatedTests group and target
+tests_group = project.main_group.find_subpath('AutomatedTests', false)
+abort 'Error: Could not find AutomatedTests group in project' unless tests_group
+
+tests_target = project.targets.find { |t| t.name == 'AutomatedTests' }
+abort 'Error: Could not find AutomatedTests target in project' unless tests_target
+
+# Check if already in project
+existing = tests_group.files.find { |f| f.path == filename }
+if existing
+  puts "#{filename} already in project, nothing to do"
+  exit 0
+end
+
+# Add file reference and build file
+file_ref = tests_group.new_file(filename)
+tests_target.source_build_phase.add_file_reference(file_ref)
+
+project.save
+puts "Added #{filename} to AutomatedTests target in #{File.basename(PROJ_PATH)}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ The generator creates a boilerplate XCTest file with OCMockito/OCHamcrest import
 **Test patterns:**
 - `DebugConfigurationTests.m` — dependency injection with real objects (preferred when possible)
 - `LogTests.m` — OCMockito mocking with `mock()`, `given()`, `stubProperty()`, `assertThat()`
-- `NotificationSettingsTests.m` — mocking with NSInvocationOperation for async-pattern methods
+- `NotificationSettingsTests.m` — bare Teak instance with mocked dependencies, internal property re-declaration
 
 **Format code:**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ The generator creates a boilerplate XCTest file with OCMockito/OCHamcrest import
 - Framework public headers: `#import <Teak/Teak.h>`
 - To access internal properties, re-declare them in a class extension in the test file rather than importing `Teak+Internal.h` (which pulls in headers not on the test target's search path)
 
+**Creating Teak instances for testing:**
+`[[Teak alloc] init]` bypasses `initWithApplicationId:andSecret:` and creates a bare instance with nil properties. This is safe for unit testing where you set only the properties under test. Production code must always use `[Teak sharedInstance]`.
+
 **Test patterns:**
 - `DebugConfigurationTests.m` — dependency injection with real objects (preferred when possible)
 - `LogTests.m` — OCMockito mocking with `mock()`, `given()`, `stubProperty()`, `assertThat()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,26 @@ bundle exec fastlane test
 ```
 Runs from the repo root. Uses the `Automated/Automated.xcworkspace` with `scan`. Results output to `test_output/automated/results.xml` (JUnit format).
 
+### Adding Tests
+
+Tests live in `Automated/AutomatedTests/` and use XCTest with OCMockito (~> 5.0) and OCHamcrest for mocking/assertions.
+
+**To add a new test file:**
+```bash
+bundle exec Automated/generate_test ClassName   # generates AutomatedTests/ClassNameTests.m and adds to Xcode project
+```
+The generator creates a boilerplate XCTest file with OCMockito/OCHamcrest imports and adds the file reference and build phase entry to the Xcode project. It's idempotent — safe to re-run on existing files.
+
+**Header imports in tests:**
+- SDK source headers via relative paths: `#import "../../Teak/TeakPushState.h"`
+- Framework public headers: `#import <Teak/Teak.h>`
+- To access internal properties, re-declare them in a class extension in the test file rather than importing `Teak+Internal.h` (which pulls in headers not on the test target's search path)
+
+**Test patterns:**
+- `DebugConfigurationTests.m` — dependency injection with real objects (preferred when possible)
+- `LogTests.m` — OCMockito mocking with `mock()`, `given()`, `stubProperty()`, `assertThat()`
+- `NotificationSettingsTests.m` — mocking with NSInvocationOperation for async-pattern methods
+
 **Format code:**
 ```bash
 ./format-code

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -304,7 +304,9 @@ Teak* _teakSharedInstance;
 
 - (BOOL)canOpenNotificationSettings {
   if (@available(iOS 15.4, *)) {
-    return YES;
+    NSInvocationOperation* op = [self.pushState currentPushState];
+    [op waitUntilFinished];
+    return op.result != [TeakPushState NotDetermined];
   } else {
     return NO;
   }

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -304,9 +304,7 @@ Teak* _teakSharedInstance;
 
 - (BOOL)canOpenNotificationSettings {
   if (@available(iOS 15.4, *)) {
-    NSInvocationOperation* op = [self.pushState currentPushState];
-    [op waitUntilFinished];
-    return op.result != [TeakPushState NotDetermined];
+    return [self.pushState cachedPushState] != [TeakPushState NotDetermined];
   } else {
     return NO;
   }

--- a/Teak/TeakPushState.h
+++ b/Teak/TeakPushState.h
@@ -11,6 +11,7 @@ DeclareTeakState(Authorized);
 DeclareTeakState(Denied);
 
 - (NSInvocationOperation* _Nonnull)currentPushState;
+- (TeakState* _Nonnull)cachedPushState;
 - (void)determineCurrentPushStateWithCompletionHandler:(void (^_Nonnull)(TeakState* _Nonnull))completionHandler;
 - (nonnull NSDictionary*)to_h;
 

--- a/Teak/TeakPushState.m
+++ b/Teak/TeakPushState.m
@@ -175,6 +175,10 @@ DefineTeakState(Denied, (@[ @"Authorized" ]));
 }
 
 - (TeakState*)invocationOperationPushState {
+  return [self cachedPushState];
+}
+
+- (TeakState*)cachedPushState {
   TeakPushStateChainEntry* lastEntry = [self.stateChain lastObject];
   return lastEntry == nil ? [TeakPushState NotDetermined] : lastEntry.state;
 }


### PR DESCRIPTION
## Summary
- `canOpenNotificationSettings` now returns `NO` when notification permissions have not been requested (`NotDetermined`), instead of only checking iOS version
- Adds `generate_test` Ruby script to automate creating test files and registering them in the Xcode project
- Documents test workflow and patterns in CLAUDE.md

Fixes #86

## Test plan
- [x] Unit tests cover all four push states (NotDetermined, Authorized, Denied, Provisional)
- [x] All 18 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)