### PR TITLE
C-608: Add registerPushToStartToken: public API

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -29,9 +29,11 @@
 		43B4619922A20FDC004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
+		6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
 		B731D0BCE8646D60DCD428A5 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
+		B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
 		C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */; };
 		F05085BD353FDBF2763B09C7 /* LiveActivityTokenForwardingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */; };
@@ -85,6 +87,7 @@
 
 /* Begin PBXFileReference section */
 		0D7BD679E00A2C57BE7AA5E3 /* Pods-AutomatedUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.release.xcconfig"; sourceTree = "<group>"; };
+		12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakDeviceConfigurationTests.m; sourceTree = "<group>"; };
 		2CC8154D37CB560E22904A43 /* Pods-AutomatedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3FFF5A9E3FBB614BDDAF98EC /* Pods-Automated.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.release.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.release.xcconfig"; sourceTree = "<group>"; };
 		433392902654423400B10DE4 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
@@ -120,6 +123,7 @@
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = NotificationSettingsTests.m; sourceTree = "<group>"; };
 		90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DebugConfigurationTests.m; sourceTree = "<group>"; };
+		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -229,6 +233,8 @@
 				6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */,
 				9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */,
 				AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */,
+				98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */,
+				12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -549,6 +555,8 @@
 				97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */,
 				6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */,
 				F05085BD353FDBF2763B09C7 /* LiveActivityTokenForwardingTests.m in Sources */,
+				6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */,
+				B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/PushToStartTokenRegistrationTests.m
+++ b/Automated/AutomatedTests/PushToStartTokenRegistrationTests.m
@@ -1,0 +1,91 @@
+#import <XCTest/XCTest.h>
+
+#import "PushRegistrationEvent.h"
+#import "TeakEvent.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Expose the internal serial event processing queue so tests can flush pending events.
+@interface TeakEvent (Testing)
++ (dispatch_queue_t)eventProcessingQueue;
+@end
+
+@interface PushToStartTokenRegistrationTests : XCTestCase
+@property (strong, nonatomic) NSMutableArray<PushRegistrationEvent*>* capturedEvents;
+@property (strong, nonatomic) TeakEventBlockHandler* handler;
+@end
+
+@implementation PushToStartTokenRegistrationTests
+
+- (void)setUp {
+  self.capturedEvents = [[NSMutableArray alloc] init];
+  NSMutableArray* events = self.capturedEvents;
+  self.handler = [TeakEventBlockHandler handlerWithBlock:^(TeakEvent* event) {
+    if (event.type == LiveActivityPushToStartRegistered) {
+      @synchronized(events) {
+        [events addObject:(PushRegistrationEvent*)event];
+      }
+    }
+  }];
+  [TeakEvent addEventHandler:self.handler];
+}
+
+- (void)tearDown {
+  [TeakEvent removeEventHandler:self.handler];
+  self.handler = nil;
+  self.capturedEvents = nil;
+}
+
+- (NSData*)sampleTokenData {
+  unsigned char bytes[] = {0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x01, 0x23};
+  return [NSData dataWithBytes:bytes length:sizeof(bytes)];
+}
+
+- (NSArray<PushRegistrationEvent*>*)drainCapturedEvents {
+  // postEvent: dispatches onto a serial queue; a synchronous barrier guarantees that any
+  // event posted before this call has been delivered to registered handlers.
+  dispatch_sync([TeakEvent eventProcessingQueue], ^{
+  });
+  @synchronized(self.capturedEvents) {
+    return [self.capturedEvents copy];
+  }
+}
+
+#pragma mark - Input validation
+
+- (void)testNilTokenDoesNotPostEvent {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  [Teak registerPushToStartToken:nil];
+#pragma clang diagnostic pop
+
+  assertThat([self drainCapturedEvents], hasCountOf(0));
+}
+
+- (void)testEmptyTokenDoesNotPostEvent {
+  [Teak registerPushToStartToken:[NSData data]];
+
+  assertThat([self drainCapturedEvents], hasCountOf(0));
+}
+
+#pragma mark - Event posting
+
+- (void)testValidTokenPostsEventWithLowercaseHexString {
+  [Teak registerPushToStartToken:[self sampleTokenData]];
+
+  NSArray<PushRegistrationEvent*>* events = [self drainCapturedEvents];
+  assertThat(events, hasCountOf(1));
+  assertThat(events[0].token, is(@"deadbeefcafe0123"));
+}
+
+- (void)testValidTokenEventUsesLiveActivityPushToStartRegisteredType {
+  [Teak registerPushToStartToken:[self sampleTokenData]];
+
+  NSArray<PushRegistrationEvent*>* events = [self drainCapturedEvents];
+  assertThat(events, hasCountOf(1));
+  XCTAssertEqual(events[0].type, LiveActivityPushToStartRegistered);
+}
+
+@end

--- a/Automated/AutomatedTests/TeakDeviceConfigurationTests.m
+++ b/Automated/AutomatedTests/TeakDeviceConfigurationTests.m
@@ -1,0 +1,120 @@
+#import <XCTest/XCTest.h>
+
+#import "PushRegistrationEvent.h"
+#import "TeakDeviceConfiguration.h"
+#import "TeakEvent.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+@interface PushRegistrationEvent (Testing)
+@property (strong, nonatomic, readwrite) NSString* _Nullable token;
+@end
+
+@interface TeakDeviceConfigurationTests : XCTestCase
+@end
+
+@implementation TeakDeviceConfigurationTests
+
+#pragma mark - Initial state
+
+- (void)testLiveActivityPushToStartTokenInitializesToEmptyString {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+  assertThat(config.liveActivityPushToStartToken, is(@""));
+}
+
+#pragma mark - handleEvent
+
+- (void)testHandlingLiveActivityPushToStartRegisteredUpdatesProperty {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+
+  PushRegistrationEvent* event = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  event.token = @"abcdef0123456789";
+  [config handleEvent:event];
+
+  assertThat(config.liveActivityPushToStartToken, is(@"abcdef0123456789"));
+}
+
+- (void)testHandlingLiveActivityPushToStartRegisteredDoesNotUpdateApnsPushToken {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+
+  PushRegistrationEvent* apnsEvent = [[PushRegistrationEvent alloc] initWithType:PushRegistered];
+  apnsEvent.token = @"apns-token";
+  [config handleEvent:apnsEvent];
+
+  PushRegistrationEvent* ptsEvent = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  ptsEvent.token = @"pts-token";
+  [config handleEvent:ptsEvent];
+
+  assertThat(config.pushToken, is(@"apns-token"));
+  assertThat(config.liveActivityPushToStartToken, is(@"pts-token"));
+}
+
+- (void)testHandlingPushRegisteredDoesNotUpdateLiveActivityPushToStartToken {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+
+  PushRegistrationEvent* apnsEvent = [[PushRegistrationEvent alloc] initWithType:PushRegistered];
+  apnsEvent.token = @"apns-token";
+  [config handleEvent:apnsEvent];
+
+  assertThat(config.liveActivityPushToStartToken, is(@""));
+}
+
+- (void)testTokenRotationUpdatesStoredValue {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+
+  PushRegistrationEvent* firstEvent = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  firstEvent.token = @"first-token";
+  [config handleEvent:firstEvent];
+  assertThat(config.liveActivityPushToStartToken, is(@"first-token"));
+
+  PushRegistrationEvent* rotatedEvent = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  rotatedEvent.token = @"second-token";
+  [config handleEvent:rotatedEvent];
+  assertThat(config.liveActivityPushToStartToken, is(@"second-token"));
+}
+
+- (void)testSameTokenTwiceDoesNotChangeValue {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+
+  PushRegistrationEvent* firstEvent = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  firstEvent.token = @"same-token";
+  [config handleEvent:firstEvent];
+
+  PushRegistrationEvent* secondEvent = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  secondEvent.token = @"same-token";
+  [config handleEvent:secondEvent];
+
+  assertThat(config.liveActivityPushToStartToken, is(@"same-token"));
+}
+
+#pragma mark - to_h
+
+- (void)testToHIncludesLiveActivityPushToStartKeyUnderPushRegistration {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+
+  PushRegistrationEvent* event = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  event.token = @"live-activity-token";
+  [config handleEvent:event];
+
+  NSDictionary* dict = [config to_h];
+  assertThat(dict[@"pushRegistration"][@"live_activity_push_to_start_key"], is(@"live-activity-token"));
+}
+
+- (void)testToHIncludesLiveActivityPushToStartKeyAlongsideApnsPushKey {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+
+  PushRegistrationEvent* apnsEvent = [[PushRegistrationEvent alloc] initWithType:PushRegistered];
+  apnsEvent.token = @"apns-token";
+  [config handleEvent:apnsEvent];
+
+  PushRegistrationEvent* ptsEvent = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  ptsEvent.token = @"pts-token";
+  [config handleEvent:ptsEvent];
+
+  NSDictionary* pushRegistration = [config to_h][@"pushRegistration"];
+  assertThat(pushRegistration[@"apns_push_key"], is(@"apns-token"));
+  assertThat(pushRegistration[@"live_activity_push_to_start_key"], is(@"pts-token"));
+}
+
+@end

--- a/Teak/Configuration/TeakDeviceConfiguration.h
+++ b/Teak/Configuration/TeakDeviceConfiguration.h
@@ -11,6 +11,7 @@ extern NSString* _Nonnull const TeakDeviceConfiguration_NotificationDisplayState
 @property (strong, nonatomic, readonly) NSString* _Nonnull deviceId;
 @property (strong, nonatomic, readonly) NSString* _Nonnull deviceModel;
 @property (strong, nonatomic, readonly) NSString* _Nonnull pushToken;
+@property (strong, nonatomic, readonly) NSString* _Nonnull liveActivityPushToStartToken;
 @property (strong, nonatomic, readonly) NSString* _Nonnull platformString;
 @property (strong, nonatomic, readonly) NSString* _Nonnull advertisingIdentifier;
 @property (strong, nonatomic, readonly) NSString* _Nonnull notificationDisplayEnabled;

--- a/Teak/Configuration/TeakDeviceConfiguration.m
+++ b/Teak/Configuration/TeakDeviceConfiguration.m
@@ -189,6 +189,9 @@ NSString* const TeakDeviceConfiguration_NotificationDisplayState_NotDetermined =
       if (self.pushToken != nil) self.pushToken = nil;
     } break;
     case LiveActivityPushToStartRegistered: {
+      // No symmetric "unregister" case: push-to-start tokens are per-device and persistent.
+      // The OS rotates the token in place via Activity.pushToStartTokenUpdates; it doesn't
+      // revoke one the way push permission revocation nils out pushToken.
       NSString* token = ((PushRegistrationEvent*)event).token;
       // Check before assignment so KVO isn't triggered unless it should be
       if (self.liveActivityPushToStartToken == nil || ![self.liveActivityPushToStartToken isEqualToString:token]) {

--- a/Teak/Configuration/TeakDeviceConfiguration.m
+++ b/Teak/Configuration/TeakDeviceConfiguration.m
@@ -18,6 +18,7 @@ NSString* const TeakDeviceConfiguration_NotificationDisplayState_NotDetermined =
 @property (strong, nonatomic, readwrite) NSString* deviceId;
 @property (strong, nonatomic, readwrite) NSString* deviceModel;
 @property (strong, nonatomic, readwrite) NSString* pushToken;
+@property (strong, nonatomic, readwrite) NSString* liveActivityPushToStartToken;
 @property (strong, nonatomic, readwrite) NSString* platformString;
 @property (strong, nonatomic, readwrite) NSString* advertisingIdentifier;
 @property (strong, nonatomic, readwrite) NSString* notificationDisplayEnabled;
@@ -89,6 +90,7 @@ NSString* const TeakDeviceConfiguration_NotificationDisplayState_NotDetermined =
     // Make sure these are not nil
     self.advertisingIdentifier = @"";
     self.pushToken = @"";
+    self.liveActivityPushToStartToken = @"";
 
     [TeakEvent addEventHandler:self];
 
@@ -152,7 +154,8 @@ NSString* const TeakDeviceConfiguration_NotificationDisplayState_NotDetermined =
     @"limitAdTracking" : [NSNumber numberWithBool:self.limitAdTracking],
     @"notificationDisplayEnabled" : self.notificationDisplayEnabled,
     @"pushRegistration" : @{
-      @"apns_push_key" : TeakValueOrNSNull(self.pushToken)
+      @"apns_push_key" : TeakValueOrNSNull(self.pushToken),
+      @"live_activity_push_to_start_key" : TeakValueOrNSNull(self.liveActivityPushToStartToken)
     }
   };
 }
@@ -184,6 +187,13 @@ NSString* const TeakDeviceConfiguration_NotificationDisplayState_NotDetermined =
     } break;
     case PushUnRegistered: {
       if (self.pushToken != nil) self.pushToken = nil;
+    } break;
+    case LiveActivityPushToStartRegistered: {
+      NSString* token = ((PushRegistrationEvent*)event).token;
+      // Check before assignment so KVO isn't triggered unless it should be
+      if (self.liveActivityPushToStartToken == nil || ![self.liveActivityPushToStartToken isEqualToString:token]) {
+        self.liveActivityPushToStartToken = token;
+      }
     } break;
     case LifecycleActivate: {
       [self updateValuesThatCouldHaveChanged];

--- a/Teak/Configuration/TeakDeviceConfiguration.m
+++ b/Teak/Configuration/TeakDeviceConfiguration.m
@@ -189,9 +189,6 @@ NSString* const TeakDeviceConfiguration_NotificationDisplayState_NotDetermined =
       if (self.pushToken != nil) self.pushToken = nil;
     } break;
     case LiveActivityPushToStartRegistered: {
-      // No symmetric "unregister" case: push-to-start tokens are per-device and persistent.
-      // The OS rotates the token in place via Activity.pushToStartTokenUpdates; it doesn't
-      // revoke one the way push permission revocation nils out pushToken.
       NSString* token = ((PushRegistrationEvent*)event).token;
       // Check before assignment so KVO isn't triggered unless it should be
       if (self.liveActivityPushToStartToken == nil || ![self.liveActivityPushToStartToken isEqualToString:token]) {

--- a/Teak/Events/PushRegistrationEvent.h
+++ b/Teak/Events/PushRegistrationEvent.h
@@ -5,4 +5,5 @@
 
 + (void)registeredWithToken:(NSString* _Nonnull)token;
 + (void)unRegistered;
++ (void)liveActivityPushToStartRegisteredWithToken:(NSString* _Nonnull)token;
 @end

--- a/Teak/Events/PushRegistrationEvent.m
+++ b/Teak/Events/PushRegistrationEvent.m
@@ -15,4 +15,10 @@
   PushRegistrationEvent* event = [[PushRegistrationEvent alloc] initWithType:PushUnRegistered];
   [TeakEvent postEvent:event];
 }
+
++ (void)liveActivityPushToStartRegisteredWithToken:(NSString* _Nonnull)token {
+  PushRegistrationEvent* event = [[PushRegistrationEvent alloc] initWithType:LiveActivityPushToStartRegistered];
+  event.token = token;
+  [TeakEvent postEvent:event];
+}
 @end

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -597,9 +597,6 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  * ``Activity<Attributes>.pushToStartTokenUpdates`` — typically at launch and again
  * whenever the OS emits a rotated token.
  *
- * Safe to call on any iOS version. Push-to-start tokens are an iOS 17.2+ feature,
- * so in practice this is only invoked on iOS 17.2 and newer.
- *
  * @param token The push-to-start token data from ``Activity.pushToStartTokenUpdates``.
  */
 + (void)registerPushToStartToken:(nonnull NSData*)token;

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -598,8 +598,8 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  * activities for this app; Teak stores it on the device configuration and forwards it with the
  * next session identify request.
  *
- * Safe to call on any iOS version: on versions below iOS 17.2 the OS never produces a
- * push-to-start token, so this method simply won't be invoked.
+ * Safe to call on any iOS version. In practice callers will only invoke this on iOS 17.2+,
+ * since the OS does not produce a push-to-start token on older versions.
  *
  * @param token The push-to-start token data from ``Activity.pushToStartTokenUpdates``.
  */

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -590,6 +590,21 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  */
 + (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken systemActivityId:(nonnull NSString*)systemActivityId;
 
+/**
+ * Report the live activity push-to-start token for this device.
+ *
+ * Call this once at launch, after observing ``Activity<Attributes>.pushToStartTokenUpdates``, and
+ * whenever the OS rotates the token. The token is per-device and applies to all push-to-start
+ * activities for this app; Teak stores it on the device configuration and forwards it with the
+ * next session identify request.
+ *
+ * Safe to call on any iOS version: on versions below iOS 17.2 the OS never produces a
+ * push-to-start token, so this method simply won't be invoked.
+ *
+ * @param token The push-to-start token data from ``Activity.pushToStartTokenUpdates``.
+ */
++ (void)registerPushToStartToken:(nonnull NSData*)token;
+
 @end
 
 #endif /* __OBJC__ */

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -591,15 +591,14 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
 + (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken systemActivityId:(nonnull NSString*)systemActivityId;
 
 /**
- * Report the live activity push-to-start token for this device.
+ * Report a live activity push-to-start token to Teak.
  *
- * Call this once at launch, after observing ``Activity<Attributes>.pushToStartTokenUpdates``, and
- * whenever the OS rotates the token. The token is per-device and applies to all push-to-start
- * activities for this app; Teak stores it on the device configuration and forwards it with the
- * next session identify request.
+ * Call this from any location where your app observes
+ * ``Activity<Attributes>.pushToStartTokenUpdates`` — typically at launch and again
+ * whenever the OS emits a rotated token.
  *
- * Safe to call on any iOS version. In practice callers will only invoke this on iOS 17.2+,
- * since the OS does not produce a push-to-start token on older versions.
+ * Safe to call on any iOS version. Push-to-start tokens are an iOS 17.2+ feature,
+ * so in practice this is only invoked on iOS 17.2 and newer.
  *
  * @param token The push-to-start token data from ``Activity.pushToStartTokenUpdates``.
  */

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -175,6 +175,17 @@ Teak* _teakSharedInstance;
   [[self sharedInstance] setStringAttribute:value forKey:key];
 }
 
++ (void)registerPushToStartToken:(nonnull NSData*)token {
+  NSString* tokenString = TeakHexStringFromData(token);
+  if (tokenString == nil) {
+    TeakLog_e(@"live_activity.push_to_start.error", @"token cannot be null or empty");
+    return;
+  }
+
+  TeakLog_i(@"live_activity.push_to_start.registered", @{@"token" : tokenString});
+  [PushRegistrationEvent liveActivityPushToStartRegisteredWithToken:tokenString];
+}
+
 + (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken systemActivityId:(nonnull NSString*)systemActivityId {
   TeakLog_t(@"[Teak startedLiveActivity]", @{@"activityId" : _(activityId), @"systemActivityId" : _(systemActivityId)});
 

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -176,9 +176,14 @@ Teak* _teakSharedInstance;
 }
 
 + (void)registerPushToStartToken:(nonnull NSData*)token {
+  if (token == nil) {
+    TeakLog_e(@"live_activity.push_to_start.error", @"token cannot be nil");
+    return;
+  }
+
   NSString* tokenString = TeakHexStringFromData(token);
   if (tokenString == nil) {
-    TeakLog_e(@"live_activity.push_to_start.error", @"token cannot be null or empty");
+    TeakLog_e(@"live_activity.push_to_start.error", @"token cannot be empty");
     return;
   }
 

--- a/Teak/TeakEvent.h
+++ b/Teak/TeakEvent.h
@@ -6,6 +6,7 @@
 typedef enum {
   PushRegistered,
   PushUnRegistered,
+  LiveActivityPushToStartRegistered,
   UserIdentified,
   TrackedEvent,
   PurchaseFailed,

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -247,6 +247,10 @@ DefineTeakState(Expired, (@[]));
       payload[@"apns_push_key"] = @"";
     }
 
+    if ([self.deviceConfiguration.liveActivityPushToStartToken length] > 0 && dataCollectionConfiguration.enablePushKey) {
+      payload[@"live_activity_push_to_start_key"] = self.deviceConfiguration.liveActivityPushToStartToken;
+    }
+
     if (!self.appConfiguration.sdk5Behaviors) {
       if (dataCollectionConfiguration.enableFacebookAccessToken) {
         if (self.facebookAccessToken == nil) {
@@ -388,6 +392,7 @@ DefineTeakState(Expired, (@[]));
 
     RegisterKeyValueObserverFor(self.deviceConfiguration, advertisingIdentifier);
     RegisterKeyValueObserverFor(self.deviceConfiguration, pushToken);
+    RegisterKeyValueObserverFor(self.deviceConfiguration, liveActivityPushToStartToken);
     RegisterKeyValueObserverFor(self, currentState);
 
     [TeakEvent addEventHandler:self];
@@ -415,6 +420,7 @@ DefineTeakState(Expired, (@[]));
   }
   UnRegisterKeyValueObserverFor(self.deviceConfiguration, advertisingIdentifier);
   UnRegisterKeyValueObserverFor(self.deviceConfiguration, pushToken);
+  UnRegisterKeyValueObserverFor(self.deviceConfiguration, liveActivityPushToStartToken);
   UnRegisterKeyValueObserverFor(self, currentState);
 
   [TeakEvent removeEventHandler:self];
@@ -920,6 +926,11 @@ KeyValueObserverFor(TeakSession, TeakDeviceConfiguration, advertisingIdentifier)
 }
 
 KeyValueObserverFor(TeakSession, TeakDeviceConfiguration, pushToken) {
+  TeakUnusedKVOValues;
+  [self identifyUserInfoHasChanged];
+}
+
+KeyValueObserverFor(TeakSession, TeakDeviceConfiguration, liveActivityPushToStartToken) {
   TeakUnusedKVOValues;
   [self identifyUserInfoHasChanged];
 }


### PR DESCRIPTION
## Summary
- Adds `+[Teak registerPushToStartToken:]` so games can forward the live activity push-to-start token from `Activity<T>.pushToStartTokenUpdates` to Teak.
- Stores the token on `TeakDeviceConfiguration` and sends it to the server as `live_activity_push_to_start_key` in the `users.json` identify payload, mirroring the existing `apns_push_key` flow.
- Server side (C-606) already accepts this field and records it as a new `push_type`.

## Key decisions
- Reused `PushRegistrationEvent` with a new `LiveActivityPushToStartRegistered` event type rather than creating a new event class, matching how `LifecycleEvent` handles multiple lifecycle transitions. Avoids churning the Teak.xcodeproj across its two framework targets.
- Stored in memory (not `NSUserDefaults`), just like `pushToken` — the game calls this at each launch after observing `pushToStartTokenUpdates`.
- KVO on `liveActivityPushToStartToken` triggers `identifyUserInfoHasChanged` so token rotation during a session re-sends the identify request.
- `live_activity_push_to_start_key` is only included in the payload when non-empty (additive), whereas `apns_push_key` always writes `""` when unset. This avoids ambiguously signaling \"clear\" on launches before the game has registered a token.
- No iOS version guard in the public API — safe to call on any iOS version, as the game just won't invoke it on OS versions that don't produce a token.

## Test plan
- [x] `bundle exec fastlane test` (48 tests passing, including 12 new)
- New unit coverage:
  - `PushToStartTokenRegistrationTests`: public API nil/empty/valid inputs and event posting (type + lowercase hex token)
  - `TeakDeviceConfigurationTests`: initial empty state, event routing between `pushToken` and `liveActivityPushToStartToken`, token rotation, `to_h` payload serialization under `pushRegistration`
- [ ] Manual: wire into teak-swift-cleanroom, observe `live_activity_push_to_start_key` in the next `users.json` request after calling `Teak.registerPushToStartToken(_:)` with an `Activity.pushToStartTokenUpdates` value

Closes C-608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)