### PR TITLE
SDK: push-to-update token forwarding for live activities

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -30,8 +30,8 @@
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
+		85A63C9999785FF21D1103A5 /* LiveActivityTokenForwardingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E6A73CCD830C97AAE1C09C9 /* LiveActivityTokenForwardingTests.m */; };
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
-
 		B731D0BCE8646D60DCD428A5 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
 		C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */; };
@@ -119,6 +119,7 @@
 		6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UserDataEventTests.m; sourceTree = "<group>"; };
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = NotificationSettingsTests.m; sourceTree = "<group>"; };
+		8E6A73CCD830C97AAE1C09C9 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
 		90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DebugConfigurationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -227,6 +228,7 @@
 				7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */,
 				6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */,
 				9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */,
+				8E6A73CCD830C97AAE1C09C9 /* LiveActivityTokenForwardingTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -546,6 +548,7 @@
 				7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */,
 				97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */,
 				6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */,
+				85A63C9999785FF21D1103A5 /* LiveActivityTokenForwardingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/LiveActivityTokenForwardingTests.m
+++ b/Automated/AutomatedTests/LiveActivityTokenForwardingTests.m
@@ -1,0 +1,96 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakOperation.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+@interface LiveActivityTokenForwardingTests : XCTestCase
+@end
+
+@implementation LiveActivityTokenForwardingTests
+
+#pragma mark - Helpers
+
+- (NSData*)sampleTokenData {
+  unsigned char bytes[] = {0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x01, 0x23};
+  return [NSData dataWithBytes:bytes length:sizeof(bytes)];
+}
+
+- (TeakOperationResult*)runOperationAndGetResult:(TeakOperation*)op {
+  NSOperationQueue* queue = [[NSOperationQueue alloc] init];
+  [queue addOperation:op];
+  [queue waitUntilAllOperationsAreFinished];
+  return (TeakOperationResult*)[op result];
+}
+
+#pragma mark - Input validation: activityId
+
+- (void)testNilActivityIdReturnsErrorOperation {
+  NSData* token = [self sampleTokenData];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  TeakOperation* op = [Teak startedLiveActivity:nil withToken:token];
+#pragma clang diagnostic pop
+
+  XCTAssertNotNil(op, @"Should return an operation even for nil activityId");
+
+  TeakOperationResult* result = [self runOperationAndGetResult:op];
+  XCTAssertNotNil(result);
+  XCTAssertTrue(result.error, @"Result should be an error");
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"activityId"]);
+}
+
+- (void)testEmptyActivityIdReturnsErrorOperation {
+  NSData* token = [self sampleTokenData];
+  TeakOperation* op = [Teak startedLiveActivity:@"" withToken:token];
+
+  XCTAssertNotNil(op, @"Should return an operation even for empty activityId");
+
+  TeakOperationResult* result = [self runOperationAndGetResult:op];
+  XCTAssertNotNil(result);
+  XCTAssertTrue(result.error, @"Result should be an error");
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"activityId"]);
+}
+
+#pragma mark - Input validation: token
+
+- (void)testNilTokenReturnsErrorOperation {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  TeakOperation* op = [Teak startedLiveActivity:@"my-activity" withToken:nil];
+#pragma clang diagnostic pop
+
+  XCTAssertNotNil(op, @"Should return an operation even for nil token");
+
+  TeakOperationResult* result = [self runOperationAndGetResult:op];
+  XCTAssertNotNil(result);
+  XCTAssertTrue(result.error, @"Result should be an error");
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"token"]);
+}
+
+- (void)testEmptyTokenReturnsErrorOperation {
+  TeakOperation* op = [Teak startedLiveActivity:@"my-activity" withToken:[NSData data]];
+
+  XCTAssertNotNil(op, @"Should return an operation even for empty token");
+
+  TeakOperationResult* result = [self runOperationAndGetResult:op];
+  XCTAssertNotNil(result);
+  XCTAssertTrue(result.error, @"Result should be an error");
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"token"]);
+}
+
+#pragma mark - Valid inputs
+
+- (void)testValidInputsReturnsNonNilOperation {
+  TeakOperation* op = [Teak startedLiveActivity:@"my-activity" withToken:[self sampleTokenData]];
+
+  XCTAssertNotNil(op, @"Should return a TeakOperation for valid inputs");
+}
+
+@end

--- a/Automated/AutomatedTests/LiveActivityTokenForwardingTests.m
+++ b/Automated/AutomatedTests/LiveActivityTokenForwardingTests.m
@@ -6,6 +6,11 @@
 @import OCHamcrest;
 @import OCMockito;
 
+// Re-expose internal replyParser property for testing
+@interface TeakOperation ()
+@property (nonatomic, copy, nullable) id (^replyParser)(NSDictionary* _Nonnull);
+@end
+
 @interface LiveActivityTokenForwardingTests : XCTestCase
 @end
 
@@ -23,6 +28,14 @@
   [queue addOperation:op];
   [queue waitUntilAllOperationsAreFinished];
   return (TeakOperationResult*)[op result];
+}
+
+/// Extract the request params dictionary (endpoint + payload) from a TeakOperation's invocation.
+- (NSDictionary*)requestParamsFromOperation:(TeakOperation*)op {
+  NSInvocation* inv = op.invocation;
+  __unsafe_unretained NSDictionary* requestParams;
+  [inv getArgument:&requestParams atIndex:2];
+  return requestParams;
 }
 
 #pragma mark - Input validation: activityId
@@ -85,12 +98,52 @@
   XCTAssertNotNil(result.errors[@"token"]);
 }
 
-#pragma mark - Valid inputs
+#pragma mark - Request construction
 
-- (void)testValidInputsReturnsNonNilOperation {
+- (void)testRequestUsesCorrectEndpoint {
   TeakOperation* op = [Teak startedLiveActivity:@"my-activity" withToken:[self sampleTokenData]];
 
-  XCTAssertNotNil(op, @"Should return a TeakOperation for valid inputs");
+  NSDictionary* requestParams = [self requestParamsFromOperation:op];
+  XCTAssertEqualObjects(requestParams[@"endpoint"], @"/me/live_activities");
+}
+
+- (void)testRequestPayloadContainsActivityId {
+  TeakOperation* op = [Teak startedLiveActivity:@"my-activity" withToken:[self sampleTokenData]];
+
+  NSDictionary* payload = [self requestParamsFromOperation:op][@"payload"];
+  XCTAssertEqualObjects(payload[@"live_activity_id"], @"my-activity",
+                         @"Payload should contain the activity ID as live_activity_id");
+}
+
+- (void)testRequestPayloadContainsHexEncodedToken {
+  TeakOperation* op = [Teak startedLiveActivity:@"my-activity" withToken:[self sampleTokenData]];
+
+  NSDictionary* payload = [self requestParamsFromOperation:op][@"payload"];
+  XCTAssertEqualObjects(payload[@"token"], @"deadbeefcafe0123",
+                         @"Payload should contain the token as a lowercase hex string");
+}
+
+#pragma mark - Reply parser
+
+- (void)testReplyParserReturnsSuccessForOkStatus {
+  TeakOperation* op = [Teak startedLiveActivity:@"my-activity" withToken:[self sampleTokenData]];
+
+  NSDictionary* reply = @{@"status" : @"ok"};
+  TeakOperationResult* result = op.replyParser(reply);
+
+  XCTAssertFalse(result.error);
+  XCTAssertEqualObjects(result.status, @"ok");
+}
+
+- (void)testReplyParserReturnsErrorForInvalidDevice {
+  TeakOperation* op = [Teak startedLiveActivity:@"my-activity" withToken:[self sampleTokenData]];
+
+  NSDictionary* reply = @{@"status" : @"invalid_device", @"errors" : @{@"device_id" : @[ @"not found" ]}};
+  TeakOperationResult* result = op.replyParser(reply);
+
+  XCTAssertTrue(result.error);
+  XCTAssertEqualObjects(result.status, @"invalid_device");
+  XCTAssertNotNil(result.errors[@"device_id"]);
 }
 
 @end

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -572,6 +572,19 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  */
 - (nonnull TeakOperation*)setState:(nonnull NSString*)state forChannel:(nonnull NSString*)channel andCategory:(nonnull NSString*)category;
 
+/**
+ * Report a live activity push-to-update token to Teak.
+ *
+ * Call this when a live activity starts and receives its push token, and again if the token
+ * changes during the activity's lifetime. The SDK forwards the token to the Teak backend so
+ * that server-driven live activity updates can be delivered via APNs.
+ *
+ * @param activityId The identifier for the live activity instance (from Activity.id).
+ * @param pushToken  The push-to-update token data (from Activity.pushTokenUpdates).
+ * @return A TeakOperation which contains the status and result of the call.
+ */
++ (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken API_AVAILABLE(ios(16.1));
+
 @end
 
 #endif /* __OBJC__ */

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -583,7 +583,7 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  * @param pushToken  The push-to-update token data (from Activity.pushTokenUpdates).
  * @return A TeakOperation which contains the status and result of the call.
  */
-+ (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken API_AVAILABLE(ios(16.1));
++ (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken;
 
 @end
 

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -197,31 +197,22 @@ Teak* _teakSharedInstance;
     return op;
   }
 
-  if (@available(iOS 16.1, *)) {
-    TeakOperation* op = [TeakOperation forEndpoint:@"/me/live_activities"
-                                       withPayload:@{
-                                         @"live_activity_id" : [activityId copy],
-                                         @"token" : [tokenString copy]
+  TeakOperation* op = [TeakOperation forEndpoint:@"/me/live_activities"
+                                     withPayload:@{
+                                       @"live_activity_id" : [activityId copy],
+                                       @"token" : [tokenString copy]
+                                     }
+                                     replyParser:^id _Nullable(NSDictionary* _Nonnull reply) {
+                                       TeakOperationResult* result = [[TeakOperationResult alloc] initWithStatus:reply[@"status"] andErrors:reply[@"errors"]];
+
+                                       if (!result.error) {
+                                         TeakLog_i(@"live_activity.token.forwarded", @{@"activityId" : activityId});
+                                       } else {
+                                         TeakLog_e(@"live_activity.token.error", @"Error forwarding live activity token.", @{@"response" : reply});
                                        }
-                                       replyParser:^id _Nullable(NSDictionary* _Nonnull reply) {
-                                         TeakOperationResult* result = [[TeakOperationResult alloc] initWithStatus:reply[@"status"] andErrors:reply[@"errors"]];
 
-                                         if (!result.error) {
-                                           TeakLog_i(@"live_activity.token.forwarded", @{@"activityId" : activityId});
-                                         } else {
-                                           TeakLog_e(@"live_activity.token.error", @"Error forwarding live activity token.", @{@"response" : reply});
-                                         }
-
-                                         return result;
-                                       }];
-    [[Teak sharedInstance].operationQueue addOperation:op];
-    return op;
-  }
-
-  // Below iOS 16.1 — no-op, return an error result
-  TeakLog_t(@"live_activity.token.unavailable", @"Live Activities require iOS 16.1 or later");
-  result = [[TeakOperationResult alloc] initWithStatus:@"error" andErrors:@{@"os" : @[ @"Live Activities require iOS 16.1 or later" ]}];
-  TeakOperation* op = [TeakOperation withResult:result];
+                                       return result;
+                                     }];
   [[Teak sharedInstance].operationQueue addOperation:op];
   return op;
 }

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -175,6 +175,57 @@ Teak* _teakSharedInstance;
   [[self sharedInstance] setStringAttribute:value forKey:key];
 }
 
++ (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken {
+  TeakLog_t(@"[Teak startedLiveActivity]", @{@"activityId" : _(activityId)});
+
+  TeakOperationResult* result = nil;
+
+  if (activityId == nil || activityId.length == 0) {
+    TeakLog_e(@"live_activity.token.error", @"activityId cannot be null or empty");
+    result = [[TeakOperationResult alloc] initWithStatus:@"error" andErrors:@{@"activityId" : @[ @"activityId cannot be null or empty" ]}];
+  }
+
+  NSString* tokenString = TeakHexStringFromData(pushToken);
+  if (!result && (pushToken == nil || tokenString == nil)) {
+    TeakLog_e(@"live_activity.token.error", @"pushToken cannot be null or empty");
+    result = [[TeakOperationResult alloc] initWithStatus:@"error" andErrors:@{@"token" : @[ @"pushToken cannot be null or empty" ]}];
+  }
+
+  if (result) {
+    TeakOperation* op = [TeakOperation withResult:result];
+    [[Teak sharedInstance].operationQueue addOperation:op];
+    return op;
+  }
+
+  if (@available(iOS 16.1, *)) {
+    TeakOperation* op = [TeakOperation forEndpoint:@"/me/live_activities"
+                                       withPayload:@{
+                                         @"live_activity_id" : [activityId copy],
+                                         @"token" : [tokenString copy]
+                                       }
+                                       replyParser:^id _Nullable(NSDictionary* _Nonnull reply) {
+                                         TeakOperationResult* result = [[TeakOperationResult alloc] initWithStatus:reply[@"status"] andErrors:reply[@"errors"]];
+
+                                         if (!result.error) {
+                                           TeakLog_i(@"live_activity.token.forwarded", @{@"activityId" : activityId});
+                                         } else {
+                                           TeakLog_e(@"live_activity.token.error", @"Error forwarding live activity token.", @{@"response" : reply});
+                                         }
+
+                                         return result;
+                                       }];
+    [[Teak sharedInstance].operationQueue addOperation:op];
+    return op;
+  }
+
+  // Below iOS 16.1 — no-op, return an error result
+  TeakLog_t(@"live_activity.token.unavailable", @"Live Activities require iOS 16.1 or later");
+  result = [[TeakOperationResult alloc] initWithStatus:@"error" andErrors:@{@"os" : @[ @"Live Activities require iOS 16.1 or later" ]}];
+  TeakOperation* op = [TeakOperation withResult:result];
+  [[Teak sharedInstance].operationQueue addOperation:op];
+  return op;
+}
+
 - (void)identifyUser:(NSString*)userIdentifier {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
## Summary

Games using iOS Live Activities need to forward per-activity push tokens to the Teak backend so the server can send live activity updates via APNs. Currently the cleanroom prototype observes `Activity.pushTokenUpdates` but has no SDK method to call — it just prints the token.

This adds `+[Teak startedLiveActivity:withToken:]`, which hex-encodes the token and POSTs it to `/me/live_activities` with the activity ID. The game calls this each time a token is received or rotated. The server upserts, so repeated calls update the token rather than creating duplicates.

Blocked by C-605 (the `/me/live_activities` server endpoint), currently in review.

## Key decisions

- Returns `TeakOperation` (not void) so callers can check for `invalid_device` errors — closer to the local notification scheduling pattern than the fire-and-forget push token registration
- No iOS availability guard — the ObjC implementation uses only `NSString`/`NSData`/`TeakRequest`, so version checking is the caller's responsibility (Swift/ActivityKit side)
- No C extern bridge yet — that's C-613 (Unity SDK wrappers), which depends on this

## Test plan

- [x] Unit tests pass (`bundle exec fastlane test` — 32/32, 0 failures)
- [x] Input validation: nil/empty activityId and pushToken return error results
- [x] Request construction: correct endpoint, payload with activity ID and hex-encoded token
- [x] Reply parser: handles `ok` and `invalid_device` responses correctly
- [ ] Integration test with C-605 endpoint once merged
- [ ] Cleanroom app updated to call `Teak.startedLiveActivity()` instead of printing tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)