### PR TITLE
feat(c-680): pin Swift names for Live Activity API with NS_SWIFT_NAME

### DIFF
--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -588,7 +588,8 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  * @param systemActivityId The OS-level per-instance activity identifier, from ``Activity.id``.
  * @return A TeakOperation which contains the status and result of the call.
  */
-+ (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken systemActivityId:(nonnull NSString*)systemActivityId;
++ (nonnull TeakOperation*)startedLiveActivity:(nonnull NSString*)activityId withToken:(nonnull NSData*)pushToken systemActivityId:(nonnull NSString*)systemActivityId
+    NS_SWIFT_NAME(startedLiveActivity(_:withToken:systemActivityId:));
 
 /**
  * Schedule a single update to be delivered to a live activity at a future time.
@@ -614,7 +615,8 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
 + (nonnull TeakOperation*)scheduleLiveActivityUpdate:(nonnull NSString*)activityId
                                               offset:(int64_t)offset
                                           customData:(nonnull NSDictionary*)customData
-                                          systemData:(nullable NSDictionary*)systemData;
+                                          systemData:(nullable NSDictionary*)systemData
+    NS_SWIFT_NAME(scheduleLiveActivityUpdate(_:offset:customData:systemData:));
 
 /**
  * Cancel all pending scheduled updates for a live activity.
@@ -628,7 +630,8 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  *         ``TeakOperationLiveActivityCancelResult`` carrying the number of updates
  *         canceled by the server.
  */
-+ (nonnull TeakOperation*)cancelLiveActivityUpdates:(nonnull NSString*)activityId;
++ (nonnull TeakOperation*)cancelLiveActivityUpdates:(nonnull NSString*)activityId
+    NS_SWIFT_NAME(cancelLiveActivityUpdates(_:));
 
 /**
  * Report a live activity push-to-start token to Teak.
@@ -639,7 +642,8 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  *
  * @param token The push-to-start token data from ``Activity.pushToStartTokenUpdates``.
  */
-+ (void)registerPushToStartToken:(nonnull NSData*)token;
++ (void)registerPushToStartToken:(nonnull NSData*)token
+    NS_SWIFT_NAME(registerPushToStartToken(_:));
 
 @end
 


### PR DESCRIPTION
## Summary

- Swift's ObjC→Swift selector splitter mangles `+registerPushToStartToken:` into `Teak.registerPush(toStartToken:)` — splits on "Push" and treats "Token" as a trailing noun. Swift-first integrators intuitively type `Teak.registerPushToStartToken(_:)` first and hit a compiler error.
- Annotates all four new Live Activity methods in `Teak/Teak.h` with `NS_SWIFT_NAME` so their Swift-side names match the ObjC selector reading and can't silently drift if a selector label is ever refactored.
- Ships before the Live Activity APIs have external adopters — any change after release would be a breaking change.

## Key decisions

- Pinned all four methods, not just `registerPushToStartToken:`. The other three happen to round-trip to the intended Swift name today, but pinning them locks that in for future selector edits.
- PR targets `4.3-stable` because that's where the Live Activity methods currently live in the release line; it will flow to `develop` via the normal merge path.
- Consumer call-site update in `teak-swift-cleanroom/TeakSwiftCleanroomPods` (`Teak.registerPush(toStartToken:)` → `Teak.registerPushToStartToken(_:)`) will land in its own PR on the cleanroom's Live Activity branch.

## Test plan

- [x] `bundle exec fastlane test` passes.
- [x] `./compile_xc_framework` produces Teak.xcframework cleanly.
- [x] Swift verification compile against the built xcframework using the pinned names (`Teak.registerPushToStartToken(_:)`, `Teak.startedLiveActivity(_:withToken:systemActivityId:)`, `Teak.scheduleLiveActivityUpdate(_:offset:customData:systemData:)`, `Teak.cancelLiveActivityUpdates(_:)`) succeeds.
- [ ] Consumer verification in teak-swift-cleanroom (follow-up PR): update the `registerPush(toStartToken:)` call-site and confirm the cleanroom builds.

Closes C-680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)