### PR TITLE
Include deviceId in ConfigurationData and UserData event payloads

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -28,7 +28,10 @@
 		43B4618F22A1EB54004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619922A20FDC004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
+		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
+		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
+
 		B731D0BCE8646D60DCD428A5 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
 		C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */; };
@@ -113,9 +116,11 @@
 		43B4619222A1EBDF004AC636 /* OCMockito.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OCMockito.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		58899BE40E40447A87FDF2D8 /* Pods-AutomatedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.release.xcconfig"; sourceTree = "<group>"; };
 		58C2AA35CD060472CAC08059 /* Pods-Automated.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.debug.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.debug.xcconfig"; sourceTree = "<group>"; };
+		6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UserDataEventTests.m; sourceTree = "<group>"; };
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = NotificationSettingsTests.m; sourceTree = "<group>"; };
 		90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DebugConfigurationTests.m; sourceTree = "<group>"; };
+		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -220,6 +225,8 @@
 				43B4617422A1E10F004AC636 /* LogTests.m */,
 				90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */,
 				7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */,
+				6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */,
+				9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -537,6 +544,8 @@
 				4358FF9C22541E550068A4FD /* AutomatedTests.m in Sources */,
 				C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */,
 				7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */,
+				97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */,
+				6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -738,6 +747,15 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 7FLZTACJ82;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Teak",
+					"$(SRCROOT)/../Teak/Core",
+					"$(SRCROOT)/../Teak/Events",
+					"$(SRCROOT)/../Teak/Configuration",
+					"$(SRCROOT)/../Teak/Extensions",
+					"$(SRCROOT)/../Teak/3rdParty",
+					"$(SRCROOT)/../Teak/Store",
+				);
 				INFOPLIST_FILE = AutomatedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -758,6 +776,15 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 7FLZTACJ82;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Teak",
+					"$(SRCROOT)/../Teak/Core",
+					"$(SRCROOT)/../Teak/Events",
+					"$(SRCROOT)/../Teak/Configuration",
+					"$(SRCROOT)/../Teak/Extensions",
+					"$(SRCROOT)/../Teak/3rdParty",
+					"$(SRCROOT)/../Teak/Store",
+				);
 				INFOPLIST_FILE = AutomatedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Automated/AutomatedTests/RemoteConfigurationEventTests.m
+++ b/Automated/AutomatedTests/RemoteConfigurationEventTests.m
@@ -1,0 +1,47 @@
+#import <XCTest/XCTest.h>
+
+#import "../../Teak/Events/RemoteConfigurationEvent.h"
+#import "../../Teak/Configuration/TeakRemoteConfiguration.h"
+#import "../../Teak/TeakChannelCategory.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+@interface RemoteConfigurationEventTests : XCTestCase
+@end
+
+@implementation RemoteConfigurationEventTests
+
+- (void)testAppFacingConfigurationIncludesDeviceId {
+  NSString* expectedDeviceId = @"test-device-id-67890";
+
+  TeakRemoteConfiguration* remoteConfig = mock([TeakRemoteConfiguration class]);
+  [given([remoteConfig channelCategories]) willReturn:@[]];
+
+  RemoteConfigurationEvent* event = [[RemoteConfigurationEvent alloc] initWithType:RemoteConfigurationReady];
+  [event setValue:remoteConfig forKey:@"remoteConfiguration"];
+  [event setValue:expectedDeviceId forKey:@"deviceId"];
+
+  NSDictionary* config = [event appFacingConfiguration];
+
+  assertThat(config[@"deviceId"], is(expectedDeviceId));
+  assertThat(config[@"channelCategories"], is(notNilValue()));
+}
+
+- (void)testAppFacingConfigurationPreservesChannelCategories {
+  NSString* deviceId = @"device-xyz";
+
+  TeakRemoteConfiguration* remoteConfig = mock([TeakRemoteConfiguration class]);
+  [given([remoteConfig channelCategories]) willReturn:@[]];
+
+  RemoteConfigurationEvent* event = [[RemoteConfigurationEvent alloc] initWithType:RemoteConfigurationReady];
+  [event setValue:remoteConfig forKey:@"remoteConfiguration"];
+  [event setValue:deviceId forKey:@"deviceId"];
+
+  NSDictionary* config = [event appFacingConfiguration];
+
+  assertThat(config[@"channelCategories"], instanceOf([NSArray class]));
+  assertThat(config[@"deviceId"], is(deviceId));
+}
+
+@end

--- a/Automated/AutomatedTests/RemoteConfigurationEventTests.m
+++ b/Automated/AutomatedTests/RemoteConfigurationEventTests.m
@@ -32,14 +32,15 @@
   assertThat(config[@"channelCategories"], is(notNilValue()));
 }
 
-- (void)testAppFacingConfigurationPreservesChannelCategories {
-  NSString* deviceId = @"device-xyz";
+- (void)testAppFacingConfigurationSerializesChannelCategories {
+  TeakChannelCategory* category = [[TeakChannelCategory alloc] initWithId:@"promo" name:@"Promotions" andDescription:@"Deals and offers"];
+  NSDictionary* expectedCategoryDict = [category toDictionary];
 
   TeakRemoteConfiguration* remoteConfig = mock([TeakRemoteConfiguration class]);
-  [given([remoteConfig channelCategories]) willReturn:@[]];
+  [given([remoteConfig channelCategories]) willReturn:@[category]];
 
   TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
-  [given([deviceConfig deviceId]) willReturn:deviceId];
+  [given([deviceConfig deviceId]) willReturn:@"device-xyz"];
 
   RemoteConfigurationEvent* event = [[RemoteConfigurationEvent alloc] initWithType:RemoteConfigurationReady];
   [event setValue:remoteConfig forKey:@"remoteConfiguration"];
@@ -47,8 +48,9 @@
 
   NSDictionary* config = [event appFacingConfiguration];
 
-  assertThat(config[@"channelCategories"], instanceOf([NSArray class]));
-  assertThat(config[@"deviceId"], is(deviceId));
+  NSArray* categories = config[@"channelCategories"];
+  assertThat(categories, hasCountOf(1));
+  assertThat(categories[0], is(expectedCategoryDict));
 }
 
 @end

--- a/Automated/AutomatedTests/RemoteConfigurationEventTests.m
+++ b/Automated/AutomatedTests/RemoteConfigurationEventTests.m
@@ -53,4 +53,20 @@
   assertThat(categories[0], is(expectedCategoryDict));
 }
 
+- (void)testAppFacingConfigurationWithNilDeviceIdProducesNSNull {
+  TeakRemoteConfiguration* remoteConfig = mock([TeakRemoteConfiguration class]);
+  [given([remoteConfig channelCategories]) willReturn:@[]];
+
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:nil];
+
+  RemoteConfigurationEvent* event = [[RemoteConfigurationEvent alloc] initWithType:RemoteConfigurationReady];
+  [event setValue:remoteConfig forKey:@"remoteConfiguration"];
+  [event setValue:deviceConfig forKey:@"deviceConfiguration"];
+
+  NSDictionary* config = [event appFacingConfiguration];
+
+  assertThat(config[@"deviceId"], is([NSNull null]));
+}
+
 @end

--- a/Automated/AutomatedTests/RemoteConfigurationEventTests.m
+++ b/Automated/AutomatedTests/RemoteConfigurationEventTests.m
@@ -1,8 +1,9 @@
 #import <XCTest/XCTest.h>
 
-#import "../../Teak/Events/RemoteConfigurationEvent.h"
-#import "../../Teak/Configuration/TeakRemoteConfiguration.h"
-#import "../../Teak/TeakChannelCategory.h"
+#import "RemoteConfigurationEvent.h"
+#import "TeakDeviceConfiguration.h"
+#import "TeakRemoteConfiguration.h"
+#import "TeakChannelCategory.h"
 
 @import OCHamcrest;
 @import OCMockito;
@@ -18,9 +19,12 @@
   TeakRemoteConfiguration* remoteConfig = mock([TeakRemoteConfiguration class]);
   [given([remoteConfig channelCategories]) willReturn:@[]];
 
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:expectedDeviceId];
+
   RemoteConfigurationEvent* event = [[RemoteConfigurationEvent alloc] initWithType:RemoteConfigurationReady];
   [event setValue:remoteConfig forKey:@"remoteConfiguration"];
-  [event setValue:expectedDeviceId forKey:@"deviceId"];
+  [event setValue:deviceConfig forKey:@"deviceConfiguration"];
 
   NSDictionary* config = [event appFacingConfiguration];
 
@@ -34,9 +38,12 @@
   TeakRemoteConfiguration* remoteConfig = mock([TeakRemoteConfiguration class]);
   [given([remoteConfig channelCategories]) willReturn:@[]];
 
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:deviceId];
+
   RemoteConfigurationEvent* event = [[RemoteConfigurationEvent alloc] initWithType:RemoteConfigurationReady];
   [event setValue:remoteConfig forKey:@"remoteConfiguration"];
-  [event setValue:deviceId forKey:@"deviceId"];
+  [event setValue:deviceConfig forKey:@"deviceConfiguration"];
 
   NSDictionary* config = [event appFacingConfiguration];
 

--- a/Automated/AutomatedTests/UserDataEventTests.m
+++ b/Automated/AutomatedTests/UserDataEventTests.m
@@ -83,4 +83,28 @@
   assertThat(dict[@"deviceId"], is(deviceId));
 }
 
+- (void)testToDictionaryWithNilDeviceIdProducesNSNull {
+  TeakChannelStatus* emailStatus = mock([TeakChannelStatus class]);
+  [given([emailStatus toDictionary]) willReturn:@{@"state" : @"unknown"}];
+  TeakChannelStatus* pushStatus = mock([TeakChannelStatus class]);
+  [given([pushStatus toDictionary]) willReturn:@{@"state" : @"unknown"}];
+  TeakChannelStatus* smsStatus = mock([TeakChannelStatus class]);
+  [given([smsStatus toDictionary]) willReturn:@{@"state" : @"unknown"}];
+
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:nil];
+
+  UserDataEvent* event = [[UserDataEvent alloc] initWithType:UserData];
+  [event setValue:@{} forKey:@"additionalData"];
+  [event setValue:emailStatus forKey:@"emailStatus"];
+  [event setValue:pushStatus forKey:@"pushStatus"];
+  [event setValue:smsStatus forKey:@"smsStatus"];
+  [event setValue:(NSDictionary*)[NSNull null] forKey:@"pushRegistration"];
+  [event setValue:deviceConfig forKey:@"deviceConfiguration"];
+
+  NSDictionary* dict = [event toDictionary];
+
+  assertThat(dict[@"deviceId"], is([NSNull null]));
+}
+
 @end

--- a/Automated/AutomatedTests/UserDataEventTests.m
+++ b/Automated/AutomatedTests/UserDataEventTests.m
@@ -1,7 +1,8 @@
 #import <XCTest/XCTest.h>
 
-#import "../../Teak/Events/UserDataEvent.h"
-#import "../../Teak/Core/TeakChannelStatus.h"
+#import "UserDataEvent.h"
+#import "TeakChannelStatus.h"
+#import "TeakDeviceConfiguration.h"
 
 @import OCHamcrest;
 @import OCMockito;
@@ -21,6 +22,9 @@
   TeakChannelStatus* smsStatus = mock([TeakChannelStatus class]);
   [given([smsStatus toDictionary]) willReturn:@{@"state" : @"unknown"}];
 
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:expectedDeviceId];
+
   NSDictionary* additionalData = @{};
   NSDictionary* pushRegistration = (NSDictionary*)[NSNull null];
 
@@ -30,7 +34,7 @@
   [event setValue:pushStatus forKey:@"pushStatus"];
   [event setValue:smsStatus forKey:@"smsStatus"];
   [event setValue:pushRegistration forKey:@"pushRegistration"];
-  [event setValue:expectedDeviceId forKey:@"deviceId"];
+  [event setValue:deviceConfig forKey:@"deviceConfiguration"];
 
   NSDictionary* dict = [event toDictionary];
 
@@ -55,6 +59,9 @@
   NSDictionary* smsDict = @{@"state" : @"unknown"};
   [given([smsStatus toDictionary]) willReturn:smsDict];
 
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:deviceId];
+
   NSDictionary* additionalData = @{@"key" : @"value"};
   NSDictionary* pushRegistration = @{@"apns" : @"token123"};
 
@@ -64,7 +71,7 @@
   [event setValue:pushStatus forKey:@"pushStatus"];
   [event setValue:smsStatus forKey:@"smsStatus"];
   [event setValue:pushRegistration forKey:@"pushRegistration"];
-  [event setValue:deviceId forKey:@"deviceId"];
+  [event setValue:deviceConfig forKey:@"deviceConfiguration"];
 
   NSDictionary* dict = [event toDictionary];
 

--- a/Automated/AutomatedTests/UserDataEventTests.m
+++ b/Automated/AutomatedTests/UserDataEventTests.m
@@ -1,0 +1,79 @@
+#import <XCTest/XCTest.h>
+
+#import "../../Teak/Events/UserDataEvent.h"
+#import "../../Teak/Core/TeakChannelStatus.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+@interface UserDataEventTests : XCTestCase
+@end
+
+@implementation UserDataEventTests
+
+- (void)testToDictionaryIncludesDeviceId {
+  NSString* expectedDeviceId = @"test-device-id-12345";
+
+  TeakChannelStatus* emailStatus = mock([TeakChannelStatus class]);
+  [given([emailStatus toDictionary]) willReturn:@{@"state" : @"unknown"}];
+  TeakChannelStatus* pushStatus = mock([TeakChannelStatus class]);
+  [given([pushStatus toDictionary]) willReturn:@{@"state" : @"unknown"}];
+  TeakChannelStatus* smsStatus = mock([TeakChannelStatus class]);
+  [given([smsStatus toDictionary]) willReturn:@{@"state" : @"unknown"}];
+
+  NSDictionary* additionalData = @{};
+  NSDictionary* pushRegistration = (NSDictionary*)[NSNull null];
+
+  UserDataEvent* event = [[UserDataEvent alloc] initWithType:UserData];
+  [event setValue:additionalData forKey:@"additionalData"];
+  [event setValue:emailStatus forKey:@"emailStatus"];
+  [event setValue:pushStatus forKey:@"pushStatus"];
+  [event setValue:smsStatus forKey:@"smsStatus"];
+  [event setValue:pushRegistration forKey:@"pushRegistration"];
+  [event setValue:expectedDeviceId forKey:@"deviceId"];
+
+  NSDictionary* dict = [event toDictionary];
+
+  assertThat(dict[@"deviceId"], is(expectedDeviceId));
+  assertThat(dict[@"emailStatus"], is(notNilValue()));
+  assertThat(dict[@"pushStatus"], is(notNilValue()));
+  assertThat(dict[@"smsStatus"], is(notNilValue()));
+}
+
+- (void)testToDictionaryPreservesExistingFields {
+  NSString* deviceId = @"device-abc";
+
+  TeakChannelStatus* emailStatus = mock([TeakChannelStatus class]);
+  NSDictionary* emailDict = @{@"state" : @"opted_in"};
+  [given([emailStatus toDictionary]) willReturn:emailDict];
+
+  TeakChannelStatus* pushStatus = mock([TeakChannelStatus class]);
+  NSDictionary* pushDict = @{@"state" : @"opted_out"};
+  [given([pushStatus toDictionary]) willReturn:pushDict];
+
+  TeakChannelStatus* smsStatus = mock([TeakChannelStatus class]);
+  NSDictionary* smsDict = @{@"state" : @"unknown"};
+  [given([smsStatus toDictionary]) willReturn:smsDict];
+
+  NSDictionary* additionalData = @{@"key" : @"value"};
+  NSDictionary* pushRegistration = @{@"apns" : @"token123"};
+
+  UserDataEvent* event = [[UserDataEvent alloc] initWithType:UserData];
+  [event setValue:additionalData forKey:@"additionalData"];
+  [event setValue:emailStatus forKey:@"emailStatus"];
+  [event setValue:pushStatus forKey:@"pushStatus"];
+  [event setValue:smsStatus forKey:@"smsStatus"];
+  [event setValue:pushRegistration forKey:@"pushRegistration"];
+  [event setValue:deviceId forKey:@"deviceId"];
+
+  NSDictionary* dict = [event toDictionary];
+
+  assertThat(dict[@"emailStatus"], is(emailDict));
+  assertThat(dict[@"pushStatus"], is(pushDict));
+  assertThat(dict[@"smsStatus"], is(smsDict));
+  assertThat(dict[@"additionalData"], is(additionalData));
+  assertThat(dict[@"pushRegistration"], is(pushRegistration));
+  assertThat(dict[@"deviceId"], is(deviceId));
+}
+
+@end

--- a/Teak/Configuration/TeakRemoteConfiguration.m
+++ b/Teak/Configuration/TeakRemoteConfiguration.m
@@ -163,7 +163,7 @@
                                                     // Categories
                                                     self.channelCategories = [TeakChannelCategory createFromRemoteConfiguration:reply[@"available_categories"]];
 
-                                                    [RemoteConfigurationEvent remoteConfigurationReady:self deviceId:[TeakConfiguration configuration].deviceConfiguration.deviceId];
+                                                    [RemoteConfigurationEvent remoteConfigurationReady:self deviceConfiguration:[TeakConfiguration configuration].deviceConfiguration];
                                                   }];
     [request send];
   }];

--- a/Teak/Configuration/TeakRemoteConfiguration.m
+++ b/Teak/Configuration/TeakRemoteConfiguration.m
@@ -163,7 +163,7 @@
                                                     // Categories
                                                     self.channelCategories = [TeakChannelCategory createFromRemoteConfiguration:reply[@"available_categories"]];
 
-                                                    [RemoteConfigurationEvent remoteConfigurationReady:self];
+                                                    [RemoteConfigurationEvent remoteConfigurationReady:self deviceId:[TeakConfiguration configuration].deviceConfiguration.deviceId];
                                                   }];
     [request send];
   }];

--- a/Teak/Configuration/TeakRemoteConfiguration.m
+++ b/Teak/Configuration/TeakRemoteConfiguration.m
@@ -163,7 +163,7 @@
                                                     // Categories
                                                     self.channelCategories = [TeakChannelCategory createFromRemoteConfiguration:reply[@"available_categories"]];
 
-                                                    [RemoteConfigurationEvent remoteConfigurationReady:self deviceConfiguration:[TeakConfiguration configuration].deviceConfiguration];
+                                                    [RemoteConfigurationEvent remoteConfigurationReady:self deviceConfiguration:session.deviceConfiguration];
                                                   }];
     [request send];
   }];

--- a/Teak/Events/RemoteConfigurationEvent.h
+++ b/Teak/Events/RemoteConfigurationEvent.h
@@ -1,10 +1,12 @@
 #import "TeakEvent.h"
 #import "TeakRemoteConfiguration.h"
 
+@class TeakDeviceConfiguration;
+
 @interface RemoteConfigurationEvent : TeakEvent
 @property (strong, nonatomic, readonly) TeakRemoteConfiguration* _Nonnull remoteConfiguration;
-@property (strong, nonatomic, readonly) NSString* _Nonnull deviceId;
+@property (strong, nonatomic, readonly) TeakDeviceConfiguration* _Nonnull deviceConfiguration;
 
-+ (void)remoteConfigurationReady:(TeakRemoteConfiguration* _Nonnull)remoteConfiguration deviceId:(NSString* _Nonnull)deviceId;
++ (void)remoteConfigurationReady:(TeakRemoteConfiguration* _Nonnull)remoteConfiguration deviceConfiguration:(TeakDeviceConfiguration* _Nonnull)deviceConfiguration;
 - (nonnull NSDictionary*)appFacingConfiguration;
 @end

--- a/Teak/Events/RemoteConfigurationEvent.h
+++ b/Teak/Events/RemoteConfigurationEvent.h
@@ -3,7 +3,8 @@
 
 @interface RemoteConfigurationEvent : TeakEvent
 @property (strong, nonatomic, readonly) TeakRemoteConfiguration* _Nonnull remoteConfiguration;
+@property (strong, nonatomic, readonly) NSString* _Nonnull deviceId;
 
-+ (void)remoteConfigurationReady:(TeakRemoteConfiguration* _Nonnull)remoteConfiguration;
++ (void)remoteConfigurationReady:(TeakRemoteConfiguration* _Nonnull)remoteConfiguration deviceId:(NSString* _Nonnull)deviceId;
 - (nonnull NSDictionary*)appFacingConfiguration;
 @end

--- a/Teak/Events/RemoteConfigurationEvent.m
+++ b/Teak/Events/RemoteConfigurationEvent.m
@@ -1,17 +1,19 @@
 #import "RemoteConfigurationEvent.h"
 #import "TeakChannelCategory.h"
+#import "TeakDeviceConfiguration.h"
+#import "TeakHelpers.h"
 
 @interface RemoteConfigurationEvent ()
 @property (strong, nonatomic, readwrite) TeakRemoteConfiguration* _Nonnull remoteConfiguration;
-@property (strong, nonatomic, readwrite) NSString* _Nonnull deviceId;
+@property (strong, nonatomic, readwrite) TeakDeviceConfiguration* _Nonnull deviceConfiguration;
 @end
 
 @implementation RemoteConfigurationEvent
 
-+ (void)remoteConfigurationReady:(TeakRemoteConfiguration* _Nonnull)remoteConfiguration deviceId:(NSString* _Nonnull)deviceId {
++ (void)remoteConfigurationReady:(TeakRemoteConfiguration* _Nonnull)remoteConfiguration deviceConfiguration:(TeakDeviceConfiguration* _Nonnull)deviceConfiguration {
   RemoteConfigurationEvent* event = [[RemoteConfigurationEvent alloc] initWithType:RemoteConfigurationReady];
   event.remoteConfiguration = remoteConfiguration;
-  event.deviceId = deviceId;
+  event.deviceConfiguration = deviceConfiguration;
   [TeakEvent postEvent:event];
 }
 
@@ -22,7 +24,7 @@
   }
   return @{
     @"channelCategories": serializedCategories,
-    @"deviceId": self.deviceId
+    @"deviceId": TeakValueOrNSNull(self.deviceConfiguration.deviceId)
   };
 }
 @end

--- a/Teak/Events/RemoteConfigurationEvent.m
+++ b/Teak/Events/RemoteConfigurationEvent.m
@@ -3,13 +3,15 @@
 
 @interface RemoteConfigurationEvent ()
 @property (strong, nonatomic, readwrite) TeakRemoteConfiguration* _Nonnull remoteConfiguration;
+@property (strong, nonatomic, readwrite) NSString* _Nonnull deviceId;
 @end
 
 @implementation RemoteConfigurationEvent
 
-+ (void)remoteConfigurationReady:(TeakRemoteConfiguration* _Nonnull)remoteConfiguration {
++ (void)remoteConfigurationReady:(TeakRemoteConfiguration* _Nonnull)remoteConfiguration deviceId:(NSString* _Nonnull)deviceId {
   RemoteConfigurationEvent* event = [[RemoteConfigurationEvent alloc] initWithType:RemoteConfigurationReady];
   event.remoteConfiguration = remoteConfiguration;
+  event.deviceId = deviceId;
   [TeakEvent postEvent:event];
 }
 
@@ -19,7 +21,8 @@
     [serializedCategories addObject:[category toDictionary]];
   }
   return @{
-    @"channelCategories": serializedCategories
+    @"channelCategories": serializedCategories,
+    @"deviceId": self.deviceId
   };
 }
 @end

--- a/Teak/Events/UserDataEvent.h
+++ b/Teak/Events/UserDataEvent.h
@@ -7,8 +7,9 @@
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull pushStatus;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull smsStatus;
 @property (strong, nonatomic, readonly) NSDictionary* _Nonnull pushRegistration;
+@property (strong, nonatomic, readonly) NSString* _Nonnull deviceId;
 
 - (NSDictionary* _Nonnull)toDictionary;
 
-+ (void)userDataReceived:(NSDictionary* _Nonnull)additionalData emailStatus:(TeakChannelStatus* _Nonnull)emailStatus pushStatus:(TeakChannelStatus* _Nonnull)pushStatus smsStatus:(TeakChannelStatus* _Nonnull)smsStatus pushRegistration:(NSDictionary* _Nonnull)pushRegistration;
++ (void)userDataReceived:(NSDictionary* _Nonnull)additionalData emailStatus:(TeakChannelStatus* _Nonnull)emailStatus pushStatus:(TeakChannelStatus* _Nonnull)pushStatus smsStatus:(TeakChannelStatus* _Nonnull)smsStatus pushRegistration:(NSDictionary* _Nonnull)pushRegistration deviceId:(NSString* _Nonnull)deviceId;
 @end

--- a/Teak/Events/UserDataEvent.h
+++ b/Teak/Events/UserDataEvent.h
@@ -1,15 +1,17 @@
 #import "TeakChannelStatus.h"
 #import "TeakEvent.h"
 
+@class TeakDeviceConfiguration;
+
 @interface UserDataEvent : TeakEvent
 @property (strong, nonatomic, readonly) NSDictionary* _Nonnull additionalData;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull emailStatus;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull pushStatus;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull smsStatus;
 @property (strong, nonatomic, readonly) NSDictionary* _Nonnull pushRegistration;
-@property (strong, nonatomic, readonly) NSString* _Nonnull deviceId;
+@property (strong, nonatomic, readonly) TeakDeviceConfiguration* _Nonnull deviceConfiguration;
 
 - (NSDictionary* _Nonnull)toDictionary;
 
-+ (void)userDataReceived:(NSDictionary* _Nonnull)additionalData emailStatus:(TeakChannelStatus* _Nonnull)emailStatus pushStatus:(TeakChannelStatus* _Nonnull)pushStatus smsStatus:(TeakChannelStatus* _Nonnull)smsStatus pushRegistration:(NSDictionary* _Nonnull)pushRegistration deviceId:(NSString* _Nonnull)deviceId;
++ (void)userDataReceived:(NSDictionary* _Nonnull)additionalData emailStatus:(TeakChannelStatus* _Nonnull)emailStatus pushStatus:(TeakChannelStatus* _Nonnull)pushStatus smsStatus:(TeakChannelStatus* _Nonnull)smsStatus pushRegistration:(NSDictionary* _Nonnull)pushRegistration deviceConfiguration:(TeakDeviceConfiguration* _Nonnull)deviceConfiguration;
 @end

--- a/Teak/Events/UserDataEvent.m
+++ b/Teak/Events/UserDataEvent.m
@@ -1,4 +1,5 @@
 #import "UserDataEvent.h"
+#import "TeakDeviceConfiguration.h"
 #import "TeakHelpers.h"
 
 @interface UserDataEvent ()
@@ -7,7 +8,7 @@
 @property (strong, nonatomic, readwrite) TeakChannelStatus* _Nonnull pushStatus;
 @property (strong, nonatomic, readwrite) TeakChannelStatus* _Nonnull smsStatus;
 @property (strong, nonatomic, readwrite) NSDictionary* _Nonnull pushRegistration;
-@property (strong, nonatomic, readwrite) NSString* _Nonnull deviceId;
+@property (strong, nonatomic, readwrite) TeakDeviceConfiguration* _Nonnull deviceConfiguration;
 @end
 
 @implementation UserDataEvent
@@ -20,18 +21,18 @@
     @"smsStatus" : [self.smsStatus toDictionary],
     @"additionalData" : TeakValueOrNSNull(self.additionalData),
     @"pushRegistration" : TeakValueOrNSNull(self.pushRegistration),
-    @"deviceId" : TeakValueOrNSNull(self.deviceId),
+    @"deviceId" : TeakValueOrNSNull(self.deviceConfiguration.deviceId),
   };
 }
 
-+ (void)userDataReceived:(NSDictionary* _Nonnull)additionalData emailStatus:(TeakChannelStatus* _Nonnull)emailStatus pushStatus:(TeakChannelStatus* _Nonnull)pushStatus smsStatus:(TeakChannelStatus* _Nonnull)smsStatus pushRegistration:(NSDictionary* _Nonnull)pushRegistration deviceId:(NSString* _Nonnull)deviceId {
++ (void)userDataReceived:(NSDictionary* _Nonnull)additionalData emailStatus:(TeakChannelStatus* _Nonnull)emailStatus pushStatus:(TeakChannelStatus* _Nonnull)pushStatus smsStatus:(TeakChannelStatus* _Nonnull)smsStatus pushRegistration:(NSDictionary* _Nonnull)pushRegistration deviceConfiguration:(TeakDeviceConfiguration* _Nonnull)deviceConfiguration {
   UserDataEvent* event = [[UserDataEvent alloc] initWithType:UserData];
   event.additionalData = additionalData;
   event.emailStatus = emailStatus;
   event.pushStatus = pushStatus;
   event.smsStatus = smsStatus;
   event.pushRegistration = pushRegistration;
-  event.deviceId = deviceId;
+  event.deviceConfiguration = deviceConfiguration;
   [TeakEvent postEvent:event];
 }
 @end

--- a/Teak/Events/UserDataEvent.m
+++ b/Teak/Events/UserDataEvent.m
@@ -7,6 +7,7 @@
 @property (strong, nonatomic, readwrite) TeakChannelStatus* _Nonnull pushStatus;
 @property (strong, nonatomic, readwrite) TeakChannelStatus* _Nonnull smsStatus;
 @property (strong, nonatomic, readwrite) NSDictionary* _Nonnull pushRegistration;
+@property (strong, nonatomic, readwrite) NSString* _Nonnull deviceId;
 @end
 
 @implementation UserDataEvent
@@ -19,16 +20,18 @@
     @"smsStatus" : [self.smsStatus toDictionary],
     @"additionalData" : TeakValueOrNSNull(self.additionalData),
     @"pushRegistration" : TeakValueOrNSNull(self.pushRegistration),
+    @"deviceId" : TeakValueOrNSNull(self.deviceId),
   };
 }
 
-+ (void)userDataReceived:(NSDictionary* _Nonnull)additionalData emailStatus:(TeakChannelStatus* _Nonnull)emailStatus pushStatus:(TeakChannelStatus* _Nonnull)pushStatus smsStatus:(TeakChannelStatus* _Nonnull)smsStatus pushRegistration:(NSDictionary* _Nonnull)pushRegistration {
++ (void)userDataReceived:(NSDictionary* _Nonnull)additionalData emailStatus:(TeakChannelStatus* _Nonnull)emailStatus pushStatus:(TeakChannelStatus* _Nonnull)pushStatus smsStatus:(TeakChannelStatus* _Nonnull)smsStatus pushRegistration:(NSDictionary* _Nonnull)pushRegistration deviceId:(NSString* _Nonnull)deviceId {
   UserDataEvent* event = [[UserDataEvent alloc] initWithType:UserData];
   event.additionalData = additionalData;
   event.emailStatus = emailStatus;
   event.pushStatus = pushStatus;
   event.smsStatus = smsStatus;
   event.pushRegistration = pushRegistration;
+  event.deviceId = deviceId;
   [TeakEvent postEvent:event];
 }
 @end

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -901,7 +901,8 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
                         emailStatus:self.emailStatus
                          pushStatus:self.pushStatus
                           smsStatus:self.smsStatus
-                   pushRegistration:pushRegistration];
+                   pushRegistration:pushRegistration
+                           deviceId:self.deviceConfiguration.deviceId];
   }
 }
 

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -902,7 +902,7 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
                          pushStatus:self.pushStatus
                           smsStatus:self.smsStatus
                    pushRegistration:pushRegistration
-                           deviceId:self.deviceConfiguration.deviceId];
+                deviceConfiguration:self.deviceConfiguration];
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `deviceId` property to `RemoteConfigurationEvent` and `UserDataEvent`
- `appFacingConfiguration` dictionary now includes `deviceId` (consumed by Unity `OnConfigurationData`)
- `toDictionary` on `UserDataEvent` now includes `deviceId` (consumed by Unity `OnUserData`)
- Device ID sourced from `TeakDeviceConfiguration.deviceId` at each event's dispatch site

Closes #92

## Test plan
- [x] Unit tests for `UserDataEvent.toDictionary` including `deviceId`
- [x] Unit tests for `RemoteConfigurationEvent.appFacingConfiguration` including `deviceId`
- [x] All 18 tests pass (4 new + 14 existing)
- [ ] Integration: verify Unity `ConfigurationData.DeviceId` populates from native payload (blocked on GoCarrot/teak-unity#102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)