### PR TITLE
Bump handlebars from 4.7.8 to 4.7.9

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -73,9 +73,9 @@ get-caller-file@^2.0.5:
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 handlebars@^4.7.7:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"


### PR DESCRIPTION
## Summary
- Updates the transitive `handlebars` dependency (via `doxygen2adoc`) in `yarn.lock` to 4.7.9.
- Closes the 8 open Dependabot alerts for `handlebars` on `4.3-stable` (severities: 1 critical, 4 high, 2 medium, 1 low).
- Same change as #118 applied to `develop`; 4.3-stable parity.

## Test plan
- [ ] CI (build, test, tag_build) green
- [ ] `npm run build` produces docs without error (docs-only dep)

Co-Authored-By: Claude <noreply@anthropic.com>