### PR TITLE
Fix NSInvalidArgumentException on non-JSON error responses

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
 		97EDAA942157436DCC939EC2 /* LiveActivityUpdateCancellationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */; };
+		AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */; };
 		B731D0BCE8646D60DCD428A5 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
 		B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
@@ -91,6 +92,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRequestResponseParsingTests.m; sourceTree = "<group>"; };
 		0D7BD679E00A2C57BE7AA5E3 /* Pods-AutomatedUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.release.xcconfig"; sourceTree = "<group>"; };
 		12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakDeviceConfigurationTests.m; sourceTree = "<group>"; };
 		2CC8154D37CB560E22904A43 /* Pods-AutomatedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -252,6 +254,7 @@
 				12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */,
 				864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */,
 				688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */,
+				068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -579,6 +582,7 @@
 				B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */,
 				67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */,
 				3B53F44500DC81BFC8562EC5 /* TeakLiveActivityLaunchDataTests.m in Sources */,
+				AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0F9BB099DE5CFEDF8A8B30F9 /* Pods_AutomatedUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */; };
+		20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */; };
 		24E918A8B1343E0E4D8092AE /* Teak.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2CC95EAD6283AE3D2A4AB872 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
 		3B53F44500DC81BFC8562EC5 /* TeakLiveActivityLaunchDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */; };
@@ -142,6 +143,7 @@
 		E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateCancellationTests.m; sourceTree = "<group>"; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRequestClientErrorTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -255,6 +257,7 @@
 				864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */,
 				688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */,
 				068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */,
+				F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -583,6 +586,7 @@
 				67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */,
 				3B53F44500DC81BFC8562EC5 /* TeakLiveActivityLaunchDataTests.m in Sources */,
 				AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */,
+				20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakRequestClientErrorTests.m
+++ b/Automated/AutomatedTests/TeakRequestClientErrorTests.m
@@ -24,10 +24,7 @@
 
 - (void)testFallsBackToConfigurationErrorWhenTitleMissing {
   NSDictionary* err = @{@"message" : @"Something went wrong"};
-  XCTAssertEqualObjects([TeakRequest titleForClientError:err], @"Configuration Error",
-                        @"Title must fall back to 'Configuration Error' when the key is missing — "
-                        @"the original ternary was inverted and returned nil here, crashing "
-                        @"TeakIntegrationChecker.reportError:forCategory:");
+  XCTAssertEqualObjects([TeakRequest titleForClientError:err], @"Configuration Error");
 }
 
 - (void)testFallsBackToConfigurationErrorForNilDict {
@@ -40,9 +37,7 @@
 
 - (void)testFallsBackToConfigurationErrorWhenTitleIsNSNull {
   NSDictionary* err = @{@"title" : [NSNull null]};
-  XCTAssertEqualObjects([TeakRequest titleForClientError:err], @"Configuration Error",
-                        @"NSNull must be treated the same as a missing key — it cannot be used as "
-                        @"a dictionary key by the downstream integration checker.");
+  XCTAssertEqualObjects([TeakRequest titleForClientError:err], @"Configuration Error");
 }
 
 @end

--- a/Automated/AutomatedTests/TeakRequestClientErrorTests.m
+++ b/Automated/AutomatedTests/TeakRequestClientErrorTests.m
@@ -1,0 +1,48 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakRequest.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose the internal helper so tests can exercise it without
+// driving a full request lifecycle. See CLAUDE.md "Header imports in tests".
+@interface TeakRequest (ClientErrorTests)
++ (NSString* _Nonnull)titleForClientError:(NSDictionary* _Nullable)clientError;
+@end
+
+@interface TeakRequestClientErrorTests : XCTestCase
+@end
+
+@implementation TeakRequestClientErrorTests
+
+- (void)testReturnsTitleFromDictWhenPresent {
+  NSDictionary* err = @{@"title" : @"Bad API Key", @"message" : @"Invalid key"};
+  XCTAssertEqualObjects([TeakRequest titleForClientError:err], @"Bad API Key");
+}
+
+- (void)testFallsBackToConfigurationErrorWhenTitleMissing {
+  NSDictionary* err = @{@"message" : @"Something went wrong"};
+  XCTAssertEqualObjects([TeakRequest titleForClientError:err], @"Configuration Error",
+                        @"Title must fall back to 'Configuration Error' when the key is missing — "
+                        @"the original ternary was inverted and returned nil here, crashing "
+                        @"TeakIntegrationChecker.reportError:forCategory:");
+}
+
+- (void)testFallsBackToConfigurationErrorForNilDict {
+  XCTAssertEqualObjects([TeakRequest titleForClientError:nil], @"Configuration Error");
+}
+
+- (void)testFallsBackToConfigurationErrorForEmptyDict {
+  XCTAssertEqualObjects([TeakRequest titleForClientError:@{}], @"Configuration Error");
+}
+
+- (void)testFallsBackToConfigurationErrorWhenTitleIsNSNull {
+  NSDictionary* err = @{@"title" : [NSNull null]};
+  XCTAssertEqualObjects([TeakRequest titleForClientError:err], @"Configuration Error",
+                        @"NSNull must be treated the same as a missing key — it cannot be used as "
+                        @"a dictionary key by the downstream integration checker.");
+}
+
+@end

--- a/Automated/AutomatedTests/TeakRequestResponseParsingTests.m
+++ b/Automated/AutomatedTests/TeakRequestResponseParsingTests.m
@@ -1,0 +1,82 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakRequest.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose the internal parse helper so tests can exercise it without
+// driving a full NSURLSession round-trip. See CLAUDE.md "Header imports in tests".
+@interface TeakRequest (ResponseParsingTests)
++ (NSDictionary* _Nonnull)parseJSONResponseData:(NSData* _Nullable)data;
+@end
+
+@interface TeakRequestResponseParsingTests : XCTestCase
+@end
+
+@implementation TeakRequestResponseParsingTests
+
+#pragma mark - Nil / empty data
+
+- (void)testReturnsEmptyDictForNilData {
+  NSDictionary* result = [TeakRequest parseJSONResponseData:nil];
+  XCTAssertNotNil(result, @"Must never return nil — downstream NSDictionary literals cannot accept nil values");
+  XCTAssertEqualObjects(result, @{});
+}
+
+- (void)testReturnsEmptyDictForZeroLengthData {
+  NSDictionary* result = [TeakRequest parseJSONResponseData:[NSData data]];
+  XCTAssertNotNil(result);
+  XCTAssertEqualObjects(result, @{});
+}
+
+#pragma mark - Non-JSON bodies (e.g. HTML error page from a 500)
+
+- (void)testReturnsEmptyDictForHTMLErrorBody {
+  NSData* html = [@"<html><body>500 Internal Server Error</body></html>" dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:html];
+  XCTAssertNotNil(result);
+  XCTAssertEqualObjects(result, @{});
+}
+
+- (void)testReturnsEmptyDictForGarbageBytes {
+  unsigned char bytes[] = {0xff, 0xfe, 0x00, 0x01};
+  NSData* garbage = [NSData dataWithBytes:bytes length:sizeof(bytes)];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:garbage];
+  XCTAssertNotNil(result);
+  XCTAssertEqualObjects(result, @{});
+}
+
+#pragma mark - Valid JSON that is not an object
+
+- (void)testReturnsEmptyDictForJSONArray {
+  NSData* jsonArray = [@"[1, 2, 3]" dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonArray];
+  XCTAssertNotNil(result);
+  XCTAssertEqualObjects(result, @{}, @"Top-level non-object JSON must not be forwarded as an NSDictionary*");
+}
+
+- (void)testReturnsEmptyDictForJSONString {
+  NSData* jsonString = [@"\"just a string\"" dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonString];
+  XCTAssertNotNil(result);
+  XCTAssertEqualObjects(result, @{});
+}
+
+#pragma mark - Valid JSON objects
+
+- (void)testReturnsParsedDictForValidJSONObject {
+  NSData* jsonData = [@"{\"status\":\"ok\",\"id\":42}" dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonData];
+  XCTAssertEqualObjects(result[@"status"], @"ok");
+  XCTAssertEqualObjects(result[@"id"], @42);
+}
+
+- (void)testReturnsEmptyDictForEmptyJSONObject {
+  NSData* jsonData = [@"{}" dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonData];
+  XCTAssertEqualObjects(result, @{});
+}
+
+@end

--- a/Automated/AutomatedTests/TeakRequestResponseParsingTests.m
+++ b/Automated/AutomatedTests/TeakRequestResponseParsingTests.m
@@ -21,7 +21,7 @@
 
 - (void)testReturnsEmptyDictForNilData {
   NSDictionary* result = [TeakRequest parseJSONResponseData:nil];
-  XCTAssertNotNil(result, @"Must never return nil — downstream NSDictionary literals cannot accept nil values");
+  XCTAssertNotNil(result);
   XCTAssertEqualObjects(result, @{});
 }
 
@@ -54,7 +54,7 @@
   NSData* jsonArray = [@"[1, 2, 3]" dataUsingEncoding:NSUTF8StringEncoding];
   NSDictionary* result = [TeakRequest parseJSONResponseData:jsonArray];
   XCTAssertNotNil(result);
-  XCTAssertEqualObjects(result, @{}, @"Top-level non-object JSON must not be forwarded as an NSDictionary*");
+  XCTAssertEqualObjects(result, @{});
 }
 
 - (void)testReturnsEmptyDictForJSONString {

--- a/Automated/AutomatedTests/TeakRequestResponseParsingTests.m
+++ b/Automated/AutomatedTests/TeakRequestResponseParsingTests.m
@@ -9,7 +9,8 @@
 // Re-expose the internal parse helper so tests can exercise it without
 // driving a full NSURLSession round-trip. See CLAUDE.md "Header imports in tests".
 @interface TeakRequest (ResponseParsingTests)
-+ (NSDictionary* _Nonnull)parseJSONResponseData:(NSData* _Nullable)data;
++ (NSDictionary* _Nonnull)parseJSONResponseData:(NSData* _Nullable)data
+                                          error:(NSError* _Nullable* _Nullable)outError;
 @end
 
 @interface TeakRequestResponseParsingTests : XCTestCase
@@ -17,65 +18,85 @@
 
 @implementation TeakRequestResponseParsingTests
 
-#pragma mark - Nil / empty data
+#pragma mark - Nil / empty data (error out-param left unchanged)
 
 - (void)testReturnsEmptyDictForNilData {
-  NSDictionary* result = [TeakRequest parseJSONResponseData:nil];
+  NSError* err = nil;
+  NSDictionary* result = [TeakRequest parseJSONResponseData:nil error:&err];
   XCTAssertNotNil(result);
   XCTAssertEqualObjects(result, @{});
+  XCTAssertNil(err);
 }
 
 - (void)testReturnsEmptyDictForZeroLengthData {
-  NSDictionary* result = [TeakRequest parseJSONResponseData:[NSData data]];
+  NSError* err = nil;
+  NSDictionary* result = [TeakRequest parseJSONResponseData:[NSData data] error:&err];
   XCTAssertNotNil(result);
   XCTAssertEqualObjects(result, @{});
+  XCTAssertNil(err);
 }
 
-#pragma mark - Non-JSON bodies (e.g. HTML error page from a 500)
+#pragma mark - Non-JSON bodies (e.g. HTML error page from a 500) — error populated
 
 - (void)testReturnsEmptyDictForHTMLErrorBody {
+  NSError* err = nil;
   NSData* html = [@"<html><body>500 Internal Server Error</body></html>" dataUsingEncoding:NSUTF8StringEncoding];
-  NSDictionary* result = [TeakRequest parseJSONResponseData:html];
-  XCTAssertNotNil(result);
+  NSDictionary* result = [TeakRequest parseJSONResponseData:html error:&err];
   XCTAssertEqualObjects(result, @{});
+  XCTAssertNotNil(err);
 }
 
 - (void)testReturnsEmptyDictForGarbageBytes {
+  NSError* err = nil;
   unsigned char bytes[] = {0xff, 0xfe, 0x00, 0x01};
   NSData* garbage = [NSData dataWithBytes:bytes length:sizeof(bytes)];
-  NSDictionary* result = [TeakRequest parseJSONResponseData:garbage];
-  XCTAssertNotNil(result);
+  NSDictionary* result = [TeakRequest parseJSONResponseData:garbage error:&err];
   XCTAssertEqualObjects(result, @{});
+  XCTAssertNotNil(err);
 }
 
-#pragma mark - Valid JSON that is not an object
+#pragma mark - Valid JSON that is not an object — error populated
 
 - (void)testReturnsEmptyDictForJSONArray {
+  NSError* err = nil;
   NSData* jsonArray = [@"[1, 2, 3]" dataUsingEncoding:NSUTF8StringEncoding];
-  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonArray];
-  XCTAssertNotNil(result);
+  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonArray error:&err];
   XCTAssertEqualObjects(result, @{});
+  XCTAssertNotNil(err);
 }
 
 - (void)testReturnsEmptyDictForJSONString {
+  NSError* err = nil;
   NSData* jsonString = [@"\"just a string\"" dataUsingEncoding:NSUTF8StringEncoding];
-  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonString];
-  XCTAssertNotNil(result);
+  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonString error:&err];
   XCTAssertEqualObjects(result, @{});
+  XCTAssertNotNil(err);
 }
 
-#pragma mark - Valid JSON objects
+#pragma mark - Valid JSON objects — error left unchanged
 
 - (void)testReturnsParsedDictForValidJSONObject {
+  NSError* err = nil;
   NSData* jsonData = [@"{\"status\":\"ok\",\"id\":42}" dataUsingEncoding:NSUTF8StringEncoding];
-  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonData];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonData error:&err];
   XCTAssertEqualObjects(result[@"status"], @"ok");
   XCTAssertEqualObjects(result[@"id"], @42);
+  XCTAssertNil(err);
 }
 
 - (void)testReturnsEmptyDictForEmptyJSONObject {
+  NSError* err = nil;
   NSData* jsonData = [@"{}" dataUsingEncoding:NSUTF8StringEncoding];
-  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonData];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:jsonData error:&err];
+  XCTAssertEqualObjects(result, @{});
+  XCTAssertNil(err);
+}
+
+#pragma mark - nil outError pointer is tolerated
+
+- (void)testAcceptsNilOutErrorPointer {
+  NSData* garbage = [@"not json" dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary* result = [TeakRequest parseJSONResponseData:garbage error:NULL];
   XCTAssertEqualObjects(result, @{});
 }
 

--- a/Teak/TeakRequest+Internal.h
+++ b/Teak/TeakRequest+Internal.h
@@ -20,7 +20,11 @@
 // Parse an HTTP response body into a reply dictionary. Always returns a
 // dictionary — nil/empty/non-JSON/non-object bodies all collapse to @{} so
 // downstream code (reply parsers, dictionary literals) never sees nil.
-+ (NSDictionary* _Nonnull)parseJSONResponseData:(NSData* _Nullable)data;
+// On parse/shape failures, `*outError` (when provided) is set to a non-nil
+// NSError so callers can surface the failure to logging. On nil/empty data
+// or a successful parse, `*outError` is left unchanged.
++ (NSDictionary* _Nonnull)parseJSONResponseData:(NSData* _Nullable)data
+                                          error:(NSError* _Nullable* _Nullable)outError;
 
 // Resolve the user-facing title for a `report_client_error` payload.
 // Returns the dict's "title" when present and a string, otherwise

--- a/Teak/TeakRequest+Internal.h
+++ b/Teak/TeakRequest+Internal.h
@@ -21,4 +21,10 @@
 // dictionary — nil/empty/non-JSON/non-object bodies all collapse to @{} so
 // downstream code (reply parsers, dictionary literals) never sees nil.
 + (NSDictionary* _Nonnull)parseJSONResponseData:(NSData* _Nullable)data;
+
+// Resolve the user-facing title for a `report_client_error` payload.
+// Returns the dict's "title" when present and a string, otherwise
+// "Configuration Error". Never nil — the result is used as a key into the
+// integration checker's error dictionary.
++ (NSString* _Nonnull)titleForClientError:(NSDictionary* _Nullable)clientError;
 @end

--- a/Teak/TeakRequest+Internal.h
+++ b/Teak/TeakRequest+Internal.h
@@ -16,4 +16,9 @@
 @property (strong, nonatomic, readwrite) NSString* _Nonnull method;
 
 - (nullable TeakRequest*)initWithSession:(nonnull TeakSession*)session forHostname:(nonnull NSString*)hostname withEndpoint:(nonnull NSString*)endpoint withPayload:(nonnull NSDictionary*)payload method:(nonnull NSString*)method callback:(nullable TeakRequestResponse)callback addCommonPayload:(BOOL)addCommonToPayload;
+
+// Parse an HTTP response body into a reply dictionary. Always returns a
+// dictionary — nil/empty/non-JSON/non-object bodies all collapse to @{} so
+// downstream code (reply parsers, dictionary literals) never sees nil.
++ (NSDictionary* _Nonnull)parseJSONResponseData:(NSData* _Nullable)data;
 @end

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -148,6 +148,12 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
   return parsed;
 }
 
++ (NSString*)titleForClientError:(NSDictionary*)clientError {
+  id title = clientError[@"title"];
+  if ([title isKindOfClass:[NSString class]]) return title;
+  return @"Configuration Error";
+}
+
 + (NSMutableDictionary*)requestsInFlight {
   static NSMutableDictionary* dict = nil;
   static dispatch_once_t onceToken;
@@ -352,7 +358,7 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
             @try {
               // We are going to get a 'message' key and optionally a 'title' key
               NSDictionary* clientError = payload[@"report_client_error"];
-              NSString* title = clientError[@"title"] == nil ? clientError[@"title"] : @"Configuration Error";
+              NSString* title = [TeakRequest titleForClientError:clientError];
 
               [[Teak sharedInstance].integrationChecker reportError:clientError[@"message"] forCategory:title];
             } @finally {

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -141,6 +141,13 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
   return session;
 }
 
++ (NSDictionary*)parseJSONResponseData:(NSData*)data {
+  if (data == nil || data.length == 0) return @{};
+  id parsed = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
+  if (![parsed isKindOfClass:[NSDictionary class]]) return @{};
+  return parsed;
+}
+
 + (NSMutableDictionary*)requestsInFlight {
   static NSMutableDictionary* dict = nil;
   static dispatch_once_t onceToken;
@@ -632,14 +639,11 @@ KeyValueObserverSupported(TeakBatchedRequest);
     TeakLog_e(@"request.reply.error", error);
   } else {
     teak_try {
+      NSData* data = nil;
       @synchronized(self) {
-        NSData* data = self.responseData[@(dataTask.taskIdentifier)];
-        if (data) {
-          reply = (NSDictionary*)[NSJSONSerialization JSONObjectWithData:data
-                                                                 options:kNilOptions
-                                                                   error:&error];
-        }
+        data = self.responseData[@(dataTask.taskIdentifier)];
       }
+      reply = [TeakRequest parseJSONResponseData:data];
     }
     teak_catch_report;
   }

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -141,10 +141,23 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
   return session;
 }
 
-+ (NSDictionary*)parseJSONResponseData:(NSData*)data {
++ (NSDictionary*)parseJSONResponseData:(NSData*)data error:(NSError**)outError {
   if (data == nil || data.length == 0) return @{};
-  id parsed = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:nil];
-  if (![parsed isKindOfClass:[NSDictionary class]]) return @{};
+
+  NSError* parseError = nil;
+  id parsed = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&parseError];
+  if (parsed == nil) {
+    if (outError) *outError = parseError;
+    return @{};
+  }
+  if (![parsed isKindOfClass:[NSDictionary class]]) {
+    if (outError) {
+      *outError = [NSError errorWithDomain:@"io.teak.TeakRequest"
+                                      code:0
+                                  userInfo:@{NSLocalizedDescriptionKey : [NSString stringWithFormat:@"Expected top-level JSON object, got %@", NSStringFromClass([parsed class])]}];
+    }
+    return @{};
+  }
   return parsed;
 }
 
@@ -649,7 +662,11 @@ KeyValueObserverSupported(TeakBatchedRequest);
       @synchronized(self) {
         data = self.responseData[@(dataTask.taskIdentifier)];
       }
-      reply = [TeakRequest parseJSONResponseData:data];
+      NSError* parseError = nil;
+      reply = [TeakRequest parseJSONResponseData:data error:&parseError];
+      if (parseError) {
+        TeakLog_e(@"request.reply.parse_error", parseError);
+      }
     }
     teak_catch_report;
   }


### PR DESCRIPTION
## Summary
- A 500 response with a non-JSON body (e.g. an HTML error page) caused `NSJSONSerialization` to return nil, which `URLSession:task:didCompleteWithError:` forwarded downstream as the reply payload; reply parsers like the one for `/me/live_activities` then crashed in `@{@"response" : reply}` with `NSInvalidArgumentException: attempt to insert nil object from objects[0]`.
- Root cause fixed at the parse step: extracted `+[TeakRequest parseJSONResponseData:]` which always returns a dictionary (nil/empty/non-JSON/non-object bodies all collapse to `@{}`).
- Also fixes a latent, inverted ternary for `report_client_error` handling that returned nil for `title` when the key was absent (and the literal string "Configuration Error" when the key was present) — extracted `+[TeakRequest titleForClientError:]` with correct fallback and NSString type-check.

## Key decisions
- Guarded at the source in `TeakRequest` rather than sprinkling null-checks into each reply parser. Future reply parsers inherit the guarantee instead of being one bug away from the same crash.
- Non-object JSON (top-level arrays/strings/numbers) also collapses to `@{}`. The previous code cast the parse result to `NSDictionary*` without checking, so those shapes would have crashed the same reply parsers; the helper closes that class too.
- Title helper rejects NSNull as well as missing keys, so a server response of `"title": null` is handled the same as an absent key.
- Based off `4.3-stable` because the reported crash is on SDK `4.3.11-rc0-45-g5bf8484`.

## Test plan
- [x] `bundle exec fastlane test` — 103 unit tests pass, including 8 new in `TeakRequestResponseParsingTests` and 5 new in `TeakRequestClientErrorTests`.
- [x] New nil-payload tests cover: nil data, zero-length data, HTML error body, garbage bytes, top-level JSON array, top-level JSON string, valid JSON object, empty JSON object.
- [x] New title-ternary tests cover: title present, title missing, nil dict, empty dict, NSNull title.
- [ ] Manual: reproduce the original 500-from-`/me/live_activities` scenario and confirm no crash (reporter to verify in the environment that produced the original Sentry event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)