### PR TITLE
Use bare header imports in test files

### DIFF
--- a/Automated/AutomatedTests/DebugConfigurationTests.m
+++ b/Automated/AutomatedTests/DebugConfigurationTests.m
@@ -1,6 +1,6 @@
 #import <XCTest/XCTest.h>
 
-#import "../../Teak/Configuration/TeakDebugConfiguration.h"
+#import "TeakDebugConfiguration.h"
 
 @interface DebugConfigurationTests : XCTestCase
 @end

--- a/Automated/AutomatedTests/LogTests.m
+++ b/Automated/AutomatedTests/LogTests.m
@@ -1,6 +1,6 @@
 #import <XCTest/XCTest.h>
 
-#import "../../Teak/TeakLog.h"
+#import "TeakLog.h"
 #import <Teak/Teak.h>
 
 @import OCHamcrest;

--- a/Automated/AutomatedTests/NotificationSettingsTests.m
+++ b/Automated/AutomatedTests/NotificationSettingsTests.m
@@ -1,6 +1,6 @@
 #import <XCTest/XCTest.h>
 
-#import "../../Teak/TeakPushState.h"
+#import "TeakPushState.h"
 #import <Teak/Teak.h>
 
 @import OCHamcrest;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ bundle exec Automated/generate_test ClassName   # generates AutomatedTests/Class
 The generator creates a boilerplate XCTest file with OCMockito/OCHamcrest imports and adds the file reference and build phase entry to the Xcode project. It's idempotent — safe to re-run on existing files.
 
 **Header imports in tests:**
-- SDK source headers via relative paths: `#import "../../Teak/TeakPushState.h"`
+- SDK source headers via bare name: `#import "TeakPushState.h"` (HEADER_SEARCH_PATHS covers all SDK subdirectories)
 - Framework public headers: `#import <Teak/Teak.h>`
 - To access internal properties, re-declare them in a class extension in the test file rather than importing `Teak+Internal.h` (which pulls in headers not on the test target's search path)
 


### PR DESCRIPTION
## Summary

- Replace fragile relative path imports (`../../Teak/...`) with bare header names in 3 existing test files, leveraging the `HEADER_SEARCH_PATHS` added in PR #103
- Update CLAUDE.md guidance to document the bare import convention

Closes #104

## Test plan

- [x] All 24 tests pass with `bundle exec fastlane test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)