### PR TITLE
fix: TeakAttributedLaunchData updateDeepLink enrichment was a no-op

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		43B4619922A20FDC004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
 		55AAEB0EF3B9E90616642C8E /* LiveActivityUpdateSchedulingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 741732706353CEBB41D0AE37 /* LiveActivityUpdateSchedulingTests.m */; };
+		67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */; };
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
 		6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
@@ -128,6 +129,7 @@
 		6C6CFC4895D0BF30D04BAE1B /* TeakOperationTestDriver.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TeakOperationTestDriver.h; sourceTree = "<group>"; };
 		741732706353CEBB41D0AE37 /* LiveActivityUpdateSchedulingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateSchedulingTests.m; sourceTree = "<group>"; };
 		7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = NotificationSettingsTests.m; sourceTree = "<group>"; };
+		864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakAttributedLaunchDataEnrichmentTests.m; sourceTree = "<group>"; };
 		90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DebugConfigurationTests.m; sourceTree = "<group>"; };
 		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				6C6CFC4895D0BF30D04BAE1B /* TeakOperationTestDriver.h */,
 				98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */,
 				12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */,
+				864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -571,6 +574,7 @@
 				F10455A046CB359057A63D58 /* TeakOperationTestDriver.m in Sources */,
 				6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */,
 				B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */,
+				67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakAttributedLaunchDataEnrichmentTests.m
+++ b/Automated/AutomatedTests/TeakAttributedLaunchDataEnrichmentTests.m
@@ -1,0 +1,112 @@
+#import <XCTest/XCTest.h>
+
+#import <Teak/Teak.h>
+
+#import "TeakLaunchData.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose the private designated initializer so tests can construct
+// TeakAttributedLaunchData directly without going through a factory.
+@interface TeakAttributedLaunchData (Testing)
+- (id)initWithUrl:(NSURL*)url andShortLink:(NSURL*)shortLink;
+@end
+
+// Forward-declare TeakConfiguration so +setUp can seed the singleton without
+// importing TeakConfiguration.h (its transitive imports aren't on the test
+// target's HEADER_SEARCH_PATHS and collide with Teak.h).
+@interface TeakConfiguration : NSObject
++ (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
+@end
+
+@interface TeakAttributedLaunchDataEnrichmentTests : XCTestCase
+@end
+
+@implementation TeakAttributedLaunchDataEnrichmentTests
+
++ (void)setUp {
+  [super setUp];
+  // to_h calls TeakLink_WillHandleDeepLink → TeakConfiguration.configuration.
+  @try {
+    [TeakConfiguration configureForAppId:@"test-app" andSecret:@"test-secret"];
+  } @catch (NSException* e) {
+    // Already initialized — fine.
+  }
+}
+
+#pragma mark - Bare attributed launch data (no pre-existing attribution)
+
+/// When there's no pre-existing attribution, a later updateDeepLink: with a URL
+/// that carries teak_* params must actually populate the attribution fields.
+/// Before the initWithUrl:andShortLink: fix, newLaunchData was built via the
+/// parent's initWithUrl: (no query parsing), so NewIfNotOld(nil, nil) always
+/// returned nil and the enrichment merge was a no-op.
+- (void)testUpdateDeepLinkPopulatesAttributionWhenOldIsNil {
+  NSURL* bareUrl = [NSURL URLWithString:@"teaktest-app://menu"];
+  TeakAttributedLaunchData* data = [[TeakAttributedLaunchData alloc] initWithUrl:bareUrl andShortLink:nil];
+  XCTAssertNil(data.scheduleId);
+  XCTAssertNil(data.creativeId);
+  XCTAssertNil(data.rewardId);
+
+  NSURL* enrichedUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=7&teak_schedule_name=daily&teak_creative_id=42&teak_creative_name=banner&teak_reward_id=99&teak_channel_name=push&teak_opt_out_category=promos"];
+  [data updateDeepLink:enrichedUrl];
+
+  XCTAssertEqualObjects(data.scheduleId, @"7");
+  XCTAssertEqualObjects(data.scheduleName, @"daily");
+  XCTAssertEqualObjects(data.creativeId, @"42");
+  XCTAssertEqualObjects(data.creativeName, @"banner");
+  XCTAssertEqualObjects(data.rewardId, @"99");
+  XCTAssertEqualObjects(data.channelName, @"push");
+  XCTAssertEqualObjects(data.optOutCategory, @"promos");
+  XCTAssertEqualObjects(data.deepLink, enrichedUrl);
+}
+
+/// to_h must surface the enriched fields too, since TeakPostLaunchSummary uses
+/// this dict as its userInfo. Previously blocked by the same newLaunchData bug.
+- (void)testUpdateDeepLinkEnrichmentFlowsIntoToH {
+  NSURL* bareUrl = [NSURL URLWithString:@"teaktest-app://menu"];
+  TeakAttributedLaunchData* data = [[TeakAttributedLaunchData alloc] initWithUrl:bareUrl andShortLink:nil];
+
+  NSURL* enrichedUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=7&teak_creative_id=42&teak_reward_id=99"];
+  [data updateDeepLink:enrichedUrl];
+
+  NSDictionary* dict = [data to_h];
+  XCTAssertEqualObjects(dict[@"teakScheduleId"], @"7");
+  XCTAssertEqualObjects(dict[@"teakCreativeId"], @"42");
+  XCTAssertEqualObjects(dict[@"teakRewardId"], @"99");
+}
+
+#pragma mark - Pre-existing attribution (behavior preservation)
+
+/// When the launch data already has attribution (notification/URL launches),
+/// NewIfNotOld keeps old when non-nil — the fix must not change that behavior.
+- (void)testUpdateDeepLinkPreservesExistingAttributionWhenOldIsNonNil {
+  NSURL* originalUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=ORIGINAL&teak_creative_id=ORIGINAL_CREATIVE&teak_reward_id=ORIGINAL_REWARD"];
+  TeakAttributedLaunchData* data = [[TeakAttributedLaunchData alloc] initWithUrl:originalUrl andShortLink:nil];
+  XCTAssertEqualObjects(data.scheduleId, @"ORIGINAL");
+
+  NSURL* enrichedUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=ENRICHED&teak_creative_id=ENRICHED_CREATIVE&teak_reward_id=ENRICHED_REWARD"];
+  [data updateDeepLink:enrichedUrl];
+
+  XCTAssertEqualObjects(data.scheduleId, @"ORIGINAL", @"old non-nil attribution must win over enriched URL values");
+  XCTAssertEqualObjects(data.creativeId, @"ORIGINAL_CREATIVE");
+  XCTAssertEqualObjects(data.rewardId, @"ORIGINAL_REWARD");
+  XCTAssertEqualObjects(data.deepLink, enrichedUrl, @"deepLink itself should still update");
+}
+
+/// A mix: old has some slots, new fills in the rest.
+- (void)testUpdateDeepLinkFillsMissingSlotsWithoutOverridingOld {
+  NSURL* originalUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=ORIGINAL_SCHEDULE"];
+  TeakAttributedLaunchData* data = [[TeakAttributedLaunchData alloc] initWithUrl:originalUrl andShortLink:nil];
+  XCTAssertEqualObjects(data.scheduleId, @"ORIGINAL_SCHEDULE");
+  XCTAssertNil(data.creativeId);
+
+  NSURL* enrichedUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=ENRICHED_SCHEDULE&teak_creative_id=NEW_CREATIVE"];
+  [data updateDeepLink:enrichedUrl];
+
+  XCTAssertEqualObjects(data.scheduleId, @"ORIGINAL_SCHEDULE", @"slot with old value preserves it");
+  XCTAssertEqualObjects(data.creativeId, @"NEW_CREATIVE", @"slot that was nil gets filled by enriched URL");
+}
+
+@end

--- a/Teak/Core/TeakLaunchData.m
+++ b/Teak/Core/TeakLaunchData.m
@@ -286,7 +286,11 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 - (id)initWithAttributedLaunchData:(TeakAttributedLaunchData*)oldLaunchData andUpdatedDeepLink:(NSURL*)updatedDeepLink {
   self = [super initWithUrl:oldLaunchData.launchUrl];
   if (self) {
-    TeakAttributedLaunchData* newLaunchData = [[TeakAttributedLaunchData alloc] initWithUrl:updatedDeepLink];
+    // Use initWithUrl:andShortLink: so newLaunchData's teak_* fields get parsed
+    // from the enriched URL — the parent's initWithUrl: doesn't touch them,
+    // which would leave NewIfNotOld(old, nil) returning old in every slot and
+    // defeat the purpose of the enrichment merge.
+    TeakAttributedLaunchData* newLaunchData = [[TeakAttributedLaunchData alloc] initWithUrl:updatedDeepLink andShortLink:nil];
     self.scheduleName = NewIfNotOld(oldLaunchData.scheduleName, newLaunchData.scheduleName);
     self.scheduleId = NewIfNotOld(oldLaunchData.scheduleId, newLaunchData.scheduleId);
     self.creativeName = NewIfNotOld(oldLaunchData.creativeName, newLaunchData.creativeName);


### PR DESCRIPTION
## Summary
- `TeakAttributedLaunchData.initWithAttributedLaunchData:andUpdatedDeepLink:` built `newLaunchData` via the parent `initWithUrl:`, which doesn't parse teak_* query params. Every `NewIfNotOld(old, new)` slot fell through to old because the new side was always nil — the server-reply enrichment merge was effectively a no-op.
- Fix: one line — use `initWithUrl:andShortLink:` so `newLaunchData`'s teak_* fields actually get populated from the enriched URL.
- New test suite exercises bare / preserved / mixed scenarios end-to-end and verifies both the instance properties and `to_h` carry the enriched attribution.

## Key decisions
- **Behavior-preserving for existing launch data types.** Notifications and URL launches arrive with `oldLaunchData.X` non-nil, so `NewIfNotOld(old, new)` still returns old. The change is narrowly scoped to the case where a slot is nil — which is exactly where enrichment is supposed to fill in.
- **Extracted from #124** (C-644 LA attribution) per review request. Landing this first so #124 can rebase on top; LA launch data is the first attributed launch data type that arrives with nil attribution slots and actually needs enrichment to fill them in.
- **Tests assert directly against `updateDeepLink:`** rather than synthetic APIs, so they exercise the same code path TeakSession hits when it sees `deep_link` in the users.json reply.

## Test plan
- `bundle exec fastlane test` → 77/77 pass.
- Locally stashed the one-line fix and re-ran: `testUpdateDeepLinkPopulatesAttributionWhenOldIsNil`, `testUpdateDeepLinkEnrichmentFlowsIntoToH`, and `testUpdateDeepLinkFillsMissingSlotsWithoutOverridingOld` all fail as expected. `testUpdateDeepLinkPreservesExistingAttributionWhenOldIsNonNil` passes in both states — confirms the fix is safe for notifications and URL launches.