### PR TITLE
Bump json from 2.18.1 to 2.19.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
       sqlite3 (~> 1.3)
       xcinvoke (~> 0.3.0)
     jmespath (1.6.2)
-    json (2.18.1)
+    json (2.19.4)
     jwt (2.10.2)
       base64
     language_server-protocol (3.17.0.5)


### PR DESCRIPTION
## Summary
- `bundle update json` — transitive of `fastlane`.
- Closes Dependabot alert #48 (GHSA-3m6g-2423-7cp3, Ruby JSON format string injection, high severity; fix = 2.19.2+).
- `activesupport` alerts (#50/#51/#52) are **not** included: `fastlane 2.232.1` pins `activesupport (>= 5.0, < 8)`, but the fix is 8.1.2.1 — needs a fastlane major bump first.

## Test plan
- [ ] CI (build, test, tag_build) green — `bundle exec fastlane test` runs in CI

Co-Authored-By: Claude <noreply@anthropic.com>