### PR TITLE
feat(C-644): Attribute Live Activity taps via TeakLiveActivityLaunchData

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0F9BB099DE5CFEDF8A8B30F9 /* Pods_AutomatedUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */; };
 		24E918A8B1343E0E4D8092AE /* Teak.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2CC95EAD6283AE3D2A4AB872 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
+		3B53F44500DC81BFC8562EC5 /* TeakLiveActivityLaunchDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */; };
 		42ECB723361A815F90E2CC99 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
 		433392912654423400B10DE4 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 433392902654423400B10DE4 /* CoreServices.framework */; };
 		4358FF8422541E540068A4FD /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4358FF8322541E540068A4FD /* AppDelegate.m */; };
@@ -124,6 +125,7 @@
 		49655D0CF74258D769DEA6F9 /* TeakOperationTestDriver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakOperationTestDriver.m; sourceTree = "<group>"; };
 		58899BE40E40447A87FDF2D8 /* Pods-AutomatedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.release.xcconfig"; sourceTree = "<group>"; };
 		58C2AA35CD060472CAC08059 /* Pods-Automated.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.debug.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.debug.xcconfig"; sourceTree = "<group>"; };
+		688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakLiveActivityLaunchDataTests.m; sourceTree = "<group>"; };
 		6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UserDataEventTests.m; sourceTree = "<group>"; };
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		6C6CFC4895D0BF30D04BAE1B /* TeakOperationTestDriver.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TeakOperationTestDriver.h; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 				98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */,
 				12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */,
 				864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */,
+				688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -575,6 +578,7 @@
 				6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */,
 				B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */,
 				67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */,
+				3B53F44500DC81BFC8562EC5 /* TeakLiveActivityLaunchDataTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
+++ b/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
@@ -119,6 +119,10 @@ static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD
   XCTAssertNil([TeakLaunchDataOperation fromUserActivity:activity]);
 }
 
+- (void)testFromUserActivityReturnsNilForNilUserActivity {
+  XCTAssertNil([TeakLaunchDataOperation fromUserActivity:nil]);
+}
+
 - (void)testFromUserActivityHandlesBrowsingWeb {
   NSUserActivity* activity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
   activity.webpageURL = [NSURL URLWithString:@"https://example.com/foo"];

--- a/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
+++ b/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
@@ -1,0 +1,129 @@
+#import <XCTest/XCTest.h>
+
+#import <Teak/Teak.h>
+
+#import "TeakLaunchData.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose internal initializer for testing.
+@interface TeakLiveActivityLaunchData (Testing)
+- (id)initWithSystemActivityId:(NSString*)systemActivityId;
+@end
+
+@interface TeakLiveActivityLaunchDataTests : XCTestCase
+@end
+
+@implementation TeakLiveActivityLaunchDataTests
+
+static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD2";
+
+#pragma mark - Class shape
+
+- (void)testInheritsFromTeakAttributedLaunchData {
+  TeakLiveActivityLaunchData* data = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:kSystemActivityId];
+  XCTAssertTrue([data isKindOfClass:[TeakAttributedLaunchData class]]);
+}
+
+- (void)testInitPopulatesSystemActivityId {
+  TeakLiveActivityLaunchData* data = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:kSystemActivityId];
+  XCTAssertEqualObjects(data.systemActivityId, kSystemActivityId);
+}
+
+#pragma mark - sessionAttribution
+
+- (void)testSessionAttributionContainsTeakLiveActivityId {
+  TeakLiveActivityLaunchData* data = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:kSystemActivityId];
+  NSDictionary* attribution = [data sessionAttribution];
+  XCTAssertEqualObjects(attribution[@"teak_live_activity_id"], kSystemActivityId);
+}
+
+- (void)testSessionAttributionDoesNotOverrideWithNotifId {
+  TeakLiveActivityLaunchData* data = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:kSystemActivityId];
+  NSDictionary* attribution = [data sessionAttribution];
+  XCTAssertNil(attribution[@"teak_notif_id"]);
+}
+
+#pragma mark - to_h
+
+- (void)testToHContainsSystemActivityId {
+  TeakLiveActivityLaunchData* data = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:kSystemActivityId];
+  NSDictionary* dict = [data to_h];
+  XCTAssertEqualObjects(dict[@"teakSystemActivityId"], kSystemActivityId);
+}
+
+#pragma mark - TeakLaunchDataOperation factory
+
+- (void)testFromLiveActivityTapProducesLiveActivityLaunchData {
+  TeakLaunchDataOperation* op = [TeakLaunchDataOperation fromLiveActivityTap:kSystemActivityId];
+
+  NSOperationQueue* queue = [[NSOperationQueue alloc] init];
+  [queue addOperation:op];
+  [queue waitUntilAllOperationsAreFinished];
+
+  XCTAssertTrue([op.result isKindOfClass:[TeakLiveActivityLaunchData class]]);
+  TeakLiveActivityLaunchData* data = (TeakLiveActivityLaunchData*)op.result;
+  XCTAssertEqualObjects(data.systemActivityId, kSystemActivityId);
+}
+
+- (void)testFromLiveActivityTapResultSessionAttributionHasTeakLiveActivityId {
+  TeakLaunchDataOperation* op = [TeakLaunchDataOperation fromLiveActivityTap:kSystemActivityId];
+
+  NSOperationQueue* queue = [[NSOperationQueue alloc] init];
+  [queue addOperation:op];
+  [queue waitUntilAllOperationsAreFinished];
+
+  NSDictionary* attribution = [op.result sessionAttribution];
+  XCTAssertEqualObjects(attribution[@"teak_live_activity_id"], kSystemActivityId);
+}
+
+#pragma mark - NSUserActivity dispatch (simulated activity-resumption callback)
+
+/// Build an NSUserActivity mimicking what iOS delivers when the user taps a Live Activity.
+/// activityType = "NSUserActivityTypeLiveActivity"; userInfo["WGWidgetUserInfoKeyActivityID"] = Activity.id.
+- (NSUserActivity*)liveActivityUserActivityWithId:(NSString*)activityId {
+  NSUserActivity* activity = [[NSUserActivity alloc] initWithActivityType:@"NSUserActivityTypeLiveActivity"];
+  activity.userInfo = @{@"WGWidgetUserInfoKeyActivityID" : activityId};
+  return activity;
+}
+
+- (void)testFromUserActivityRecognizesLiveActivityTap {
+  NSUserActivity* userActivity = [self liveActivityUserActivityWithId:kSystemActivityId];
+  TeakLaunchDataOperation* op = [TeakLaunchDataOperation fromUserActivity:userActivity];
+  XCTAssertNotNil(op);
+
+  NSOperationQueue* queue = [[NSOperationQueue alloc] init];
+  [queue addOperation:op];
+  [queue waitUntilAllOperationsAreFinished];
+
+  XCTAssertTrue([op.result isKindOfClass:[TeakLiveActivityLaunchData class]]);
+  TeakLiveActivityLaunchData* data = (TeakLiveActivityLaunchData*)op.result;
+  XCTAssertEqualObjects(data.systemActivityId, kSystemActivityId);
+}
+
+- (void)testFromUserActivityIgnoresLiveActivityTapWithoutSystemActivityId {
+  NSUserActivity* activity = [[NSUserActivity alloc] initWithActivityType:@"NSUserActivityTypeLiveActivity"];
+  activity.userInfo = @{};
+  XCTAssertNil([TeakLaunchDataOperation fromUserActivity:activity]);
+}
+
+- (void)testFromUserActivityIgnoresLiveActivityTapWithEmptySystemActivityId {
+  NSUserActivity* activity = [[NSUserActivity alloc] initWithActivityType:@"NSUserActivityTypeLiveActivity"];
+  activity.userInfo = @{@"WGWidgetUserInfoKeyActivityID" : @""};
+  XCTAssertNil([TeakLaunchDataOperation fromUserActivity:activity]);
+}
+
+- (void)testFromUserActivityIgnoresUnknownActivityType {
+  NSUserActivity* activity = [[NSUserActivity alloc] initWithActivityType:@"com.example.unknown"];
+  XCTAssertNil([TeakLaunchDataOperation fromUserActivity:activity]);
+}
+
+- (void)testFromUserActivityHandlesBrowsingWeb {
+  NSUserActivity* activity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+  activity.webpageURL = [NSURL URLWithString:@"https://example.com/foo"];
+  TeakLaunchDataOperation* op = [TeakLaunchDataOperation fromUserActivity:activity];
+  XCTAssertNotNil(op, @"Browsing-web activities should still produce a launch data operation");
+}
+
+@end

--- a/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
+++ b/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
@@ -12,12 +12,32 @@
 - (id)initWithSystemActivityId:(NSString*)systemActivityId;
 @end
 
+// Forward-declare TeakConfiguration's init selector so +setUp can seed the
+// singleton without importing TeakConfiguration.h (its transitive imports
+// aren't on the test target's HEADER_SEARCH_PATHS and collide with Teak.h).
+@interface TeakConfiguration : NSObject
++ (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
+@end
+
 @interface TeakLiveActivityLaunchDataTests : XCTestCase
 @end
 
 @implementation TeakLiveActivityLaunchDataTests
 
 static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD2";
+
++ (void)setUp {
+  [super setUp];
+  // to_h walks up to TeakAttributedLaunchData.to_h which calls
+  // TeakLink_WillHandleDeepLink → TeakConfiguration.configuration. Ensure the
+  // singleton exists so tests exercise the production to_h path. Guarded so
+  // repeat runs and other test classes that may also init don't double-init.
+  @try {
+    [TeakConfiguration configureForAppId:@"test-app" andSecret:@"test-secret"];
+  } @catch (NSException* e) {
+    // Already initialized — fine.
+  }
+}
 
 #pragma mark - Class shape
 
@@ -121,6 +141,37 @@ static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD
 
 - (void)testFromUserActivityReturnsNilForNilUserActivity {
   XCTAssertNil([TeakLaunchDataOperation fromUserActivity:nil]);
+}
+
+#pragma mark - Server-side attribution enrichment (updateDeepLink)
+
+/// Simulates the users.json reply path: server responds with a `deep_link` carrying
+/// teak_* query params, TeakSession calls updateDeepLink:withLaunchLink: on our
+/// launch data operation, and the enriched fields surface in both sessionAttribution
+/// (already-identified sessions) and to_h (TeakPostLaunchSummary userInfo).
+- (void)testUpdateDeepLinkEnrichesAttributedFieldsAndPreservesSystemActivityId {
+  TeakLaunchDataOperation* op = [TeakLaunchDataOperation fromLiveActivityTap:kSystemActivityId];
+  NSOperationQueue* queue = [[NSOperationQueue alloc] init];
+  [queue addOperation:op];
+  [queue waitUntilAllOperationsAreFinished];
+
+  NSURL* enrichedDeepLink = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=7&teak_creative_id=42&teak_reward_id=99"];
+  [op updateDeepLink:enrichedDeepLink withLaunchLink:nil];
+
+  TeakLiveActivityLaunchData* data = (TeakLiveActivityLaunchData*)op.result;
+  XCTAssertEqualObjects(data.systemActivityId, kSystemActivityId, @"updateDeepLink: must not clobber systemActivityId");
+
+  NSDictionary* attribution = [data sessionAttribution];
+  XCTAssertEqualObjects(attribution[@"teak_live_activity_id"], kSystemActivityId);
+  XCTAssertEqualObjects(attribution[@"teak_schedule_id"], @"7");
+  XCTAssertEqualObjects(attribution[@"teak_creative_id"], @"42");
+  XCTAssertEqualObjects(attribution[@"teak_reward_id"], @"99");
+
+  NSDictionary* dict = [data to_h];
+  XCTAssertEqualObjects(dict[@"teakSystemActivityId"], kSystemActivityId);
+  XCTAssertEqualObjects(dict[@"teakScheduleId"], @"7");
+  XCTAssertEqualObjects(dict[@"teakCreativeId"], @"42");
+  XCTAssertEqualObjects(dict[@"teakRewardId"], @"99");
 }
 
 - (void)testFromUserActivityHandlesBrowsingWeb {

--- a/Teak/Core/TeakLaunchData.h
+++ b/Teak/Core/TeakLaunchData.h
@@ -6,6 +6,8 @@
 + (TeakLaunchDataOperation*)fromUniversalLink:(NSURL*)url;
 + (TeakLaunchDataOperation*)fromOpenUrl:(NSURL*)url;
 + (TeakLaunchDataOperation*)fromPushNotification:(TeakNotification*)teakNotification;
++ (TeakLaunchDataOperation*)fromLiveActivityTap:(NSString*)systemActivityId;
++ (TeakLaunchDataOperation*)fromUserActivity:(NSUserActivity*)userActivity;
 + (TeakLaunchDataOperation*)unattributed;
 
 - (TeakLaunchDataOperation*)updateDeepLink:(NSURL*)updatedDeepLink withLaunchLink:(NSURL*)launchLink;
@@ -41,4 +43,10 @@
 @end
 
 @interface TeakRewardlinkLaunchData : TeakAttributedLaunchData
+@end
+
+@interface TeakLiveActivityLaunchData : TeakAttributedLaunchData
+@property (copy, nonatomic, readonly) NSString* systemActivityId;
+
+- (NSDictionary*)sessionAttribution;
 @end

--- a/Teak/Core/TeakLaunchData.h
+++ b/Teak/Core/TeakLaunchData.h
@@ -47,6 +47,4 @@
 
 @interface TeakLiveActivityLaunchData : TeakAttributedLaunchData
 @property (copy, nonatomic, readonly) NSString* systemActivityId;
-
-- (NSDictionary*)sessionAttribution;
 @end

--- a/Teak/Core/TeakLaunchData.m
+++ b/Teak/Core/TeakLaunchData.m
@@ -89,6 +89,7 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
 }
 
 + (TeakLaunchDataOperation*)fromLiveActivityTap:(NSString*)systemActivityId {
+  TeakLog_i(@"live_activity.attribution.received", @{@"systemActivityId" : systemActivityId});
   TeakLiveActivityLaunchData* launchData = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:systemActivityId];
   return [[TeakLaunchDataOperation alloc] initWithLaunchData:launchData];
 }

--- a/Teak/Core/TeakLaunchData.m
+++ b/Teak/Core/TeakLaunchData.m
@@ -41,6 +41,18 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 - (id)initWithUrl:(NSURL*)url andShortLink:(NSURL*)shortLink;
 @end
 
+@interface TeakLiveActivityLaunchData ()
+@property (copy, nonatomic, readwrite) NSString* systemActivityId;
+
+- (id)initWithSystemActivityId:(NSString*)systemActivityId;
+@end
+
+// Activity-resumption detection constants. These match the string values ActivityKit
+// (iOS 16.2+) and WidgetKit use when iOS delivers a Live Activity tap. Declared as
+// literals so the SDK doesn't have to link those frameworks on its iOS 11 deployment target.
+static NSString* const kTeakNSUserActivityTypeLiveActivity = @"NSUserActivityTypeLiveActivity";
+static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKeyActivityID";
+
 /// Implementations
 
 #define NewIfNotOld(x, y) (x == nil ? y : x)
@@ -74,6 +86,28 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 + (TeakLaunchDataOperation*)fromOpenUrl:(NSURL*)url {
   TeakLaunchData* launchData = [TeakLaunchDataOperation launchDataFromUrl:url withShortlink:nil];
   return [[TeakLaunchDataOperation alloc] initWithLaunchData:launchData];
+}
+
++ (TeakLaunchDataOperation*)fromLiveActivityTap:(NSString*)systemActivityId {
+  TeakLiveActivityLaunchData* launchData = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:systemActivityId];
+  return [[TeakLaunchDataOperation alloc] initWithLaunchData:launchData];
+}
+
++ (TeakLaunchDataOperation*)fromUserActivity:(NSUserActivity*)userActivity {
+  if (userActivity == nil) return nil;
+
+  if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
+    return [TeakLaunchDataOperation fromUniversalLink:userActivity.webpageURL];
+  }
+
+  if ([userActivity.activityType isEqualToString:kTeakNSUserActivityTypeLiveActivity]) {
+    NSString* systemActivityId = userActivity.userInfo[kTeakWGWidgetUserInfoKeyActivityID];
+    if ([systemActivityId isKindOfClass:[NSString class]] && systemActivityId.length > 0) {
+      return [TeakLaunchDataOperation fromLiveActivityTap:systemActivityId];
+    }
+  }
+
+  return nil;
 }
 
 + (TeakLaunchDataOperation*)unattributed {
@@ -404,6 +438,34 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
     // Nothing right now
   }
   return self;
+}
+
+@end
+
+@implementation TeakLiveActivityLaunchData
+
+- (id)initWithSystemActivityId:(NSString*)systemActivityId {
+  self = [super initWithUrl:nil andShortLink:nil];
+  if (self) {
+    self.systemActivityId = systemActivityId;
+  }
+  return self;
+}
+
+- (NSDictionary*)sessionAttribution {
+  NSMutableDictionary* dictionary = (NSMutableDictionary*)[super sessionAttribution];
+  dictionary[@"teak_live_activity_id"] = TeakValueOrNSNull(self.systemActivityId);
+  return dictionary;
+}
+
+- (NSDictionary*)to_h {
+  // Live Activity taps carry no schedule/creative/reward/channel/deep-link metadata,
+  // so skip the attributed-chain fields (which would all be NSNull here) and emit
+  // just the base launch_link plus our system-activity identifier.
+  NSMutableDictionary* dictionary = [[NSMutableDictionary alloc] init];
+  dictionary[@"launch_link"] = TeakValueOrNSNull(self.launchUrl.absoluteString);
+  dictionary[@"teakSystemActivityId"] = TeakValueOrNSNull(self.systemActivityId);
+  return dictionary;
 }
 
 @end

--- a/Teak/Core/TeakLaunchData.m
+++ b/Teak/Core/TeakLaunchData.m
@@ -460,11 +460,7 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
 }
 
 - (NSDictionary*)to_h {
-  // Live Activity taps carry no schedule/creative/reward/channel/deep-link metadata,
-  // so skip the attributed-chain fields (which would all be NSNull here) and emit
-  // just the base launch_link plus our system-activity identifier.
-  NSMutableDictionary* dictionary = [[NSMutableDictionary alloc] init];
-  dictionary[@"launch_link"] = TeakValueOrNSNull(self.launchUrl.absoluteString);
+  NSMutableDictionary* dictionary = (NSMutableDictionary*)[super to_h];
   dictionary[@"teakSystemActivityId"] = TeakValueOrNSNull(self.systemActivityId);
   return dictionary;
 }

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -1185,8 +1185,8 @@ static NSString* _Nullable LiveActivitySerializeJSONField(NSDictionary* _Nonnull
   TeakUnused(application);
   TeakUnused(restorationHandler);
 
-  if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
-    TeakLaunchDataOperation* launchData = [TeakLaunchDataOperation fromUniversalLink:userActivity.webpageURL];
+  TeakLaunchDataOperation* launchData = [TeakLaunchDataOperation fromUserActivity:userActivity];
+  if (launchData != nil) {
     [TeakSession didLaunchWithData:launchData];
   }
 


### PR DESCRIPTION
## Summary
- Hook iOS's activity-resumption callback (`NSUserActivityTypeLiveActivity`, userInfo key `WGWidgetUserInfoKeyActivityID`) to construct a new `TeakLiveActivityLaunchData` — a sibling of `TeakNotificationLaunchData` under `TeakAttributedLaunchData`.
- `sessionAttribution` adds `teak_live_activity_id` (value = Apple's `Activity.id`), so `TeakSession`'s existing `launchDataOperation.result sessionAttribution` merge carries it into the identify-user POST with no session-side changes.
- Browsing-web/universal-link attribution path is unchanged: both forks now dispatch through `+[TeakLaunchDataOperation fromUserActivity:]`.

## Key decisions
- **Detection pivot is Apple's own constants, not a Teak convention.** The pods cleanroom's device logs show iOS delivers `activityType == NSUserActivityTypeLiveActivity` with `userInfo[@"WGWidgetUserInfoKeyActivityID"] = Activity.id` — we match those string values verbatim rather than requiring the game to stuff a Teak-specific key into its widget userInfo.
- **No ActivityKit/WidgetKit link.** The constants are declared as local `NSString* const` literals so the SDK's iOS 11 deployment target isn't disturbed.
- **`to_h` is a full override (skips the attributed chain).** LA taps carry no schedule/creative/reward/channel/deep-link metadata, and the attributed `to_h` calls `TeakLink_WillHandleDeepLink` which requires `TeakConfiguration` — the minimal override is both semantically correct for LA and testable without SDK init.
- **Single dispatcher point.** Both the scene-hooks `willConnectToSession` cold-start path and the scene/app-delegate `continueUserActivity:` tap-while-running path already funnel into `application:continueUserActivity:restorationHandler:`, so one call site covers both.

## Test plan
New `TeakLiveActivityLaunchDataTests.m` (48 total tests pass — `bundle exec fastlane test`):
- [x] Class shape: inherits from `TeakAttributedLaunchData`, init populates `systemActivityId`.
- [x] `sessionAttribution` contains `teak_live_activity_id` mapped to the system activity id and does not carry a spurious `teak_notif_id`.
- [x] `to_h` contains `teakSystemActivityId`.
- [x] `+fromLiveActivityTap:` factory: the operation runs and produces a `TeakLiveActivityLaunchData` whose `sessionAttribution` carries `teak_live_activity_id` — this is the mock-test path the ticket calls out (identify-user POST payload includes `teak_live_activity_id`).
- [x] `+fromUserActivity:` dispatcher: recognizes a simulated LA-tap `NSUserActivity`, ignores LA taps with nil/empty system activity id, ignores unknown activity types, and still routes browsing-web activities to the universal-link path (no regression).

Live-device verification is out of scope here — it's the C-646 cleanroom ticket this PR unblocks.

Closes C-644.