### PR TITLE
Upload xcframework artifacts to S3 in deploy jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,10 @@ jobs:
             aws s3 cp workspace/Sample/build/Release-iphoneos/TeakNotificationContent.appex.zip s3://teak-build-artifacts/ios/TeakNotificationContent-$(git describe --tags --always).appex.zip --acl public-read
             aws s3 cp workspace/TeakExtensions.zip s3://teak-build-artifacts/ios/TeakExtensions-$(git describe --tags --always).zip --acl public-read
             aws s3 cp workspace/Teak.framework.zip.sha512 s3://teak-build-artifacts/ios/Teak-$(git describe --tags --always).framework.zip.sha512 --acl public-read
+            aws s3 cp workspace/TeakFramework/Teak.xcframework.zip s3://teak-build-artifacts/ios/Teak-$(git describe --tags --always).xcframework.zip --acl public-read
+            aws s3 cp workspace/TeakFramework/Teak.xcframework.zip.sha512 s3://teak-build-artifacts/ios/Teak-$(git describe --tags --always).xcframework.zip.sha512 --acl public-read
+            aws s3 cp workspace/TeakFramework/TeakExtension.xcframework.zip s3://teak-build-artifacts/ios/TeakExtension-$(git describe --tags --always).xcframework.zip --acl public-read
+            aws s3 cp workspace/TeakFramework/TeakExtension.xcframework.zip.sha512 s3://teak-build-artifacts/ios/TeakExtension-$(git describe --tags --always).xcframework.zip.sha512 --acl public-read
 
   deploy_latest:
     docker:
@@ -87,6 +91,10 @@ jobs:
             aws s3 cp workspace/Sample/build/Release-iphoneos/TeakNotificationContent.appex.zip s3://teak-build-artifacts/ios/TeakNotificationContent.appex.zip --acl public-read
             aws s3 cp workspace/TeakExtensions.zip s3://teak-build-artifacts/ios/TeakExtensions.zip --acl public-read
             aws s3 cp workspace/Teak.framework.zip.sha512 s3://teak-build-artifacts/ios/Teak.framework.zip.sha512 --acl public-read
+            aws s3 cp workspace/TeakFramework/Teak.xcframework.zip s3://teak-build-artifacts/ios/Teak.xcframework.zip --acl public-read
+            aws s3 cp workspace/TeakFramework/Teak.xcframework.zip.sha512 s3://teak-build-artifacts/ios/Teak.xcframework.zip.sha512 --acl public-read
+            aws s3 cp workspace/TeakFramework/TeakExtension.xcframework.zip s3://teak-build-artifacts/ios/TeakExtension.xcframework.zip --acl public-read
+            aws s3 cp workspace/TeakFramework/TeakExtension.xcframework.zip.sha512 s3://teak-build-artifacts/ios/TeakExtension.xcframework.zip.sha512 --acl public-read
 
 workflows:
   version: 2


### PR DESCRIPTION
## Summary

- Add S3 upload commands for `Teak.xcframework.zip`, `TeakExtension.xcframework.zip`, and their SHA512 checksums to both `deploy_versioned` and `deploy_latest` CI jobs
- The `build` job already produces and persists these artifacts to the workspace, but they were never uploaded
- Existing legacy `.framework.zip` uploads are preserved (removal tracked in #102)

Fixes #111

## Test plan

- [ ] Verify the `tagged-build` workflow runs `deploy_versioned` successfully with the new S3 paths
- [ ] Verify xcframework zips appear in `s3://teak-build-artifacts/ios/` with correct versioned names
- [ ] Verify `deploy_latest` uploads unversioned xcframework zips after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)