### PR TITLE
feat(C-688): TeakCExtern C wrappers for Live Activity public APIs

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */; };
 		0F9BB099DE5CFEDF8A8B30F9 /* Pods_AutomatedUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */; };
 		20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */; };
 		24E918A8B1343E0E4D8092AE /* Teak.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -142,6 +143,7 @@
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateCancellationTests.m; sourceTree = "<group>"; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakCExternLiveActivityTests.m; sourceTree = "<group>"; };
 		EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRequestClientErrorTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -258,6 +260,7 @@
 				688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */,
 				068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */,
 				F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */,
+				EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -587,6 +590,7 @@
 				3B53F44500DC81BFC8562EC5 /* TeakLiveActivityLaunchDataTests.m in Sources */,
 				AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */,
 				20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */,
+				01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakCExternLiveActivityTests.m
+++ b/Automated/AutomatedTests/TeakCExternLiveActivityTests.m
@@ -59,6 +59,18 @@ extern TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId);
   XCTAssertNotNil(result.errors[@"token"]);
 }
 
+- (void)testStartedLiveActivity_NullActivityIdSurfacesErrorResult {
+  unsigned char bytes[] = {0xde, 0xad, 0xbe, 0xef};
+  TeakOperation* op = TeakStartedLiveActivity(NULL, bytes, (int)sizeof(bytes), "system-activity-uuid");
+
+  XCTAssertNotNil(op, @"Wrapper should still return an operation for a NULL activityId");
+
+  TeakOperationResult* result = [self.driver runSync:op];
+  XCTAssertTrue(result.error);
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"activityId"]);
+}
+
 #pragma mark - TeakScheduleLiveActivityUpdate
 
 - (void)testScheduleLiveActivityUpdate_BuildsValidRequest {
@@ -94,9 +106,22 @@ extern TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId);
   XCTAssertNotNil(op);
 
   NSDictionary* payload = [self.driver requestParamsFor:op][@"payload"];
-  id systemData = payload[@"system_data"];
-  XCTAssertTrue(systemData == nil || systemData == [NSNull null],
-                @"NULL systemDataJson should map to nil/NSNull on the payload");
+  XCTAssertEqualObjects(payload[@"system_data"], [NSNull null],
+                        @"NULL systemDataJson should serialize to NSNull on the payload");
+}
+
+- (void)testScheduleLiveActivityUpdate_NullActivityIdSurfacesErrorResult {
+  TeakOperation* op = TeakScheduleLiveActivityUpdate(NULL,
+                                                     3600,
+                                                     "{\"score\":42}",
+                                                     "{\"event\":\"update\"}");
+
+  XCTAssertNotNil(op, @"Wrapper should still return an operation for a NULL activityId");
+
+  TeakOperationResult* result = [self.driver runSync:op];
+  XCTAssertTrue(result.error);
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"activityId"]);
 }
 
 - (void)testScheduleLiveActivityUpdate_MalformedCustomDataJsonSurfacesError {
@@ -128,9 +153,8 @@ extern TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId);
 
   NSDictionary* payload = [self.driver requestParamsFor:op][@"payload"];
   XCTAssertNotNil(payload, @"Malformed systemDataJson should not short-circuit to an error");
-  id systemData = payload[@"system_data"];
-  XCTAssertTrue(systemData == nil || systemData == [NSNull null],
-                @"Malformed systemDataJson should be treated as absent");
+  XCTAssertEqualObjects(payload[@"system_data"], [NSNull null],
+                        @"Malformed systemDataJson should be treated as absent (NSNull on payload)");
 }
 
 #pragma mark - TeakCancelLiveActivityUpdates
@@ -145,6 +169,17 @@ extern TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId);
 
   NSDictionary* payload = requestParams[@"payload"];
   XCTAssertEqualObjects(payload[@"live_activity_id"], @"chest_timer");
+}
+
+- (void)testCancelLiveActivityUpdates_NullActivityIdSurfacesErrorResult {
+  TeakOperation* op = TeakCancelLiveActivityUpdates(NULL);
+
+  XCTAssertNotNil(op, @"Wrapper should still return an operation for a NULL activityId");
+
+  TeakOperationResult* result = [self.driver runSync:op];
+  XCTAssertTrue(result.error);
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"activityId"]);
 }
 
 @end

--- a/Automated/AutomatedTests/TeakCExternLiveActivityTests.m
+++ b/Automated/AutomatedTests/TeakCExternLiveActivityTests.m
@@ -1,0 +1,150 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakOperationTestDriver.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Forward declarations for the TeakCExtern Live Activity wrappers. They are
+// defined in TeakCExtern.m (compiled into Teak.framework) and consumed from
+// Unity via the same extern pattern.
+extern TeakOperation* TeakStartedLiveActivity(const char* activityId,
+                                              const void* pushTokenBytes,
+                                              int pushTokenLength,
+                                              const char* systemActivityId);
+extern TeakOperation* TeakScheduleLiveActivityUpdate(const char* activityId,
+                                                    int64_t offset,
+                                                    const char* customDataJson,
+                                                    const char* systemDataJson);
+extern TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId);
+
+@interface TeakCExternLiveActivityTests : XCTestCase
+@property (nonatomic) TeakOperationTestDriver* driver;
+@end
+
+@implementation TeakCExternLiveActivityTests
+
+- (void)setUp {
+  [super setUp];
+  self.driver = [[TeakOperationTestDriver alloc] init];
+}
+
+#pragma mark - TeakStartedLiveActivity
+
+- (void)testStartedLiveActivity_BuildsValidRequest {
+  unsigned char bytes[] = {0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x01, 0x23};
+  TeakOperation* op = TeakStartedLiveActivity("chest_timer", bytes, (int)sizeof(bytes), "system-activity-uuid");
+
+  XCTAssertNotNil(op);
+
+  NSDictionary* requestParams = [self.driver requestParamsFor:op];
+  XCTAssertEqualObjects(requestParams[@"endpoint"], @"/me/live_activities");
+
+  NSDictionary* payload = requestParams[@"payload"];
+  XCTAssertEqualObjects(payload[@"live_activity_id"], @"chest_timer");
+  XCTAssertEqualObjects(payload[@"system_activity_id"], @"system-activity-uuid");
+  XCTAssertEqualObjects(payload[@"token"], @"deadbeefcafe0123",
+                        @"Token bytes should be marshalled to a lowercase hex string");
+}
+
+- (void)testStartedLiveActivity_NullPushTokenSurfacesErrorResult {
+  TeakOperation* op = TeakStartedLiveActivity("chest_timer", NULL, 0, "system-activity-uuid");
+
+  XCTAssertNotNil(op, @"Wrapper should still return an operation for a NULL token");
+
+  TeakOperationResult* result = [self.driver runSync:op];
+  XCTAssertTrue(result.error);
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"token"]);
+}
+
+#pragma mark - TeakScheduleLiveActivityUpdate
+
+- (void)testScheduleLiveActivityUpdate_BuildsValidRequest {
+  TeakOperation* op = TeakScheduleLiveActivityUpdate("chest_timer",
+                                                     3600,
+                                                     "{\"score\":42,\"period\":2}",
+                                                     "{\"event\":\"update\"}");
+
+  XCTAssertNotNil(op);
+
+  NSDictionary* requestParams = [self.driver requestParamsFor:op];
+  XCTAssertEqualObjects(requestParams[@"endpoint"], @"/me/live_activity_updates");
+
+  NSDictionary* payload = requestParams[@"payload"];
+  XCTAssertEqualObjects(payload[@"live_activity_id"], @"chest_timer");
+  XCTAssertEqualObjects(payload[@"offset_seconds"], @3600);
+
+  NSData* customBytes = [payload[@"custom_data"] dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary* customRoundTrip = [NSJSONSerialization JSONObjectWithData:customBytes options:0 error:nil];
+  XCTAssertEqualObjects(customRoundTrip, (@{@"score" : @42, @"period" : @2}));
+
+  NSData* systemBytes = [payload[@"system_data"] dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary* systemRoundTrip = [NSJSONSerialization JSONObjectWithData:systemBytes options:0 error:nil];
+  XCTAssertEqualObjects(systemRoundTrip, (@{@"event" : @"update"}));
+}
+
+- (void)testScheduleLiveActivityUpdate_NullSystemDataJsonIsAllowed {
+  TeakOperation* op = TeakScheduleLiveActivityUpdate("chest_timer",
+                                                     3600,
+                                                     "{\"score\":42}",
+                                                     NULL);
+
+  XCTAssertNotNil(op);
+
+  NSDictionary* payload = [self.driver requestParamsFor:op][@"payload"];
+  id systemData = payload[@"system_data"];
+  XCTAssertTrue(systemData == nil || systemData == [NSNull null],
+                @"NULL systemDataJson should map to nil/NSNull on the payload");
+}
+
+- (void)testScheduleLiveActivityUpdate_MalformedCustomDataJsonSurfacesError {
+  // Must not crash. Malformed JSON parses to nil; the underlying ObjC method
+  // then rejects nil customData with a status=error, errors[customData] result.
+  TeakOperation* op = TeakScheduleLiveActivityUpdate("chest_timer",
+                                                     3600,
+                                                     "not{valid}json",
+                                                     "{\"event\":\"update\"}");
+
+  XCTAssertNotNil(op);
+
+  TeakOperationResult* result = [self.driver runSync:op];
+  XCTAssertTrue(result.error);
+  XCTAssertEqualObjects(result.status, @"error");
+  XCTAssertNotNil(result.errors[@"customData"]);
+}
+
+- (void)testScheduleLiveActivityUpdate_MalformedSystemDataJsonDoesNotCrash {
+  // Malformed systemDataJson parses to nil, which is a valid (absent) systemData
+  // per the underlying ObjC API — so the operation should still build a real
+  // request rather than error out.
+  TeakOperation* op = TeakScheduleLiveActivityUpdate("chest_timer",
+                                                     3600,
+                                                     "{\"score\":42}",
+                                                     "not{valid}json");
+
+  XCTAssertNotNil(op);
+
+  NSDictionary* payload = [self.driver requestParamsFor:op][@"payload"];
+  XCTAssertNotNil(payload, @"Malformed systemDataJson should not short-circuit to an error");
+  id systemData = payload[@"system_data"];
+  XCTAssertTrue(systemData == nil || systemData == [NSNull null],
+                @"Malformed systemDataJson should be treated as absent");
+}
+
+#pragma mark - TeakCancelLiveActivityUpdates
+
+- (void)testCancelLiveActivityUpdates_BuildsValidRequest {
+  TeakOperation* op = TeakCancelLiveActivityUpdates("chest_timer");
+
+  XCTAssertNotNil(op);
+
+  NSDictionary* requestParams = [self.driver requestParamsFor:op];
+  XCTAssertEqualObjects(requestParams[@"endpoint"], @"/me/cancel_all_live_activity_updates");
+
+  NSDictionary* payload = requestParams[@"payload"];
+  XCTAssertEqualObjects(payload[@"live_activity_id"], @"chest_timer");
+}
+
+@end

--- a/Teak/TeakCExtern.m
+++ b/Teak/TeakCExtern.m
@@ -256,6 +256,51 @@ BOOL TeakRequestPushAuthorization(BOOL includeProvisional) {
   return TeakRequestPushAuthorizationWithCallback(includeProvisional, NULL, NULL);
 }
 
+// Parse a UTF-8 JSON cstring into an NSDictionary, or return nil for NULL,
+// non-UTF-8, malformed JSON, or non-dictionary roots. Used by the Live Activity
+// wrappers; callers rely on nil propagating into the underlying ObjC API's
+// existing nil-handling (which surfaces a TeakOperationResult error).
+static NSDictionary* TeakParseJSONDictionaryOrNil(const char* jsonCStr) {
+  if (jsonCStr == NULL) {
+    return nil;
+  }
+  NSString* jsonString = [NSString stringWithUTF8String:jsonCStr];
+  if (jsonString == nil) {
+    return nil;
+  }
+  NSData* jsonData = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
+  if (jsonData == nil) {
+    return nil;
+  }
+  id parsed = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:NULL];
+  if (![parsed isKindOfClass:[NSDictionary class]]) {
+    return nil;
+  }
+  return parsed;
+}
+
+TeakOperation* TeakStartedLiveActivity(const char* activityId, const void* pushTokenBytes, int pushTokenLength, const char* systemActivityId) {
+  NSString* activityIdString = activityId == NULL ? nil : [NSString stringWithUTF8String:activityId];
+  NSString* systemActivityIdString = systemActivityId == NULL ? nil : [NSString stringWithUTF8String:systemActivityId];
+  NSData* tokenData = (pushTokenBytes == NULL || pushTokenLength <= 0) ? nil : [NSData dataWithBytes:pushTokenBytes length:pushTokenLength];
+  return [Teak startedLiveActivity:activityIdString withToken:tokenData systemActivityId:systemActivityIdString];
+}
+
+TeakOperation* TeakScheduleLiveActivityUpdate(const char* activityId, int64_t offset, const char* customDataJson, const char* systemDataJson) {
+  NSString* activityIdString = activityId == NULL ? nil : [NSString stringWithUTF8String:activityId];
+  NSDictionary* customData = TeakParseJSONDictionaryOrNil(customDataJson);
+  NSDictionary* systemData = TeakParseJSONDictionaryOrNil(systemDataJson);
+  return [Teak scheduleLiveActivityUpdate:activityIdString
+                                   offset:offset
+                               customData:customData
+                               systemData:systemData];
+}
+
+TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId) {
+  NSString* activityIdString = activityId == NULL ? nil : [NSString stringWithUTF8String:activityId];
+  return [Teak cancelLiveActivityUpdates:activityIdString];
+}
+
 TeakOperation* TeakSetStateForChannel(const char* stateCstr, const char* channelCstr) {
   NSString* state = [NSString stringWithUTF8String:stateCstr];
   NSString* channel = [NSString stringWithUTF8String:channelCstr];


### PR DESCRIPTION
## Summary

- Adds three C bridges in `Teak/TeakCExtern.m` (`TeakStartedLiveActivity`, `TeakScheduleLiveActivityUpdate`, `TeakCancelLiveActivityUpdates`) that marshal C primitives into NSString / NSData / NSDictionary and forward to the Live Activity public class methods landed in C-641 / C-643.
- Unblocks the Unity SDK ([C-645](https://linear.app/teakio/issue/C-645)) — its `Assets/Teak/Plugins/iOS/teak_init.m` `extern`s these symbols.
- New `Automated/AutomatedTests/TeakCExternLiveActivityTests.m` covers the wrappers' dispatch, JSON parsing, NULL handling, and malformed-JSON behavior (7 cases, all passing).

## Key decisions

- **Header surface unchanged.** `TeakCExtern.h` continues to expose only `TeakRequestPushAuthorization` / `Teak_Plant`; the new wrappers follow the existing convention of being defined in `.m` and `extern`ed from the Unity side, keeping the framework public header minimal.
- **Malformed JSON propagates as nil**, not as a wrapper-side error, so the underlying ObjC method's existing validation path produces a uniform `TeakOperationResult` error (`status=error`, `errors[customData]`). For `systemDataJson`, malformed input is treated as absent — matching the ObjC API which accepts a nullable `systemData`.
- **`@available(iOS 16.1, *)` stays on the ObjC side.** The C wrappers do no version-gating; the existing class methods already handle that on all iOS versions (they don't touch `ActivityKit` directly).
- Token bytes pass as `(const void* bytes, int length)` so Unity can hand its managed byte[] across with a pointer + length.

## Test plan

- [x] `bundle exec fastlane test` — all suites green, including the 7 new `TeakCExternLiveActivityTests` cases.
- [ ] Once C-645 lands, smoke-test end-to-end from Unity: start a live activity, schedule an update, cancel updates, confirm `TeakOperationGetResultAsDictionary` returns the expected status payloads.

Closes [C-688](https://linear.app/teakio/issue/C-688).

🤖 Generated with [Claude Code](https://claude.com/claude-code)