### PR TITLE
Bump fastlane from 2.232.1 to 2.232.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.232.1)
+    fastlane (2.232.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)


### PR DESCRIPTION
## Summary
- `bundle update --conservative fastlane`.
- Patch-level hygiene bump; no transitive changes. Not a security fix — `fastlane` itself does not constrain `activesupport`, so a bump here does **not** help the activesupport alerts (#50/#51/#52, which were dismissed today as upstream-blocked by `cocoapods-core` 1.16.2 and `jazzy` 0.15.4, both latest, both still pinning `activesupport < 8`).

## Test plan
- [ ] CI (build, test, tag_build) green — `bundle exec fastlane test` runs in CI

Co-Authored-By: Claude <noreply@anthropic.com>