### PR TITLE
C-697: iOS claim_mode opt-in, click payload, enum extension

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */; };
 		0F9BB099DE5CFEDF8A8B30F9 /* Pods_AutomatedUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */; };
+		10AF0D9783E4B95AD56C894E /* TeakRewardStatusMappingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5309416095CC5DA95AFB776E /* TeakRewardStatusMappingTests.m */; };
 		20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */; };
 		24E918A8B1343E0E4D8092AE /* Teak.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2CC95EAD6283AE3D2A4AB872 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
@@ -31,11 +32,13 @@
 		43B4618F22A1EB54004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619922A20FDC004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
+		535C7E3DE7B81B495C220248 /* TeakRemoteConfigurationClaimModeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C8C931E76609DB7A99E2D1CD /* TeakRemoteConfigurationClaimModeTests.m */; };
 		55AAEB0EF3B9E90616642C8E /* LiveActivityUpdateSchedulingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 741732706353CEBB41D0AE37 /* LiveActivityUpdateSchedulingTests.m */; };
 		67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */; };
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
 		6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
+		92D3B67E3B434729F9769B2A /* TeakAppConfigurationClaimModeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E2617913405D1D641FE57676 /* TeakAppConfigurationClaimModeTests.m */; };
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
 		97EDAA942157436DCC939EC2 /* LiveActivityUpdateCancellationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */; };
 		AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */; };
@@ -127,6 +130,7 @@
 		43B4618E22A1EB54004AC636 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		43B4619222A1EBDF004AC636 /* OCMockito.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OCMockito.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		49655D0CF74258D769DEA6F9 /* TeakOperationTestDriver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakOperationTestDriver.m; sourceTree = "<group>"; };
+		5309416095CC5DA95AFB776E /* TeakRewardStatusMappingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRewardStatusMappingTests.m; sourceTree = "<group>"; };
 		58899BE40E40447A87FDF2D8 /* Pods-AutomatedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.release.xcconfig"; sourceTree = "<group>"; };
 		58C2AA35CD060472CAC08059 /* Pods-Automated.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.debug.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.debug.xcconfig"; sourceTree = "<group>"; };
 		688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakLiveActivityLaunchDataTests.m; sourceTree = "<group>"; };
@@ -140,7 +144,9 @@
 		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
+		C8C931E76609DB7A99E2D1CD /* TeakRemoteConfigurationClaimModeTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRemoteConfigurationClaimModeTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2617913405D1D641FE57676 /* TeakAppConfigurationClaimModeTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakAppConfigurationClaimModeTests.m; sourceTree = "<group>"; };
 		E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateCancellationTests.m; sourceTree = "<group>"; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakCExternLiveActivityTests.m; sourceTree = "<group>"; };
@@ -261,6 +267,9 @@
 				068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */,
 				F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */,
 				EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */,
+				5309416095CC5DA95AFB776E /* TeakRewardStatusMappingTests.m */,
+				E2617913405D1D641FE57676 /* TeakAppConfigurationClaimModeTests.m */,
+				C8C931E76609DB7A99E2D1CD /* TeakRemoteConfigurationClaimModeTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -591,6 +600,9 @@
 				AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */,
 				20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */,
 				01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */,
+				10AF0D9783E4B95AD56C894E /* TeakRewardStatusMappingTests.m in Sources */,
+				92D3B67E3B434729F9769B2A /* TeakAppConfigurationClaimModeTests.m in Sources */,
+				535C7E3DE7B81B495C220248 /* TeakRemoteConfigurationClaimModeTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakAppConfigurationClaimModeTests.m
+++ b/Automated/AutomatedTests/TeakAppConfigurationClaimModeTests.m
@@ -1,0 +1,29 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakAppConfiguration.h"
+
+@interface TeakAppConfigurationClaimModeTests : XCTestCase
+@end
+
+@implementation TeakAppConfigurationClaimModeTests
+
+- (void)testClaimModeDefaultsToLegacyWhenInfoPlistKeyAbsent {
+  // The test bundle's Info.plist does not declare TeakClaimMode, so a real
+  // TeakAppConfiguration constructed against [NSBundle mainBundle] should
+  // fall back to the documented default of @"legacy".
+  TeakAppConfiguration* config = [[TeakAppConfiguration alloc] initWithAppId:@"app-id" apiKey:@"api-key"];
+
+  XCTAssertNotNil(config.claimMode, @"claimMode must always be populated");
+  XCTAssertEqualObjects(config.claimMode, @"legacy",
+                        @"Apps without TeakClaimMode in Info.plist must default to 'legacy'");
+}
+
+- (void)testClaimModeIsExposedInToHForLogging {
+  TeakAppConfiguration* config = [[TeakAppConfiguration alloc] initWithAppId:@"app-id" apiKey:@"api-key"];
+  NSDictionary* dict = [config to_h];
+
+  XCTAssertNotNil(dict[@"claimMode"], @"to_h must include claimMode for the configuration log event");
+  XCTAssertEqualObjects(dict[@"claimMode"], config.claimMode);
+}
+
+@end

--- a/Automated/AutomatedTests/TeakAppConfigurationClaimModeTests.m
+++ b/Automated/AutomatedTests/TeakAppConfigurationClaimModeTests.m
@@ -8,14 +8,14 @@
 @implementation TeakAppConfigurationClaimModeTests
 
 - (void)testClaimModeDefaultsToLegacyWhenInfoPlistKeyAbsent {
-  // The test bundle's Info.plist does not declare TeakClaimMode, so a real
+  // The test bundle's Info.plist does not declare TeakRewardClaimMode, so a real
   // TeakAppConfiguration constructed against [NSBundle mainBundle] should
   // fall back to the documented default of @"legacy".
   TeakAppConfiguration* config = [[TeakAppConfiguration alloc] initWithAppId:@"app-id" apiKey:@"api-key"];
 
   XCTAssertNotNil(config.claimMode, @"claimMode must always be populated");
   XCTAssertEqualObjects(config.claimMode, @"legacy",
-                        @"Apps without TeakClaimMode in Info.plist must default to 'legacy'");
+                        @"Apps without TeakRewardClaimMode in Info.plist must default to 'legacy'");
 }
 
 - (void)testClaimModeIsExposedInToHForLogging {

--- a/Automated/AutomatedTests/TeakRemoteConfigurationClaimModeTests.m
+++ b/Automated/AutomatedTests/TeakRemoteConfigurationClaimModeTests.m
@@ -1,0 +1,135 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakLog.h"
+#import "TeakRemoteConfiguration.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Static method under test — re-exposed for the test target.
+@interface TeakRemoteConfiguration (TestAccess)
++ (BOOL)validateClaimMode:(nullable NSString*)configuredClaimMode againstSupported:(nullable id)supportedClaimModes;
+@end
+
+// Re-expose internal log property so tests can wire a real TeakLog into the
+// shared instance and observe TeakLog_w emissions through logListener.
+@interface Teak ()
+@property (strong, nonatomic) TeakLog* _Nonnull log;
+@end
+
+extern Teak* _teakSharedInstance;
+
+@interface TeakRemoteConfigurationClaimModeTests : XCTestCase
+@property (strong, nonatomic) Teak* previousSharedInstance;
+@property (strong, nonatomic) Teak* teakMock;
+@end
+
+@implementation TeakRemoteConfigurationClaimModeTests
+
+- (void)setUp {
+  [super setUp];
+  self.previousSharedInstance = _teakSharedInstance;
+
+  self.teakMock = mock([Teak class]);
+  [given([self.teakMock enableRemoteLogging]) willReturn:@NO];
+  [given([self.teakMock enableDebugOutput]) willReturn:@NO];
+
+  TeakLog* log = [[TeakLog alloc] initForTeak:self.teakMock withAppId:@"automated"];
+  [given([self.teakMock log]) willReturn:log];
+
+  _teakSharedInstance = self.teakMock;
+}
+
+- (void)tearDown {
+  _teakSharedInstance = self.previousSharedInstance;
+  [super tearDown];
+}
+
+#pragma mark - validateClaimMode return value
+
+- (void)testReturnsTrueWhenConfiguredModeIsInSupportedSet {
+  NSArray* supported = @[@"legacy", @"server_jwt"];
+  BOOL ok = [TeakRemoteConfiguration validateClaimMode:@"server_jwt" againstSupported:supported];
+  XCTAssertTrue(ok);
+}
+
+- (void)testReturnsTrueWhenLegacyDefaultIsSupported {
+  NSArray* supported = @[@"legacy"];
+  BOOL ok = [TeakRemoteConfiguration validateClaimMode:@"legacy" againstSupported:supported];
+  XCTAssertTrue(ok);
+}
+
+- (void)testReturnsFalseWhenConfiguredModeNotSupported {
+  NSArray* supported = @[@"legacy"];
+  BOOL ok = [TeakRemoteConfiguration validateClaimMode:@"server_jwt" againstSupported:supported];
+  XCTAssertFalse(ok);
+}
+
+#pragma mark - validateClaimMode log emission
+
+- (void)testEmitsWarningLevelEventWhenModeUnsupported {
+  __block NSString* observedEvent = nil;
+  __block NSString* observedLevel = nil;
+  __block NSDictionary* observedData = nil;
+  stubProperty(self.teakMock, logListener,
+               ^(NSString* _Nonnull event,
+                 NSString* _Nonnull level,
+                 NSDictionary* _Nullable eventData) {
+                 if ([event isEqualToString:@"claim_mode.unsupported"]) {
+                   observedEvent = event;
+                   observedLevel = level;
+                   observedData = eventData[@"event_data"];
+                 }
+               });
+
+  NSArray* supported = @[@"legacy"];
+  [TeakRemoteConfiguration validateClaimMode:@"server_jwt" againstSupported:supported];
+
+  assertThat(observedEvent, is(@"claim_mode.unsupported"));
+  assertThat(observedLevel, is(@"WARN"));
+  assertThat(observedData[@"configured"], is(@"server_jwt"));
+  assertThat(observedData[@"supported"], hasItem(@"legacy"));
+}
+
+- (void)testDoesNotEmitWarningWhenModeIsSupported {
+  __block BOOL warningSeen = NO;
+  stubProperty(self.teakMock, logListener,
+               ^(NSString* _Nonnull event,
+                 NSString* _Nonnull level,
+                 NSDictionary* _Nullable eventData) {
+                 if ([event isEqualToString:@"claim_mode.unsupported"]) {
+                   warningSeen = YES;
+                 }
+               });
+
+  NSArray* supported = @[@"legacy", @"server_jwt"];
+  [TeakRemoteConfiguration validateClaimMode:@"legacy" againstSupported:supported];
+
+  XCTAssertFalse(warningSeen, @"warning must not fire when configured mode is supported");
+}
+
+#pragma mark - Defensive handling of unexpected server payloads
+
+- (void)testReturnsTrueAndDoesNotWarnWhenSupportedListMissing {
+  __block BOOL warningSeen = NO;
+  stubProperty(self.teakMock, logListener,
+               ^(NSString* _Nonnull event,
+                 NSString* _Nonnull level,
+                 NSDictionary* _Nullable eventData) {
+                 if ([event isEqualToString:@"claim_mode.unsupported"]) {
+                   warningSeen = YES;
+                 }
+               });
+
+  BOOL ok = [TeakRemoteConfiguration validateClaimMode:@"server_jwt" againstSupported:nil];
+  XCTAssertTrue(ok);
+  XCTAssertFalse(warningSeen, @"do not warn if server omitted supported_claim_modes");
+}
+
+- (void)testReturnsTrueWhenSupportedListIsNotAnArray {
+  BOOL ok = [TeakRemoteConfiguration validateClaimMode:@"server_jwt" againstSupported:@"server_jwt"];
+  XCTAssertTrue(ok);
+}
+
+@end

--- a/Automated/AutomatedTests/TeakRemoteConfigurationClaimModeTests.m
+++ b/Automated/AutomatedTests/TeakRemoteConfigurationClaimModeTests.m
@@ -86,10 +86,12 @@ extern Teak* _teakSharedInstance;
   NSArray* supported = @[@"legacy"];
   [TeakRemoteConfiguration validateClaimMode:@"server_jwt" againstSupported:supported];
 
+  // Field shape mirrors Android's claim_mode.unsupported event so cross-SDK
+  // log ingestion doesn't need per-platform branches.
   assertThat(observedEvent, is(@"claim_mode.unsupported"));
   assertThat(observedLevel, is(@"WARN"));
-  assertThat(observedData[@"configured"], is(@"server_jwt"));
-  assertThat(observedData[@"supported"], hasItem(@"legacy"));
+  assertThat(observedData[@"configured_claim_mode"], is(@"server_jwt"));
+  assertThat(observedData[@"supported_claim_modes"], is(@"[\"legacy\"]"));
 }
 
 - (void)testDoesNotEmitWarningWhenModeIsSupported {

--- a/Automated/AutomatedTests/TeakRewardStatusMappingTests.m
+++ b/Automated/AutomatedTests/TeakRewardStatusMappingTests.m
@@ -1,0 +1,44 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakReward.h"
+
+@interface TeakReward (TestAccess)
++ (TeakRewardStatus)rewardStatusForString:(NSString*)status;
+@end
+
+@interface TeakRewardStatusMappingTests : XCTestCase
+@end
+
+@implementation TeakRewardStatusMappingTests
+
+- (void)testMapsExistingStatusStrings {
+  XCTAssertEqual([TeakReward rewardStatusForString:@"grant_reward"], kTeakRewardStatusGrantReward);
+  XCTAssertEqual([TeakReward rewardStatusForString:@"self_click"], kTeakRewardStatusSelfClick);
+  XCTAssertEqual([TeakReward rewardStatusForString:@"already_clicked"], kTeakRewardStatusAlreadyClicked);
+  XCTAssertEqual([TeakReward rewardStatusForString:@"too_many_clicks"], kTeakRewardStatusTooManyClicks);
+  XCTAssertEqual([TeakReward rewardStatusForString:@"exceed_max_clicks_for_day"], kTeakRewardStatusExceedMaxClicksForDay);
+  XCTAssertEqual([TeakReward rewardStatusForString:@"expired"], kTeakRewardStatusExpired);
+  XCTAssertEqual([TeakReward rewardStatusForString:@"invalid_post"], kTeakRewardStatusInvalidPost);
+}
+
+- (void)testMapsPlayerIneligible {
+  XCTAssertEqual([TeakReward rewardStatusForString:@"player_ineligible"], kTeakRewardStatusPlayerIneligible);
+  XCTAssertEqual((int)kTeakRewardStatusPlayerIneligible, 7);
+}
+
+- (void)testMapsNoRewardAvailable {
+  XCTAssertEqual([TeakReward rewardStatusForString:@"no_reward_available"], kTeakRewardStatusNoRewardAvailable);
+  XCTAssertEqual((int)kTeakRewardStatusNoRewardAvailable, 8);
+}
+
+- (void)testMapsClaimModeUnsupported {
+  XCTAssertEqual([TeakReward rewardStatusForString:@"claim_mode_unsupported"], kTeakRewardStatusClaimModeUnsupported);
+  XCTAssertEqual((int)kTeakRewardStatusClaimModeUnsupported, 9);
+}
+
+- (void)testUnknownStringMapsToUnknown {
+  XCTAssertEqual([TeakReward rewardStatusForString:@"some_future_status"], kTeakRewardStatusUnknown);
+  XCTAssertEqual([TeakReward rewardStatusForString:@""], kTeakRewardStatusUnknown);
+}
+
+@end

--- a/Teak/Configuration/TeakAppConfiguration.h
+++ b/Teak/Configuration/TeakAppConfiguration.h
@@ -6,6 +6,7 @@
 @property (strong, nonatomic, readonly) NSString* _Nonnull bundleId;
 @property (strong, nonatomic, readonly) NSString* _Nonnull appVersion;
 @property (strong, nonatomic, readonly) NSString* _Nonnull appVersionName;
+@property (strong, nonatomic, readonly) NSString* _Nonnull claimMode;
 @property (strong, nonatomic, readonly) NSSet* _Nonnull urlSchemes;
 @property (nonatomic, readonly) BOOL isProduction;
 @property (nonatomic, readonly) BOOL traceLog;

--- a/Teak/Configuration/TeakAppConfiguration.m
+++ b/Teak/Configuration/TeakAppConfiguration.m
@@ -22,6 +22,7 @@ BOOL Teak_isProductionBuild(void) {
 @property (strong, nonatomic, readwrite) NSString* bundleId;
 @property (strong, nonatomic, readwrite) NSString* appVersion;
 @property (strong, nonatomic, readwrite) NSString* _Nonnull appVersionName;
+@property (strong, nonatomic, readwrite) NSString* claimMode;
 @property (strong, nonatomic, readwrite) NSSet* urlSchemes;
 @property (nonatomic, readwrite) BOOL isProduction;
 @property (nonatomic, readwrite) BOOL traceLog;
@@ -68,6 +69,15 @@ BOOL Teak_isProductionBuild(void) {
     }
     teak_catch_report;
 
+    self.claimMode = @"legacy";
+    teak_try {
+      NSString* claimMode = [[NSBundle mainBundle] infoDictionary][@"TeakClaimMode"];
+      if ([claimMode isKindOfClass:[NSString class]] && claimMode.length > 0) {
+        self.claimMode = claimMode;
+      }
+    }
+    teak_catch_report;
+
 #define kTeakLogTrace @"TeakLogTrace"
 #define kTeakSDK5Behaviors @"TeakSDK5Behaviors"
 #define kTeakDoNotRefreshPushToken @"TeakDoNotRefreshPushToken"
@@ -89,6 +99,7 @@ BOOL Teak_isProductionBuild(void) {
     @"apiKey" : self.apiKey,
     @"bundleId" : self.bundleId,
     @"appVersion" : self.appVersion,
+    @"claimMode" : self.claimMode,
     @"isProduction" : self.isProduction ? @YES : @NO,
     @"traceLog" : self.traceLog ? @YES : @NO,
     @"sdk5Behaviors" : self.sdk5Behaviors ? @YES : @NO
@@ -96,13 +107,14 @@ BOOL Teak_isProductionBuild(void) {
 }
 
 - (NSString*)description {
-  return [NSString stringWithFormat:@"<%@: %p> app-id: %@; api-key: %@; bundle-id: %@; app-version: %@; is-production: %@; trace-log: %@; sdk5-behaviors: %@",
+  return [NSString stringWithFormat:@"<%@: %p> app-id: %@; api-key: %@; bundle-id: %@; app-version: %@; claim-mode: %@; is-production: %@; trace-log: %@; sdk5-behaviors: %@",
                                     NSStringFromClass([self class]),
                                     self, // @"0x%016llx"
                                     self.appId,
                                     self.apiKey,
                                     self.bundleId,
                                     self.appVersion,
+                                    self.claimMode,
                                     self.isProduction ? @"YES" : @"NO",
                                     self.traceLog ? @"YES" : @"NO",
                                     self.sdk5Behaviors ? @"YES" : @"NO"];

--- a/Teak/Configuration/TeakAppConfiguration.m
+++ b/Teak/Configuration/TeakAppConfiguration.m
@@ -71,7 +71,7 @@ BOOL Teak_isProductionBuild(void) {
 
     self.claimMode = @"legacy";
     teak_try {
-      NSString* claimMode = [[NSBundle mainBundle] infoDictionary][@"TeakClaimMode"];
+      NSString* claimMode = [[NSBundle mainBundle] infoDictionary][@"TeakRewardClaimMode"];
       if ([claimMode isKindOfClass:[NSString class]] && claimMode.length > 0) {
         self.claimMode = claimMode;
       }

--- a/Teak/Configuration/TeakRemoteConfiguration.m
+++ b/Teak/Configuration/TeakRemoteConfiguration.m
@@ -45,7 +45,7 @@
   }
 
   TeakLog_w(@"claim_mode.unsupported",
-            @"Configured TeakClaimMode is not in the game's supported_claim_modes; reward clicks may be rejected.",
+            @"Configured TeakRewardClaimMode is not in the game's supported_claim_modes; reward clicks may be rejected.",
             @{@"configured_claim_mode" : configuredClaimMode,
               @"supported_claim_modes" : supportedClaimModesString});
   return NO;

--- a/Teak/Configuration/TeakRemoteConfiguration.m
+++ b/Teak/Configuration/TeakRemoteConfiguration.m
@@ -29,10 +29,25 @@
   if ([(NSArray*)supportedClaimModes containsObject:configuredClaimMode]) {
     return YES;
   }
+
+  // Match Android's event_data shape so cross-SDK log ingestion doesn't have
+  // to special-case per-platform: snake-cased keys and a stringified list.
+  NSString* supportedClaimModesString = nil;
+  teak_try {
+    NSData* json = [NSJSONSerialization dataWithJSONObject:supportedClaimModes options:0 error:nil];
+    if (json != nil) {
+      supportedClaimModesString = [[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding];
+    }
+  }
+  teak_catch_report;
+  if (supportedClaimModesString == nil) {
+    supportedClaimModesString = [(NSArray*)supportedClaimModes description];
+  }
+
   TeakLog_w(@"claim_mode.unsupported",
             @"Configured TeakClaimMode is not in the game's supported_claim_modes; reward clicks may be rejected.",
-            @{@"configured" : configuredClaimMode,
-              @"supported" : supportedClaimModes});
+            @{@"configured_claim_mode" : configuredClaimMode,
+              @"supported_claim_modes" : supportedClaimModesString});
   return NO;
 }
 

--- a/Teak/Configuration/TeakRemoteConfiguration.m
+++ b/Teak/Configuration/TeakRemoteConfiguration.m
@@ -22,6 +22,20 @@
 
 @implementation TeakRemoteConfiguration
 
++ (BOOL)validateClaimMode:(nullable NSString*)configuredClaimMode againstSupported:(nullable id)supportedClaimModes {
+  if (configuredClaimMode == nil || ![supportedClaimModes isKindOfClass:[NSArray class]]) {
+    return YES;
+  }
+  if ([(NSArray*)supportedClaimModes containsObject:configuredClaimMode]) {
+    return YES;
+  }
+  TeakLog_w(@"claim_mode.unsupported",
+            @"Configured TeakClaimMode is not in the game's supported_claim_modes; reward clicks may be rejected.",
+            @{@"configured" : configuredClaimMode,
+              @"supported" : supportedClaimModes});
+  return NO;
+}
+
 + (NSDictionary*)defaultEndpointConfiguration {
 #define QUOTE(...) #__VA_ARGS__
   static NSString* defaultEndpointConfiguration = @QUOTE(
@@ -162,6 +176,10 @@
 
                                                     // Categories
                                                     self.channelCategories = [TeakChannelCategory createFromRemoteConfiguration:reply[@"available_categories"]];
+
+                                                    // Validate the configured claim mode against the game's supported set.
+                                                    [TeakRemoteConfiguration validateClaimMode:session.appConfiguration.claimMode
+                                                                              againstSupported:reply[@"supported_claim_modes"]];
 
                                                     [RemoteConfigurationEvent remoteConfigurationReady:self deviceConfiguration:session.deviceConfiguration];
                                                   }];

--- a/Teak/TeakLog.h
+++ b/Teak/TeakLog.h
@@ -29,3 +29,8 @@ extern __attribute__((overloadable)) void TeakLog_i(NSString* _Nonnull eventType
 extern __attribute__((overloadable)) void TeakLog_i(NSString* _Nonnull eventType, NSDictionary* _Nullable eventData);
 extern __attribute__((overloadable)) void TeakLog_i(NSString* _Nonnull eventType, NSString* _Nullable message);
 extern __attribute__((overloadable)) void TeakLog_i(NSString* _Nonnull eventType, NSString* _Nullable message, NSDictionary* _Nullable eventData);
+
+extern __attribute__((overloadable)) void TeakLog_w(NSString* _Nonnull eventType);
+extern __attribute__((overloadable)) void TeakLog_w(NSString* _Nonnull eventType, NSDictionary* _Nullable eventData);
+extern __attribute__((overloadable)) void TeakLog_w(NSString* _Nonnull eventType, NSString* _Nullable message);
+extern __attribute__((overloadable)) void TeakLog_w(NSString* _Nonnull eventType, NSString* _Nullable message, NSDictionary* _Nullable eventData);

--- a/Teak/TeakLog.m
+++ b/Teak/TeakLog.m
@@ -12,6 +12,7 @@
 #import "TeakHelpers.h"
 
 NSString* INFO = @"INFO";
+NSString* WARN = @"WARN";
 NSString* ERROR = @"ERROR";
 
 extern BOOL Teak_isProductionBuild(void);
@@ -82,6 +83,26 @@ __attribute__((overloadable)) void TeakLog_i(NSString* eventType, NSString* mess
     [payload setValue:message forKey:@"message"];
   }
   [[Teak sharedInstance].log logEvent:eventType level:INFO eventData:payload];
+}
+
+__attribute__((overloadable)) void TeakLog_w(NSString* eventType) {
+  TeakLog_w(eventType, nil, nil);
+}
+
+__attribute__((overloadable)) void TeakLog_w(NSString* _Nonnull eventType, NSDictionary* _Nullable eventData) {
+  TeakLog_w(eventType, nil, eventData);
+}
+
+__attribute__((overloadable)) void TeakLog_w(NSString* eventType, NSString* message) {
+  TeakLog_w(eventType, message, nil);
+}
+
+__attribute__((overloadable)) void TeakLog_w(NSString* eventType, NSString* message, NSDictionary* eventData) {
+  NSMutableDictionary* payload = [NSMutableDictionary dictionaryWithDictionary:eventData == nil ? @{} : eventData];
+  if (message != nil) {
+    [payload setValue:message forKey:@"message"];
+  }
+  [[Teak sharedInstance].log logEvent:eventType level:WARN eventData:payload];
 }
 
 @interface TeakLog ()

--- a/Teak/TeakReward.h
+++ b/Teak/TeakReward.h
@@ -1,14 +1,17 @@
 #import <Foundation/Foundation.h>
 
 typedef enum : int {
-  kTeakRewardStatusUnknown = -1,              ///< An unknown error occured while processing the reward.
-  kTeakRewardStatusGrantReward = 0,           ///< Valid reward claim, grant the user the reward.
-  kTeakRewardStatusSelfClick = 1,             ///< The user has attempted to claim a reward from their own social post.
-  kTeakRewardStatusAlreadyClicked = 2,        ///< The user has already been issued this reward.
-  kTeakRewardStatusTooManyClicks = 3,         ///< The reward has already been claimed its maximum number of times globally.
-  kTeakRewardStatusExceedMaxClicksForDay = 4, ///< The user has already claimed their maximum number of rewards of this type for the day.
-  kTeakRewardStatusExpired = 5,               ///< This reward has expired and is no longer valid.
-  kTeakRewardStatusInvalidPost = 6,           ///< Teak does not recognize this reward id.
+  kTeakRewardStatusUnknown = -1,                ///< An unknown error occured while processing the reward.
+  kTeakRewardStatusGrantReward = 0,             ///< Valid reward claim, grant the user the reward.
+  kTeakRewardStatusSelfClick = 1,               ///< The user has attempted to claim a reward from their own social post.
+  kTeakRewardStatusAlreadyClicked = 2,          ///< The user has already been issued this reward.
+  kTeakRewardStatusTooManyClicks = 3,           ///< The reward has already been claimed its maximum number of times globally.
+  kTeakRewardStatusExceedMaxClicksForDay = 4,   ///< The user has already claimed their maximum number of rewards of this type for the day.
+  kTeakRewardStatusExpired = 5,                 ///< This reward has expired and is no longer valid.
+  kTeakRewardStatusInvalidPost = 6,             ///< Teak does not recognize this reward id.
+  kTeakRewardStatusPlayerIneligible = 7,        ///< The player is not eligible to claim this reward.
+  kTeakRewardStatusNoRewardAvailable = 8,       ///< No reward is currently available for this click.
+  kTeakRewardStatusClaimModeUnsupported = 9,    ///< The configured claim mode is not supported by this game.
 } TeakRewardStatus;
 
 typedef void (^RewardCompleted)(void);

--- a/Teak/TeakReward.m
+++ b/Teak/TeakReward.m
@@ -13,6 +13,32 @@
 @end
 
 @implementation TeakReward
+
++ (TeakRewardStatus)rewardStatusForString:(NSString*)status {
+  if ([status isEqualToString:@"grant_reward"]) {
+    return kTeakRewardStatusGrantReward;
+  } else if ([status isEqualToString:@"self_click"]) {
+    return kTeakRewardStatusSelfClick;
+  } else if ([status isEqualToString:@"already_clicked"]) {
+    return kTeakRewardStatusAlreadyClicked;
+  } else if ([status isEqualToString:@"too_many_clicks"]) {
+    return kTeakRewardStatusTooManyClicks;
+  } else if ([status isEqualToString:@"exceed_max_clicks_for_day"]) {
+    return kTeakRewardStatusExceedMaxClicksForDay;
+  } else if ([status isEqualToString:@"expired"]) {
+    return kTeakRewardStatusExpired;
+  } else if ([status isEqualToString:@"invalid_post"]) {
+    return kTeakRewardStatusInvalidPost;
+  } else if ([status isEqualToString:@"player_ineligible"]) {
+    return kTeakRewardStatusPlayerIneligible;
+  } else if ([status isEqualToString:@"no_reward_available"]) {
+    return kTeakRewardStatusNoRewardAvailable;
+  } else if ([status isEqualToString:@"claim_mode_unsupported"]) {
+    return kTeakRewardStatusClaimModeUnsupported;
+  }
+  return kTeakRewardStatusUnknown;
+}
+
 - (NSString*)description {
   return [NSString stringWithFormat:@"<%@: %p> completed: %@; reward-status: %d; json: %@",
                                     NSStringFromClass([self class]),
@@ -37,7 +63,8 @@
     TeakRequest* request = [TeakRequest requestWithSession:session
                                                forHostname:[NSString stringWithFormat:@"rewards.%@", kTeakHostname]
                                               withEndpoint:urlString
-                                               withPayload:@{@"clicking_user_id" : session.userId}
+                                               withPayload:@{@"clicking_user_id" : session.userId,
+                                                             @"claim_mode" : session.appConfiguration.claimMode}
                                                     method:TeakRequest_POST
                                                   callback:^(NSDictionary* reply) {
                                                     NSMutableDictionary* rewardResponse = [NSMutableDictionary dictionaryWithDictionary:reply[@"response"]];
@@ -64,22 +91,7 @@
                                                     }
                                                     ret.json = rewardResponse;
 
-                                                    NSString* status = rewardResponse[@"status"];
-                                                    if ([status isEqualToString:@"grant_reward"]) {
-                                                      ret.rewardStatus = kTeakRewardStatusGrantReward;
-                                                    } else if ([status isEqualToString:@"self_click"]) {
-                                                      ret.rewardStatus = kTeakRewardStatusSelfClick;
-                                                    } else if ([status isEqualToString:@"already_clicked"]) {
-                                                      ret.rewardStatus = kTeakRewardStatusAlreadyClicked;
-                                                    } else if ([status isEqualToString:@"too_many_clicks"]) {
-                                                      ret.rewardStatus = kTeakRewardStatusTooManyClicks;
-                                                    } else if ([status isEqualToString:@"exceed_max_clicks_for_day"]) {
-                                                      ret.rewardStatus = kTeakRewardStatusExceedMaxClicksForDay;
-                                                    } else if ([status isEqualToString:@"expired"]) {
-                                                      ret.rewardStatus = kTeakRewardStatusExpired;
-                                                    } else if ([status isEqualToString:@"invalid_post"]) {
-                                                      ret.rewardStatus = kTeakRewardStatusInvalidPost;
-                                                    }
+                                                    ret.rewardStatus = [TeakReward rewardStatusForString:rewardResponse[@"status"]];
 
                                                     ret.completed = YES;
 


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-697/ios-sdk-claim-mode-opt-in-click-payload-enum-extension

## Summary

SDK A "skeleton" for Simplify Rewards on iOS: declares the app's claim mode, wires it onto every reward click, and prepares the reward-status enum for the new server outcomes. Self-contained — no click-time JWT handling here (that's C-698).

- `TeakAppConfiguration.claimMode` reads `TeakClaimMode` from Info.plist, defaulting to `@"legacy"`. Surfaced in `to_h` / `description` for the `configuration.app` log event.
- `TeakReward` click POST always carries `claim_mode = appConfiguration.claimMode` — explicit on every request, including `claim_mode=legacy` for non-opted-in apps.
- `TeakRewardStatus` enum gains `kTeakRewardStatusPlayerIneligible` (7), `kTeakRewardStatusNoRewardAvailable` (8), `kTeakRewardStatusClaimModeUnsupported` (9), with matching string-to-enum entries for `player_ineligible`, `no_reward_available`, `claim_mode_unsupported`.
- After the settings.json reply lands, `TeakRemoteConfiguration` validates the configured mode against the returned `supported_claim_modes` and emits a `claim_mode.unsupported` warning (new `TeakLog_w` / WARN level) when there's a mismatch. Warning only — never an init abort.

## Key decisions

- The status-string mapping is hoisted into `+[TeakReward rewardStatusForString:]` and the validation logic into `+[TeakRemoteConfiguration validateClaimMode:againstSupported:]`. Both are private surfaces re-declared in test class extensions, avoiding the need to drag `TeakSession` or HTTP plumbing into unit tests.
- `TeakLog_w` (WARN) is added alongside the existing `TeakLog_i` / `TeakLog_e` overload sets so the new init-time validation message has its own level.
- Init-time validation hooks into the existing settings.json reply callback rather than subscribing to `RemoteConfigurationReady` as a separate observer — `session.appConfiguration` is already in scope there.

## Test plan

- `bundle exec fastlane test` → 129 tests, 0 failures.
- New coverage:
  - `TeakRewardStatusMappingTests` — five tests: existing statuses, each of the three new statuses (with explicit raw-value assertions for 7/8/9), unknown string falls through to `kTeakRewardStatusUnknown`.
  - `TeakAppConfigurationClaimModeTests` — `claimMode` defaults to `@"legacy"` when Info.plist has no `TeakClaimMode`; `to_h` includes the field.
  - `TeakRemoteConfigurationClaimModeTests` — return-value behavior across supported/unsupported/missing/non-array inputs, plus a `logListener`-based check that the warning fires at WARN level with the configured/supported pair in `event_data` and stays silent when the mode is supported.

Did not run `./format-code` (per the worktree CLAUDE.md, the script is currently broken; followed the existing style by hand).

## Readers left behind

- `kTeakRewardStatusClaimModeUnsupported` is wire-ready but only meaningful once the server can return `claim_mode_unsupported` — that's a Carrot-side change and out of scope here.
- Click-time JWT minting / `event=click_*` emission is C-698 / SDK B; this PR deliberately stops at the wire.