### PR TITLE
[worker-698] iOS SDK: JWT-mode click-time events + poll + ack

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		43B4618F22A1EB54004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619922A20FDC004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
+		4A4F58D2FDE8E862D2447E2B /* JwtModeRewardEventsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 07C44163D8A2651B1FF11F82 /* JwtModeRewardEventsTests.m */; };
 		535C7E3DE7B81B495C220248 /* TeakRemoteConfigurationClaimModeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C8C931E76609DB7A99E2D1CD /* TeakRemoteConfigurationClaimModeTests.m */; };
 		55AAEB0EF3B9E90616642C8E /* LiveActivityUpdateSchedulingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 741732706353CEBB41D0AE37 /* LiveActivityUpdateSchedulingTests.m */; };
 		67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */; };
@@ -46,6 +47,8 @@
 		B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
 		C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */; };
+		CB779F070A3C83A3A8223F45 /* ClaimStatusPollTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 908AEC6AEB595F804A0BFCF4 /* ClaimStatusPollTests.m */; };
+		EBBE9F50F3A660F96E30D7FA /* SessionAttributionSpecParityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9649026D4DAC93C7543F0B38 /* SessionAttributionSpecParityTests.m */; };
 		F05085BD353FDBF2763B09C7 /* LiveActivityTokenForwardingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */; };
 		F10455A046CB359057A63D58 /* TeakOperationTestDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 49655D0CF74258D769DEA6F9 /* TeakOperationTestDriver.m */; };
 		F4B9E6A620B8C3BC50CCB7CE /* libPods-Automated.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */; };
@@ -98,6 +101,7 @@
 
 /* Begin PBXFileReference section */
 		068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRequestResponseParsingTests.m; sourceTree = "<group>"; };
+		07C44163D8A2651B1FF11F82 /* JwtModeRewardEventsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = JwtModeRewardEventsTests.m; sourceTree = "<group>"; };
 		0D7BD679E00A2C57BE7AA5E3 /* Pods-AutomatedUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.release.xcconfig"; sourceTree = "<group>"; };
 		12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakDeviceConfigurationTests.m; sourceTree = "<group>"; };
 		2CC8154D37CB560E22904A43 /* Pods-AutomatedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -141,6 +145,8 @@
 		7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = NotificationSettingsTests.m; sourceTree = "<group>"; };
 		864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakAttributedLaunchDataEnrichmentTests.m; sourceTree = "<group>"; };
 		90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DebugConfigurationTests.m; sourceTree = "<group>"; };
+		908AEC6AEB595F804A0BFCF4 /* ClaimStatusPollTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ClaimStatusPollTests.m; sourceTree = "<group>"; };
+		9649026D4DAC93C7543F0B38 /* SessionAttributionSpecParityTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SessionAttributionSpecParityTests.m; sourceTree = "<group>"; };
 		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
@@ -270,6 +276,9 @@
 				5309416095CC5DA95AFB776E /* TeakRewardStatusMappingTests.m */,
 				E2617913405D1D641FE57676 /* TeakAppConfigurationClaimModeTests.m */,
 				C8C931E76609DB7A99E2D1CD /* TeakRemoteConfigurationClaimModeTests.m */,
+				9649026D4DAC93C7543F0B38 /* SessionAttributionSpecParityTests.m */,
+				07C44163D8A2651B1FF11F82 /* JwtModeRewardEventsTests.m */,
+				908AEC6AEB595F804A0BFCF4 /* ClaimStatusPollTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -603,6 +612,9 @@
 				10AF0D9783E4B95AD56C894E /* TeakRewardStatusMappingTests.m in Sources */,
 				92D3B67E3B434729F9769B2A /* TeakAppConfigurationClaimModeTests.m in Sources */,
 				535C7E3DE7B81B495C220248 /* TeakRemoteConfigurationClaimModeTests.m in Sources */,
+				EBBE9F50F3A660F96E30D7FA /* SessionAttributionSpecParityTests.m in Sources */,
+				4A4F58D2FDE8E862D2447E2B /* JwtModeRewardEventsTests.m in Sources */,
+				CB779F070A3C83A3A8223F45 /* ClaimStatusPollTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */; };
 		24E918A8B1343E0E4D8092AE /* Teak.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2CC95EAD6283AE3D2A4AB872 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
+		356B51387D21C7C89C429FA4 /* TeakRemoteConfigurationClaimPollSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CAD2D02BFDE0FC73C27B6D66 /* TeakRemoteConfigurationClaimPollSettingsTests.m */; };
 		3B53F44500DC81BFC8562EC5 /* TeakLiveActivityLaunchDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */; };
 		42ECB723361A815F90E2CC99 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
 		433392912654423400B10DE4 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 433392902654423400B10DE4 /* CoreServices.framework */; };
@@ -152,6 +153,7 @@
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
 		C8C931E76609DB7A99E2D1CD /* TeakRemoteConfigurationClaimModeTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRemoteConfigurationClaimModeTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAD2D02BFDE0FC73C27B6D66 /* TeakRemoteConfigurationClaimPollSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRemoteConfigurationClaimPollSettingsTests.m; sourceTree = "<group>"; };
 		E2617913405D1D641FE57676 /* TeakAppConfigurationClaimModeTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakAppConfigurationClaimModeTests.m; sourceTree = "<group>"; };
 		E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateCancellationTests.m; sourceTree = "<group>"; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -279,6 +281,7 @@
 				9649026D4DAC93C7543F0B38 /* SessionAttributionSpecParityTests.m */,
 				07C44163D8A2651B1FF11F82 /* JwtModeRewardEventsTests.m */,
 				908AEC6AEB595F804A0BFCF4 /* ClaimStatusPollTests.m */,
+				CAD2D02BFDE0FC73C27B6D66 /* TeakRemoteConfigurationClaimPollSettingsTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				EBBE9F50F3A660F96E30D7FA /* SessionAttributionSpecParityTests.m in Sources */,
 				4A4F58D2FDE8E862D2447E2B /* JwtModeRewardEventsTests.m in Sources */,
 				CB779F070A3C83A3A8223F45 /* ClaimStatusPollTests.m in Sources */,
+				356B51387D21C7C89C429FA4 /* TeakRemoteConfigurationClaimPollSettingsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/ClaimStatusPollTests.m
+++ b/Automated/AutomatedTests/ClaimStatusPollTests.m
@@ -16,10 +16,10 @@
 + (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
 @end
 
-// Internal accessor for the active polls dictionary so the dedupe contract
-// can be asserted against state, not behavior alone.
+// Internal accessor for the in-flight claims dictionary so the dedupe
+// contract can be asserted against state, not behavior alone.
 @interface TeakClaimPoll (Testing)
-+ (NSMutableDictionary*)activePolls;
++ (NSMutableDictionary*)inflightClaims;
 @end
 
 @interface ClaimStatusPollTests : XCTestCase
@@ -136,10 +136,10 @@
   [self waitForExpectations:@[ e ] timeout:1.0];
 }
 
-/// First +startPollForEventId: schedules a timer; a second call with the
-/// same eventId is a no-op (the existing poll continues, no second timer).
-/// Tightens the cross-SDK dedupe contract: at most one poll per event id,
-/// regardless of whether a timer is scheduled or a request is mid-flight.
+/// First +startPollForEventId: records an in-flight claim; a second call
+/// with the same eventId is a no-op (the existing claim continues, no
+/// second entry). Cross-SDK dedupe contract: the SDK is responsible for
+/// delivering each event_id exactly once.
 - (void)testStartPollDedupesByEventId {
   [TeakClaimPoll cancelAllPolls];
   [self drainMainQueue];
@@ -149,35 +149,37 @@
   [TeakClaimPoll startPollForEventId:eventId launchData:nil initialDelay:60.0 ceiling:120.0];
   [self drainMainQueue];
 
-  id firstSlot = [TeakClaimPoll activePolls][eventId];
-  XCTAssertNotNil(firstSlot, @"first start must record a poll for event id");
+  id firstSlot = [TeakClaimPoll inflightClaims][eventId];
+  XCTAssertNotNil(firstSlot, @"first start must record an in-flight claim for the event id");
 
   [TeakClaimPoll startPollForEventId:eventId launchData:nil initialDelay:60.0 ceiling:120.0];
   [self drainMainQueue];
 
-  id secondSlot = [TeakClaimPoll activePolls][eventId];
+  id secondSlot = [TeakClaimPoll inflightClaims][eventId];
   XCTAssertEqual(firstSlot, secondSlot,
-                 @"re-entrant start with the same eventId must not replace the existing poll slot");
-  XCTAssertEqual([TeakClaimPoll activePolls].count, (NSUInteger)1,
-                 @"only one poll should be tracked");
+                 @"re-entrant start with the same eventId must not replace the existing claim");
+  XCTAssertEqual([TeakClaimPoll inflightClaims].count, (NSUInteger)1,
+                 @"only one in-flight claim should be tracked");
 
   [TeakClaimPoll cancelAllPolls];
   [self drainMainQueue];
 }
 
 /// +cancelAllPolls clears the dictionary and invalidates pending timers.
+/// Called from the Expired session transition; the click-time tracker is
+/// abandoned in favor of the session-start sweep at next launch.
 - (void)testCancelAllPollsClearsState {
   [TeakClaimPoll startPollForEventId:@"evt-cancel-1" launchData:nil initialDelay:60.0 ceiling:120.0];
   [TeakClaimPoll startPollForEventId:@"evt-cancel-2" launchData:nil initialDelay:60.0 ceiling:120.0];
   [self drainMainQueue];
 
-  XCTAssertEqual([TeakClaimPoll activePolls].count, (NSUInteger)2);
+  XCTAssertEqual([TeakClaimPoll inflightClaims].count, (NSUInteger)2);
 
   [TeakClaimPoll cancelAllPolls];
   [self drainMainQueue];
 
-  XCTAssertEqual([TeakClaimPoll activePolls].count, (NSUInteger)0,
-                 @"cancelAllPolls must clear the active polls dictionary");
+  XCTAssertEqual([TeakClaimPoll inflightClaims].count, (NSUInteger)0,
+                 @"cancelAllPolls must clear the in-flight claims dictionary");
 }
 
 @end

--- a/Automated/AutomatedTests/ClaimStatusPollTests.m
+++ b/Automated/AutomatedTests/ClaimStatusPollTests.m
@@ -16,6 +16,12 @@
 + (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
 @end
 
+// Internal accessor for the active polls dictionary so the dedupe contract
+// can be asserted against state, not behavior alone.
+@interface TeakClaimPoll (Testing)
++ (NSMutableDictionary*)activePolls;
+@end
+
 @interface ClaimStatusPollTests : XCTestCase
 @end
 
@@ -116,6 +122,62 @@
 - (void)testSessionAttributionMintReturnsNilForNilLaunchData {
   NSString* blob = [TeakReward sessionAttributionStringFromLaunchData:nil];
   XCTAssertNil(blob);
+}
+
+#pragma mark - Dedupe and lifecycle
+
+/// Helper: drain the main queue so async dispatches from +startPollForEventId:
+/// and +cancelAllPolls have a chance to run before the assertion.
+- (void)drainMainQueue {
+  XCTestExpectation* e = [self expectationWithDescription:@"main-queue drain"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [e fulfill];
+  });
+  [self waitForExpectations:@[ e ] timeout:1.0];
+}
+
+/// First +startPollForEventId: schedules a timer; a second call with the
+/// same eventId is a no-op (the existing poll continues, no second timer).
+/// Tightens the cross-SDK dedupe contract: at most one poll per event id,
+/// regardless of whether a timer is scheduled or a request is mid-flight.
+- (void)testStartPollDedupesByEventId {
+  [TeakClaimPoll cancelAllPolls];
+  [self drainMainQueue];
+
+  NSString* eventId = @"evt-dedupe-1";
+  // Use a long initial delay so the timer can't fire before the assertion.
+  [TeakClaimPoll startPollForEventId:eventId launchData:nil initialDelay:60.0 ceiling:120.0];
+  [self drainMainQueue];
+
+  id firstSlot = [TeakClaimPoll activePolls][eventId];
+  XCTAssertNotNil(firstSlot, @"first start must record a poll for event id");
+
+  [TeakClaimPoll startPollForEventId:eventId launchData:nil initialDelay:60.0 ceiling:120.0];
+  [self drainMainQueue];
+
+  id secondSlot = [TeakClaimPoll activePolls][eventId];
+  XCTAssertEqual(firstSlot, secondSlot,
+                 @"re-entrant start with the same eventId must not replace the existing poll slot");
+  XCTAssertEqual([TeakClaimPoll activePolls].count, (NSUInteger)1,
+                 @"only one poll should be tracked");
+
+  [TeakClaimPoll cancelAllPolls];
+  [self drainMainQueue];
+}
+
+/// +cancelAllPolls clears the dictionary and invalidates pending timers.
+- (void)testCancelAllPollsClearsState {
+  [TeakClaimPoll startPollForEventId:@"evt-cancel-1" launchData:nil initialDelay:60.0 ceiling:120.0];
+  [TeakClaimPoll startPollForEventId:@"evt-cancel-2" launchData:nil initialDelay:60.0 ceiling:120.0];
+  [self drainMainQueue];
+
+  XCTAssertEqual([TeakClaimPoll activePolls].count, (NSUInteger)2);
+
+  [TeakClaimPoll cancelAllPolls];
+  [self drainMainQueue];
+
+  XCTAssertEqual([TeakClaimPoll activePolls].count, (NSUInteger)0,
+                 @"cancelAllPolls must clear the active polls dictionary");
 }
 
 @end

--- a/Automated/AutomatedTests/ClaimStatusPollTests.m
+++ b/Automated/AutomatedTests/ClaimStatusPollTests.m
@@ -1,0 +1,121 @@
+#import <XCTest/XCTest.h>
+
+#import <Teak/Teak.h>
+
+#import "TeakClaimPoll.h"
+#import "TeakLaunchData.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+@interface TeakNotificationLaunchData (Testing)
+- (id)initWithUrl:(NSURL*)url;
+@end
+
+@interface TeakConfiguration : NSObject
++ (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
+@end
+
+@interface ClaimStatusPollTests : XCTestCase
+@end
+
+@implementation ClaimStatusPollTests
+
++ (void)setUp {
+  [super setUp];
+  @try {
+    [TeakConfiguration configureForAppId:@"test-app" andSecret:@"test-secret"];
+  } @catch (NSException* e) {
+    // Already initialized — fine.
+  }
+}
+
+#pragma mark - Backoff schedule
+
+/// First poll happens after the initial delay (~2s per spec).
+- (void)testFirstPollUsesInitialDelay {
+  NSTimeInterval delay = [TeakClaimPoll nextDelayAfter:0
+                                          initialDelay:2.0
+                                               ceiling:30.0];
+  XCTAssertEqualWithAccuracy(delay, 2.0, 0.001);
+}
+
+/// Each subsequent attempt doubles the delay (exponential backoff).
+- (void)testSubsequentPollsDoubleTheDelay {
+  XCTAssertEqualWithAccuracy([TeakClaimPoll nextDelayAfter:1 initialDelay:2.0 ceiling:30.0], 4.0, 0.001);
+  XCTAssertEqualWithAccuracy([TeakClaimPoll nextDelayAfter:2 initialDelay:2.0 ceiling:30.0], 8.0, 0.001);
+  XCTAssertEqualWithAccuracy([TeakClaimPoll nextDelayAfter:3 initialDelay:2.0 ceiling:30.0], 16.0, 0.001);
+}
+
+/// Delay caps at the ceiling and never exceeds it, regardless of attempt count.
+- (void)testDelayClampsToCeiling {
+  // 2 * 2^4 = 32, exceeds 30s ceiling — must clamp.
+  XCTAssertEqualWithAccuracy([TeakClaimPoll nextDelayAfter:4 initialDelay:2.0 ceiling:30.0], 30.0, 0.001);
+  // Far past the ceiling: still clamped.
+  XCTAssertEqualWithAccuracy([TeakClaimPoll nextDelayAfter:20 initialDelay:2.0 ceiling:30.0], 30.0, 0.001);
+}
+
+/// Helper accepts arbitrary base values — guards against hard-coded constants
+/// (a future tunable could change initial/ceiling).
+- (void)testBackoffIsParameterizedNotHardcoded {
+  XCTAssertEqualWithAccuracy([TeakClaimPoll nextDelayAfter:0 initialDelay:1.0 ceiling:10.0], 1.0, 0.001);
+  XCTAssertEqualWithAccuracy([TeakClaimPoll nextDelayAfter:3 initialDelay:1.0 ceiling:10.0], 8.0, 0.001);
+  XCTAssertEqualWithAccuracy([TeakClaimPoll nextDelayAfter:5 initialDelay:1.0 ceiling:10.0], 10.0, 0.001);
+}
+
+#pragma mark - Terminal status detection
+
+/// `pending` is the only non-terminal /claim_status response — keep polling.
+- (void)testPendingIsNotTerminal {
+  XCTAssertFalse([TeakClaimPoll isTerminalStatus:@"pending"]);
+}
+
+/// `completed` and `failed` are terminal — fire resolved event and stop.
+- (void)testCompletedAndFailedAreTerminal {
+  XCTAssertTrue([TeakClaimPoll isTerminalStatus:@"completed"]);
+  XCTAssertTrue([TeakClaimPoll isTerminalStatus:@"failed"]);
+}
+
+/// Unknown / nil / empty values are treated as non-terminal so a malformed
+/// reply doesn't lock the poll into an early exit. The poll's own retry/timeout
+/// machinery handles network-level oddness.
+- (void)testUnknownStatusIsNotTerminal {
+  XCTAssertFalse([TeakClaimPoll isTerminalStatus:nil]);
+  XCTAssertFalse([TeakClaimPoll isTerminalStatus:@""]);
+  XCTAssertFalse([TeakClaimPoll isTerminalStatus:@"some_future_state"]);
+}
+
+#pragma mark - session_attribution mint (round-trip)
+
+/// session_attribution is minted at click-request-build time as a JSON string
+/// of launchData.to_h (the canonical wire shape from session_attribution_spec.md).
+/// The blob must round-trip through JSON cleanly so the server can persist it.
+- (void)testSessionAttributionMintRoundTripsForNotificationFixture {
+  NSURL* url = [NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=2048153148060669486&teak_schedule_id=2046986133304291328&teak_schedule_name=daily_promo_2026q2&teak_creative_id=2046986561123301779&teak_creative_name=summer_sale_v3&teak_reward_id=2048153148060669138&teak_channel_name=ios_push&teak_opt_out_category=teak"];
+  TeakNotificationLaunchData* data = [[TeakNotificationLaunchData alloc] initWithUrl:url];
+
+  NSString* blob = [TeakReward sessionAttributionStringFromLaunchData:data];
+  XCTAssertNotNil(blob, @"mint must produce a non-nil JSON string");
+
+  NSError* err = nil;
+  NSDictionary* roundTripped = [NSJSONSerialization JSONObjectWithData:[blob dataUsingEncoding:NSUTF8StringEncoding]
+                                                                options:0
+                                                                  error:&err];
+  XCTAssertNil(err);
+  XCTAssertEqualObjects(roundTripped[@"teakNotifId"], @"2048153148060669486");
+  XCTAssertEqualObjects(roundTripped[@"teakScheduleId"], @"2046986133304291328");
+  XCTAssertEqualObjects(roundTripped[@"teakCreativeId"], @"2046986561123301779");
+  XCTAssertEqualObjects(roundTripped[@"teakRewardId"], @"2048153148060669138");
+  XCTAssertEqualObjects(roundTripped[@"teakChannelName"], @"ios_push");
+  // Class-aware nulls present-but-null on a notification mint.
+  XCTAssertEqualObjects(roundTripped[@"teakSystemActivityId"], [NSNull null]);
+}
+
+/// Mint from a nil launchData yields nil — caller (TeakReward) treats nil as
+/// "omit the param from the click POST" rather than sending an empty blob.
+- (void)testSessionAttributionMintReturnsNilForNilLaunchData {
+  NSString* blob = [TeakReward sessionAttributionStringFromLaunchData:nil];
+  XCTAssertNil(blob);
+}
+
+@end

--- a/Automated/AutomatedTests/ClaimStatusPollTests.m
+++ b/Automated/AutomatedTests/ClaimStatusPollTests.m
@@ -16,10 +16,12 @@
 + (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
 @end
 
-// Internal accessor for the in-flight claims dictionary so the dedupe
-// contract can be asserted against state, not behavior alone.
+// Internal accessors for the in-flight claims dictionary and the
+// reply-handling step, so the round-2 invariants (dedupe, cancel,
+// stale-session drop) can be asserted against state, not behavior alone.
 @interface TeakClaimPoll (Testing)
 + (NSMutableDictionary*)inflightClaims;
++ (void)handleClaimStatusReply:(NSDictionary*)reply forEventId:(NSString*)eventId;
 @end
 
 @interface ClaimStatusPollTests : XCTestCase
@@ -163,6 +165,34 @@
 
   [TeakClaimPoll cancelAllPolls];
   [self drainMainQueue];
+}
+
+/// A reply for a claim whose originating session is no longer the current
+/// session must drop the claim without firing TeakOnRewardClaimResolved.
+/// In the test environment there's no live TeakSession, so the captured
+/// originatingSession is nil at start-poll time — equivalent to the
+/// production case where the originating session was deallocated post-
+/// capture (logout/login swap, post-Expired session replacement). The
+/// staleness check at reply time is the central round-2 correctness
+/// invariant: it ensures a late reply never fires a resolved event against
+/// a session the host game doesn't remember initiating.
+- (void)testReplyForStaleClaimIsDropped {
+  [TeakClaimPoll cancelAllPolls];
+  [self drainMainQueue];
+
+  NSString* eventId = @"evt-stale-1";
+  [TeakClaimPoll startPollForEventId:eventId launchData:nil initialDelay:60.0 ceiling:120.0];
+  [self drainMainQueue];
+
+  XCTAssertNotNil([TeakClaimPoll inflightClaims][eventId],
+                  @"start-poll must record the claim");
+
+  [TeakClaimPoll handleClaimStatusReply:@{@"status" : @"completed", @"event_id" : eventId}
+                             forEventId:eventId];
+  [self drainMainQueue];
+
+  XCTAssertNil([TeakClaimPoll inflightClaims][eventId],
+               @"reply for a claim with no live originating session must drop the entry");
 }
 
 /// +cancelAllPolls clears the dictionary and invalidates pending timers.

--- a/Automated/AutomatedTests/JwtModeRewardEventsTests.m
+++ b/Automated/AutomatedTests/JwtModeRewardEventsTests.m
@@ -177,6 +177,11 @@
 /// response data, plus the launchData.to_h provenance fields (in-session
 /// optimization: SDK uses its own launch-data state instead of round-tripping
 /// the persisted blob).
+///
+/// The reply fixture intentionally uses a different `teak_reward_id` than the
+/// launch-data's `teakRewardId` — proxy reward routes can resolve to a
+/// different reward than the one the click was attributed to, and both must
+/// land on the resolved-event userInfo as distinct, non-aliased fields.
 - (void)testResolvedEventCarriesLaunchDataProvenanceAndPollReply {
   NSDictionary* claimStatusReply = @{
     @"event_id" : @"evt-pending-1",
@@ -185,6 +190,8 @@
     @"customer_response" : @"{\"ok\":true}",
     @"customer_status_code" : @200,
     @"acked_at" : [NSNull null],
+    // Different from the launch-data's teakRewardId — proxy reward case.
+    @"teak_reward_id" : @"2048153148060669999",
   };
   TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
 
@@ -200,10 +207,16 @@
 
   // Launch-data provenance is carried via the in-session optimization.
   XCTAssertEqualObjects(userInfo[@"teakNotifId"], @"2048153148060669486");
-  XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
   XCTAssertEqualObjects(userInfo[@"teakScheduleId"], @"2046986133304291328");
   XCTAssertEqualObjects(userInfo[@"teakCreativeId"], @"2046986561123301779");
   XCTAssertEqualObjects(userInfo[@"teakChannelName"], @"ios_push");
+
+  // Both reward-id flavors are present and carry distinct values.
+  // teakRewardId (camelCase) — what this launch was *attributed to*.
+  // teak_reward_id (snake_case) — what the server *authoritatively granted*.
+  XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
+  XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"2048153148060669999");
+  XCTAssertNotEqualObjects(userInfo[@"teakRewardId"], userInfo[@"teak_reward_id"]);
 }
 
 /// When the launch data is nil (defensive — shouldn't happen in production

--- a/Automated/AutomatedTests/JwtModeRewardEventsTests.m
+++ b/Automated/AutomatedTests/JwtModeRewardEventsTests.m
@@ -1,0 +1,227 @@
+#import <XCTest/XCTest.h>
+
+#import <Teak/Teak.h>
+
+#import "TeakClaimPoll.h"
+#import "TeakLaunchData.h"
+#import "TeakSession.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Internal dispatcher under test. Lives on TeakSession; the SDK branches the
+// click-time wire response on its `status` field and constructs an
+// NSNotification with a payload shape derived from the launch data + reply.
+// The notification is returned (and posted) so tests can inspect both name
+// and userInfo without needing to wire NSNotificationCenter observers.
+@interface TeakSession (Testing)
++ (NSNotification*)dispatchClickResponse:(NSDictionary*)reply
+                           forLaunchData:(TeakAttributedLaunchData*)launchData;
+@end
+
+@interface TeakNotificationLaunchData (Testing)
+- (id)initWithUrl:(NSURL*)url;
+@end
+
+@interface TeakRewardlinkLaunchData (Testing)
+- (id)initWithUrl:(NSURL*)url andShortLink:(NSURL*)shortLink;
+@end
+
+@interface TeakConfiguration : NSObject
++ (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
+@end
+
+@interface JwtModeRewardEventsTests : XCTestCase
+@end
+
+@implementation JwtModeRewardEventsTests
+
++ (void)setUp {
+  [super setUp];
+  @try {
+    [TeakConfiguration configureForAppId:@"test-app" andSecret:@"test-secret"];
+  } @catch (NSException* e) {
+    // Already initialized — fine.
+  }
+}
+
+- (void)tearDown {
+  // dispatchClickResponse:forLaunchData: starts a real poll on claim_pending.
+  // Cancel any scheduled timers between test cases so they don't leak.
+  [TeakClaimPoll cancelAllPolls];
+  [super tearDown];
+}
+
+#pragma mark - Notification name surface
+
+/// The three new wire events are NSNotification names exported alongside
+/// TeakOnReward. Keep them as plain string constants so host games can listen
+/// without importing internal headers.
+- (void)testJwtModeNotificationNamesAreExported {
+  XCTAssertEqualObjects(TeakOnRewardJwtIssued, @"TeakOnRewardJwtIssued");
+  XCTAssertEqualObjects(TeakOnRewardClaimPending, @"TeakOnRewardClaimPending");
+  XCTAssertEqualObjects(TeakOnRewardClaimResolved, @"TeakOnRewardClaimResolved");
+}
+
+#pragma mark - dispatchClickResponse:forLaunchData: branches on status
+
+- (TeakAttributedLaunchData*)launchDataForNotificationFixture {
+  // Notification-fixture-shaped URL: the resulting to_h round-trips the
+  // canonical eleven keys with the notification slots populated.
+  NSURL* url = [NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=2048153148060669486&teak_schedule_id=2046986133304291328&teak_schedule_name=daily_promo_2026q2&teak_creative_id=2046986561123301779&teak_creative_name=summer_sale_v3&teak_reward_id=2048153148060669138&teak_channel_name=ios_push&teak_opt_out_category=teak"];
+  return [[TeakNotificationLaunchData alloc] initWithUrl:url];
+}
+
+/// Wire `status: 'grant_reward'` goes to the existing TeakOnReward event
+/// (legacy path — preserved for back-compat with non-JWT apps).
+- (void)testGrantRewardStatusFiresLegacyTeakOnReward {
+  NSDictionary* reply = @{
+    @"status" : @"grant_reward",
+    @"reward" : @{@"coins" : @100},
+    @"teakRewardId" : @"2048153148060669138",
+  };
+  TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
+
+  NSNotification* note = [TeakSession dispatchClickResponse:reply forLaunchData:launchData];
+  XCTAssertEqualObjects(note.name, TeakOnReward);
+  XCTAssertEqualObjects(note.userInfo[@"status"], @"grant_reward");
+  XCTAssertEqualObjects(note.userInfo[@"teakNotifId"], @"2048153148060669486");
+}
+
+/// Wire `status: 'token_issued'` (client_jwt mode) fires TeakOnRewardJwtIssued.
+/// Payload includes the JWT token, event_id, reward, claim_source, teak_reward_id,
+/// merged with the launchData.to_h so host games get the full provenance.
+- (void)testTokenIssuedStatusFiresJwtIssuedEvent {
+  NSDictionary* reply = @{
+    @"status" : @"token_issued",
+    @"token" : @"eyJ.fake.jwt",
+    @"event_id" : @"evt-2048153148060669500",
+    @"reward" : @{@"coins" : @100},
+    @"claim_source" : @"server",
+    @"teak_reward_id" : @"2048153148060669138",
+  };
+  TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
+
+  NSNotification* note = [TeakSession dispatchClickResponse:reply forLaunchData:launchData];
+  XCTAssertEqualObjects(note.name, TeakOnRewardJwtIssued);
+
+  XCTAssertEqualObjects(note.userInfo[@"status"], @"token_issued");
+  XCTAssertEqualObjects(note.userInfo[@"token"], @"eyJ.fake.jwt");
+  XCTAssertEqualObjects(note.userInfo[@"event_id"], @"evt-2048153148060669500");
+  XCTAssertEqualObjects(note.userInfo[@"reward"], @{@"coins" : @100});
+  XCTAssertEqualObjects(note.userInfo[@"claim_source"], @"server");
+  XCTAssertEqualObjects(note.userInfo[@"teak_reward_id"], @"2048153148060669138");
+
+  // Provenance from launchData.to_h must ride along on JWT-issued events.
+  XCTAssertEqualObjects(note.userInfo[@"teakNotifId"], @"2048153148060669486");
+  XCTAssertEqualObjects(note.userInfo[@"teakScheduleId"], @"2046986133304291328");
+  XCTAssertEqualObjects(note.userInfo[@"teakCreativeId"], @"2046986561123301779");
+}
+
+/// Wire `status: 'claim_pending'` (server_jwt mode) fires TeakOnRewardClaimPending.
+/// Payload carries the event_id the SDK polls /claim_status against, plus the
+/// JWT/reward/etc. so the host game can show optimistic UI while polling runs.
+- (void)testClaimPendingStatusFiresClaimPendingEvent {
+  NSDictionary* reply = @{
+    @"status" : @"claim_pending",
+    @"token" : @"eyJ.fake.jwt",
+    @"event_id" : @"evt-pending-1",
+    @"reward" : @{@"gems" : @25},
+    @"claim_source" : @"server",
+    @"teak_reward_id" : @"2048153148060669138",
+  };
+  TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
+
+  NSNotification* note = [TeakSession dispatchClickResponse:reply forLaunchData:launchData];
+  XCTAssertEqualObjects(note.name, TeakOnRewardClaimPending);
+
+  XCTAssertEqualObjects(note.userInfo[@"status"], @"claim_pending");
+  XCTAssertEqualObjects(note.userInfo[@"event_id"], @"evt-pending-1");
+  XCTAssertEqualObjects(note.userInfo[@"token"], @"eyJ.fake.jwt");
+
+  // Provenance still rides on claim_pending so a host game can render the
+  // optimistic surface with correct attribution context.
+  XCTAssertEqualObjects(note.userInfo[@"teakNotifId"], @"2048153148060669486");
+}
+
+/// The gate-rejection statuses (claim_mode_unsupported, invalid_claim_mode)
+/// continue to ride the existing TeakOnReward event — no new event for them
+/// per spec.
+- (void)testClaimModeUnsupportedStatusFiresTeakOnReward {
+  NSDictionary* reply = @{
+    @"status" : @"claim_mode_unsupported",
+  };
+  TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
+
+  NSNotification* note = [TeakSession dispatchClickResponse:reply forLaunchData:launchData];
+  XCTAssertEqualObjects(note.name, TeakOnReward);
+  XCTAssertEqualObjects(note.userInfo[@"status"], @"claim_mode_unsupported");
+}
+
+/// An unknown wire status defaults to TeakOnReward (forward compatibility:
+/// future enum values render as legacy events host games already handle).
+- (void)testUnknownStatusFallsBackToTeakOnReward {
+  NSDictionary* reply = @{
+    @"status" : @"some_future_status",
+  };
+  TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
+
+  NSNotification* note = [TeakSession dispatchClickResponse:reply forLaunchData:launchData];
+  XCTAssertEqualObjects(note.name, TeakOnReward);
+}
+
+#pragma mark - TeakOnRewardClaimResolved payload assembly
+
+/// The resolved-claim event fires when the click-time poll observes a terminal
+/// status from /claim_status. userInfo merges the polled status, customer
+/// response data, plus the launchData.to_h provenance fields (in-session
+/// optimization: SDK uses its own launch-data state instead of round-tripping
+/// the persisted blob).
+- (void)testResolvedEventCarriesLaunchDataProvenanceAndPollReply {
+  NSDictionary* claimStatusReply = @{
+    @"event_id" : @"evt-pending-1",
+    @"status" : @"completed",
+    @"reward" : @{@"gems" : @25},
+    @"customer_response" : @"{\"ok\":true}",
+    @"customer_status_code" : @200,
+    @"acked_at" : [NSNull null],
+  };
+  TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
+
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:claimStatusReply
+                                                          withLaunchData:launchData];
+
+  XCTAssertNotNil(userInfo);
+  XCTAssertEqualObjects(userInfo[@"event_id"], @"evt-pending-1");
+  XCTAssertEqualObjects(userInfo[@"status"], @"completed");
+  XCTAssertEqualObjects(userInfo[@"reward"], @{@"gems" : @25});
+  XCTAssertEqualObjects(userInfo[@"customer_response"], @"{\"ok\":true}");
+  XCTAssertEqualObjects(userInfo[@"customer_status_code"], @200);
+
+  // Launch-data provenance is carried via the in-session optimization.
+  XCTAssertEqualObjects(userInfo[@"teakNotifId"], @"2048153148060669486");
+  XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
+  XCTAssertEqualObjects(userInfo[@"teakScheduleId"], @"2046986133304291328");
+  XCTAssertEqualObjects(userInfo[@"teakCreativeId"], @"2046986561123301779");
+  XCTAssertEqualObjects(userInfo[@"teakChannelName"], @"ios_push");
+}
+
+/// When the launch data is nil (defensive — shouldn't happen in production
+/// but proves the helper degrades gracefully), the userInfo carries only the
+/// poll reply fields.
+- (void)testResolvedEventHandlesNilLaunchDataDefensively {
+  NSDictionary* claimStatusReply = @{
+    @"event_id" : @"evt-pending-1",
+    @"status" : @"completed",
+  };
+
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:claimStatusReply
+                                                          withLaunchData:nil];
+
+  XCTAssertNotNil(userInfo);
+  XCTAssertEqualObjects(userInfo[@"event_id"], @"evt-pending-1");
+  XCTAssertEqualObjects(userInfo[@"status"], @"completed");
+  XCTAssertNil(userInfo[@"teakNotifId"]);
+}
+
+@end

--- a/Automated/AutomatedTests/SessionAttributionSpecParityTests.m
+++ b/Automated/AutomatedTests/SessionAttributionSpecParityTests.m
@@ -89,10 +89,12 @@ static NSArray<NSString*>* TeakCanonicalWireKeys(void) {
                  label, (unsigned long)canonical.count, (unsigned long)dict.count, dict.allKeys);
 }
 
-#pragma mark - Drift item 1: all-keys-always-present
+#pragma mark - All eleven canonical keys always present
 
 /// Bare unattributed launch — only `launch_link` carries a value. The other
-/// ten keys must still be present in to_h, all as NSNull. Spec drift item 1.
+/// ten keys must still be present in to_h, all as NSNull. The cross-SDK
+/// contract is "every blob carries every key"; readers can address each
+/// slot by name without per-launch-class branching.
 - (void)testBareLaunchDataEmitsAllElevenKeysWithNullsForUnattributed {
   TeakLaunchData* data = [[TeakLaunchData alloc] init];
   NSDictionary* dict = [data to_h];
@@ -108,7 +110,7 @@ static NSArray<NSString*>* TeakCanonicalWireKeys(void) {
 
 /// Rewardlink-shaped launch — populates schedule/creative/reward/channel/etc.
 /// but not `teakNotifId` or `teakSystemActivityId`. Both must still be present
-/// (as NSNull) in to_h. Spec drift item 1.
+/// (as NSNull) in to_h.
 - (void)testRewardlinkLaunchDataEmitsAllElevenKeys {
   NSURL* url = [NSURL URLWithString:@"teaktest-app://promo?teak_rewardlink_id=42&teak_rewardlink_name=referral&teak_reward_id=99&teak_channel_name=generic_link&teak_opt_out_category=promos"];
   TeakRewardlinkLaunchData* data = [[TeakRewardlinkLaunchData alloc] initWithUrl:url andShortLink:nil];
@@ -128,7 +130,7 @@ static NSArray<NSString*>* TeakCanonicalWireKeys(void) {
 }
 
 /// Notification launch carries `teakNotifId` but never `teakSystemActivityId`.
-/// The latter must still be in to_h as NSNull. Spec drift item 1.
+/// The latter must still be in to_h as NSNull.
 - (void)testNotificationLaunchDataEmitsAllElevenKeys {
   NSURL* url = [NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=12345&teak_schedule_id=7&teak_creative_id=42&teak_reward_id=99&teak_channel_name=ios_push&teak_opt_out_category=promos"];
   TeakNotificationLaunchData* data = [[TeakNotificationLaunchData alloc] initWithUrl:url];
@@ -142,8 +144,9 @@ static NSArray<NSString*>* TeakCanonicalWireKeys(void) {
 }
 
 /// Live-activity launch carries `teakSystemActivityId` but no URL/attribution.
-/// The other ten keys must still be NSNull in to_h. Spec drift item 1; matches
-/// fixtures/session_attribution/live_activity.json.
+/// The other ten keys must still be NSNull in to_h. Matches the canonical
+/// `live_activity.json` fixture: an LA tap has no notification or attributed-
+/// URL source, so every attributed slot stays null on the wire.
 - (void)testLiveActivityLaunchDataEmitsAllElevenKeysWithOnlySystemActivityIdPopulated {
   NSString* systemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD2";
   TeakLiveActivityLaunchData* data = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:systemActivityId];
@@ -159,13 +162,13 @@ static NSArray<NSString*>* TeakCanonicalWireKeys(void) {
   }
 }
 
-#pragma mark - Drift item 2: teakDeepLink uses deepLink (not launchUrl)
+#pragma mark - teakDeepLink publishes the resolved deep link
 
 /// On the rewardlink path, the outer (short) launch URL carries a
 /// `teak_deep_link` query param that points to the inner deep link the host
 /// game routes on. The constructor uses the short link's query for the
 /// teak_deep_link lookup; teakDeepLink must surface the inner link, not the
-/// outer short link. Spec drift item 2.
+/// outer short link.
 - (void)testTeakDeepLinkPublishesInnerDeepLinkForRewardlinkLaunch {
   NSURL* shortLink = [NSURL URLWithString:@"teaktest-app://r/abc?teak_rewardlink_id=42&teak_deep_link=teaktest-app%3A%2F%2Fpromo%2Fsummer"];
   NSURL* resolvedUrl = [NSURL URLWithString:@"teaktest-app://r/abc?teak_rewardlink_id=42"];
@@ -189,11 +192,12 @@ static NSArray<NSString*>* TeakCanonicalWireKeys(void) {
                         @"teakDeepLink must publish self.deepLink (the resolved deep link), gated by TeakLink_WillHandleDeepLink");
 }
 
-#pragma mark - Drift item 3: teakOptOutCategory defaults to "teak"
+#pragma mark - teakOptOutCategory defaults to "teak" on attributed launches
 
 /// On a notification launch where the source omitted `teak_opt_out_category`,
-/// teakOptOutCategory must default to the literal string "teak", matching
-/// Android. Spec drift item 3.
+/// teakOptOutCategory must default to the literal string "teak". Cross-SDK
+/// contract — Android publishes the same default, host games rely on a
+/// non-null category bucket on every attributed launch.
 - (void)testTeakOptOutCategoryDefaultsToTeakLiteralWhenAbsentOnNotification {
   NSURL* url = [NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=12345&teak_creative_id=42&teak_reward_id=99"];
   TeakNotificationLaunchData* data = [[TeakNotificationLaunchData alloc] initWithUrl:url];

--- a/Automated/AutomatedTests/SessionAttributionSpecParityTests.m
+++ b/Automated/AutomatedTests/SessionAttributionSpecParityTests.m
@@ -1,0 +1,242 @@
+#import <XCTest/XCTest.h>
+
+#import <Teak/Teak.h>
+
+#import "TeakLaunchData.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose the private designated initializers so tests can construct each
+// concrete launch-data subclass without going through factories or the
+// notification-payload path.
+@interface TeakLaunchData (Testing)
+- (id)init;
+- (id)initWithUrl:(NSURL*)url;
+@end
+
+@interface TeakAttributedLaunchData (Testing)
+- (id)initWithUrl:(NSURL*)url andShortLink:(NSURL*)shortLink;
+@end
+
+@interface TeakNotificationLaunchData (Testing)
+- (id)initWithUrl:(NSURL*)url;
+@end
+
+@interface TeakRewardlinkLaunchData (Testing)
+- (id)initWithUrl:(NSURL*)url andShortLink:(NSURL*)shortLink;
+@end
+
+@interface TeakLiveActivityLaunchData (Testing)
+- (id)initWithSystemActivityId:(NSString*)systemActivityId;
+@end
+
+// Forward-declare TeakConfiguration's init selector so +setUp can seed the
+// singleton without importing TeakConfiguration.h (its transitive imports
+// aren't on the test target's HEADER_SEARCH_PATHS and collide with Teak.h).
+@interface TeakConfiguration : NSObject
++ (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
+@end
+
+// The eleven canonical wire keys from session_attribution_spec.md. Every blob
+// emitted by every SDK MUST contain exactly this key set, with values either
+// strings or NSNull.
+static NSArray<NSString*>* TeakCanonicalWireKeys(void) {
+  return @[
+    @"launch_link",
+    @"teakScheduleName",
+    @"teakScheduleId",
+    @"teakCreativeName",
+    @"teakCreativeId",
+    @"teakRewardId",
+    @"teakChannelName",
+    @"teakDeepLink",
+    @"teakOptOutCategory",
+    @"teakNotifId",
+    @"teakSystemActivityId",
+  ];
+}
+
+@interface SessionAttributionSpecParityTests : XCTestCase
+@end
+
+@implementation SessionAttributionSpecParityTests
+
++ (void)setUp {
+  [super setUp];
+  // to_h walks up to TeakAttributedLaunchData.to_h which calls
+  // TeakLink_WillHandleDeepLink → TeakConfiguration.configuration. Ensure the
+  // singleton exists so tests exercise the production to_h path. Guarded so
+  // repeat runs and other test classes that may also init don't double-init.
+  @try {
+    [TeakConfiguration configureForAppId:@"test-app" andSecret:@"test-secret"];
+  } @catch (NSException* e) {
+    // Already initialized — fine.
+  }
+}
+
+#pragma mark - Helpers
+
+/// Asserts the dictionary has exactly the eleven canonical wire keys present.
+/// Fails if any key is missing OR if any extra non-canonical key is present.
+- (void)assertCanonicalKeysAlwaysPresent:(NSDictionary*)dict label:(NSString*)label {
+  NSArray<NSString*>* canonical = TeakCanonicalWireKeys();
+  for (NSString* key in canonical) {
+    XCTAssertNotNil(dict[key], @"%@: canonical key '%@' must be present (NSNull or value)", label, key);
+  }
+  XCTAssertEqual(dict.count, canonical.count,
+                 @"%@: to_h must emit exactly %lu keys, got %lu (keys=%@)",
+                 label, (unsigned long)canonical.count, (unsigned long)dict.count, dict.allKeys);
+}
+
+#pragma mark - Drift item 1: all-keys-always-present
+
+/// Bare unattributed launch — only `launch_link` carries a value. The other
+/// ten keys must still be present in to_h, all as NSNull. Spec drift item 1.
+- (void)testBareLaunchDataEmitsAllElevenKeysWithNullsForUnattributed {
+  TeakLaunchData* data = [[TeakLaunchData alloc] init];
+  NSDictionary* dict = [data to_h];
+
+  [self assertCanonicalKeysAlwaysPresent:dict label:@"unattributed bare LaunchData"];
+
+  // Every key is null on a bare launch (no URL was supplied).
+  for (NSString* key in TeakCanonicalWireKeys()) {
+    XCTAssertEqualObjects(dict[key], [NSNull null],
+                          @"unattributed: %@ should be NSNull, got %@", key, dict[key]);
+  }
+}
+
+/// Rewardlink-shaped launch — populates schedule/creative/reward/channel/etc.
+/// but not `teakNotifId` or `teakSystemActivityId`. Both must still be present
+/// (as NSNull) in to_h. Spec drift item 1.
+- (void)testRewardlinkLaunchDataEmitsAllElevenKeys {
+  NSURL* url = [NSURL URLWithString:@"teaktest-app://promo?teak_rewardlink_id=42&teak_rewardlink_name=referral&teak_reward_id=99&teak_channel_name=generic_link&teak_opt_out_category=promos"];
+  TeakRewardlinkLaunchData* data = [[TeakRewardlinkLaunchData alloc] initWithUrl:url andShortLink:nil];
+  NSDictionary* dict = [data to_h];
+
+  [self assertCanonicalKeysAlwaysPresent:dict label:@"rewardlink"];
+
+  // Populated fields
+  XCTAssertEqualObjects(dict[@"teakCreativeId"], @"42");
+  XCTAssertEqualObjects(dict[@"teakCreativeName"], @"referral");
+  XCTAssertEqualObjects(dict[@"teakRewardId"], @"99");
+  XCTAssertEqualObjects(dict[@"teakChannelName"], @"generic_link");
+
+  // Class-aware keys are present-but-null on a rewardlink mint.
+  XCTAssertEqualObjects(dict[@"teakNotifId"], [NSNull null]);
+  XCTAssertEqualObjects(dict[@"teakSystemActivityId"], [NSNull null]);
+}
+
+/// Notification launch carries `teakNotifId` but never `teakSystemActivityId`.
+/// The latter must still be in to_h as NSNull. Spec drift item 1.
+- (void)testNotificationLaunchDataEmitsAllElevenKeys {
+  NSURL* url = [NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=12345&teak_schedule_id=7&teak_creative_id=42&teak_reward_id=99&teak_channel_name=ios_push&teak_opt_out_category=promos"];
+  TeakNotificationLaunchData* data = [[TeakNotificationLaunchData alloc] initWithUrl:url];
+  NSDictionary* dict = [data to_h];
+
+  [self assertCanonicalKeysAlwaysPresent:dict label:@"notification"];
+
+  XCTAssertEqualObjects(dict[@"teakNotifId"], @"12345");
+  XCTAssertEqualObjects(dict[@"teakSystemActivityId"], [NSNull null],
+                        @"notification mint never populates teakSystemActivityId; must be NSNull, not absent");
+}
+
+/// Live-activity launch carries `teakSystemActivityId` but no URL/attribution.
+/// The other ten keys must still be NSNull in to_h. Spec drift item 1; matches
+/// fixtures/session_attribution/live_activity.json.
+- (void)testLiveActivityLaunchDataEmitsAllElevenKeysWithOnlySystemActivityIdPopulated {
+  NSString* systemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD2";
+  TeakLiveActivityLaunchData* data = [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:systemActivityId];
+  NSDictionary* dict = [data to_h];
+
+  [self assertCanonicalKeysAlwaysPresent:dict label:@"live_activity"];
+
+  XCTAssertEqualObjects(dict[@"teakSystemActivityId"], systemActivityId);
+  for (NSString* key in TeakCanonicalWireKeys()) {
+    if ([key isEqualToString:@"teakSystemActivityId"]) continue;
+    XCTAssertEqualObjects(dict[key], [NSNull null],
+                          @"live_activity: %@ should be NSNull, got %@", key, dict[key]);
+  }
+}
+
+#pragma mark - Drift item 2: teakDeepLink uses deepLink (not launchUrl)
+
+/// On the rewardlink path, the outer (short) launch URL carries a
+/// `teak_deep_link` query param that points to the inner deep link the host
+/// game routes on. The constructor uses the short link's query for the
+/// teak_deep_link lookup; teakDeepLink must surface the inner link, not the
+/// outer short link. Spec drift item 2.
+- (void)testTeakDeepLinkPublishesInnerDeepLinkForRewardlinkLaunch {
+  NSURL* shortLink = [NSURL URLWithString:@"teaktest-app://r/abc?teak_rewardlink_id=42&teak_deep_link=teaktest-app%3A%2F%2Fpromo%2Fsummer"];
+  NSURL* resolvedUrl = [NSURL URLWithString:@"teaktest-app://r/abc?teak_rewardlink_id=42"];
+  TeakRewardlinkLaunchData* data = [[TeakRewardlinkLaunchData alloc] initWithUrl:resolvedUrl andShortLink:shortLink];
+
+  NSDictionary* dict = [data to_h];
+
+  XCTAssertEqualObjects(dict[@"teakDeepLink"], @"teaktest-app://promo/summer",
+                        @"teakDeepLink must be the inner deepLink (teak_deep_link query value on the short link), not the outer rewardlink URL");
+}
+
+/// When the source URL carries no `teak_deep_link` query param, teakDeepLink
+/// surfaces the resolved deep link directly (no inner-vs-outer distinction).
+- (void)testTeakDeepLinkPublishesResolvedDeepLinkOnNotificationLaunch {
+  NSURL* url = [NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=12345&teak_creative_id=42"];
+  TeakNotificationLaunchData* data = [[TeakNotificationLaunchData alloc] initWithUrl:url];
+
+  NSDictionary* dict = [data to_h];
+
+  XCTAssertEqualObjects(dict[@"teakDeepLink"], @"teaktest-app://chest?teak_notif_id=12345&teak_creative_id=42",
+                        @"teakDeepLink must publish self.deepLink (the resolved deep link), gated by TeakLink_WillHandleDeepLink");
+}
+
+#pragma mark - Drift item 3: teakOptOutCategory defaults to "teak"
+
+/// On a notification launch where the source omitted `teak_opt_out_category`,
+/// teakOptOutCategory must default to the literal string "teak", matching
+/// Android. Spec drift item 3.
+- (void)testTeakOptOutCategoryDefaultsToTeakLiteralWhenAbsentOnNotification {
+  NSURL* url = [NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=12345&teak_creative_id=42&teak_reward_id=99"];
+  TeakNotificationLaunchData* data = [[TeakNotificationLaunchData alloc] initWithUrl:url];
+
+  NSDictionary* dict = [data to_h];
+
+  XCTAssertEqualObjects(dict[@"teakOptOutCategory"], @"teak",
+                        @"teakOptOutCategory must default to 'teak' when source omitted teak_opt_out_category");
+}
+
+/// When the source explicitly sets a category, that value rides on the wire
+/// (no override).
+- (void)testTeakOptOutCategoryRidesExplicitValueWhenPresent {
+  NSURL* url = [NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=12345&teak_opt_out_category=promos"];
+  TeakNotificationLaunchData* data = [[TeakNotificationLaunchData alloc] initWithUrl:url];
+
+  NSDictionary* dict = [data to_h];
+
+  XCTAssertEqualObjects(dict[@"teakOptOutCategory"], @"promos");
+}
+
+#pragma mark - JSON serializability
+
+/// The wire format requires JSON-encodable values: strings or null, no nested
+/// types. NSDictionary with NSNull values must round-trip cleanly through
+/// NSJSONSerialization. This guards the click-request session_attribution mint
+/// path that JSON-encodes to_h before sending.
+- (void)testToHIsJsonSerializableForEveryClass {
+  NSArray* cases = @[
+    [[TeakLaunchData alloc] init],
+    [[TeakRewardlinkLaunchData alloc] initWithUrl:[NSURL URLWithString:@"teaktest-app://r/abc?teak_rewardlink_id=42"] andShortLink:nil],
+    [[TeakNotificationLaunchData alloc] initWithUrl:[NSURL URLWithString:@"teaktest-app://chest?teak_notif_id=12345"]],
+    [[TeakLiveActivityLaunchData alloc] initWithSystemActivityId:@"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD2"],
+  ];
+
+  for (TeakLaunchData* data in cases) {
+    NSDictionary* dict = [data to_h];
+    XCTAssertTrue([NSJSONSerialization isValidJSONObject:dict],
+                  @"%@.to_h must be JSON-encodable", NSStringFromClass(data.class));
+    NSError* err = nil;
+    NSData* encoded = [NSJSONSerialization dataWithJSONObject:dict options:0 error:&err];
+    XCTAssertNotNil(encoded, @"%@: JSON encode failed: %@", NSStringFromClass(data.class), err);
+  }
+}
+
+@end

--- a/Automated/AutomatedTests/TeakRemoteConfigurationClaimPollSettingsTests.m
+++ b/Automated/AutomatedTests/TeakRemoteConfigurationClaimPollSettingsTests.m
@@ -1,0 +1,75 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakRemoteConfiguration.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Static helper under test — re-exposed for the test target. Bridges the
+// wire/SDK unit boundary for the JWT-claim poll cadence settings emitted
+// by Carrot's GamesController#settings.
+@interface TeakRemoteConfiguration (TestAccess)
++ (NSTimeInterval)secondsFromReply:(NSDictionary*)reply
+                               key:(NSString*)key
+                          fallback:(NSTimeInterval)fallback;
+@end
+
+@interface TeakRemoteConfigurationClaimPollSettingsTests : XCTestCase
+@end
+
+@implementation TeakRemoteConfigurationClaimPollSettingsTests
+
+#pragma mark - Wire field present and numeric
+
+/// Wire field carries integer milliseconds; SDK property is NSTimeInterval
+/// seconds. The helper divides by 1000.
+- (void)testNumericMillisecondsAreConvertedToSeconds {
+  NSDictionary* reply = @{@"claim_poll_initial_delay_ms" : @1500};
+  NSTimeInterval seconds = [TeakRemoteConfiguration secondsFromReply:reply
+                                                                 key:@"claim_poll_initial_delay_ms"
+                                                            fallback:2.0];
+  XCTAssertEqualWithAccuracy(seconds, 1.5, 0.001);
+}
+
+/// Floating-point milliseconds (defensive — server should always emit
+/// integers, but any NSNumber subclass works).
+- (void)testFloatingPointMillisecondsAreConvertedToSeconds {
+  NSDictionary* reply = @{@"claim_poll_ceiling_ms" : @45000.5};
+  NSTimeInterval seconds = [TeakRemoteConfiguration secondsFromReply:reply
+                                                                 key:@"claim_poll_ceiling_ms"
+                                                            fallback:30.0];
+  XCTAssertEqualWithAccuracy(seconds, 45.0005, 0.0001);
+}
+
+/// Field-not-present in the reply leaves the caller's fallback in place.
+/// The settings.json schema marks these columns nullable on Game, so a
+/// game with no override gets the SDK-baked defaults.
+- (void)testMissingFieldReturnsFallback {
+  NSDictionary* reply = @{@"unrelated_field" : @123};
+  NSTimeInterval seconds = [TeakRemoteConfiguration secondsFromReply:reply
+                                                                 key:@"claim_poll_initial_delay_ms"
+                                                            fallback:2.0];
+  XCTAssertEqualWithAccuracy(seconds, 2.0, 0.001);
+}
+
+/// NSNull (the JSON-decoded form of `null`) returns the fallback.
+- (void)testNullValueReturnsFallback {
+  NSDictionary* reply = @{@"claim_poll_initial_delay_ms" : [NSNull null]};
+  NSTimeInterval seconds = [TeakRemoteConfiguration secondsFromReply:reply
+                                                                 key:@"claim_poll_initial_delay_ms"
+                                                            fallback:2.0];
+  XCTAssertEqualWithAccuracy(seconds, 2.0, 0.001);
+}
+
+/// Non-numeric value (defensive — guards against schema drift on the
+/// server side) returns the fallback rather than NaN-ing the property.
+- (void)testNonNumericValueReturnsFallback {
+  NSDictionary* reply = @{@"claim_poll_ceiling_ms" : @"not_a_number"};
+  NSTimeInterval seconds = [TeakRemoteConfiguration secondsFromReply:reply
+                                                                 key:@"claim_poll_ceiling_ms"
+                                                            fallback:30.0];
+  XCTAssertEqualWithAccuracy(seconds, 30.0, 0.001);
+}
+
+@end

--- a/Teak.xcodeproj/project.pbxproj
+++ b/Teak.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C81FA798A430194391516D8 /* TeakClaimPoll.m in Sources */ = {isa = PBXBuildFile; fileRef = 0612074E03743D105DBDBD42 /* TeakClaimPoll.m */; };
 		4301A94C233AD13F001DBF60 /* AdditionalDataEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 4301A94A233AD13F001DBF60 /* AdditionalDataEvent.h */; };
 		4301A94D233AD13F001DBF60 /* AdditionalDataEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 4301A94B233AD13F001DBF60 /* AdditionalDataEvent.m */; };
 		4306C02620F7DD8500216F18 /* TeakPushState.h in Headers */ = {isa = PBXBuildFile; fileRef = 4306C02420F7DD8500216F18 /* TeakPushState.h */; };
@@ -128,11 +129,14 @@
 		43EB2D1827FF87330048A1A6 /* UserDataEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 43EB2D1627FF87330048A1A6 /* UserDataEvent.m */; };
 		43F7CFF81EF0957E00361256 /* TeakLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 43F7CFF61EF0957E00361256 /* TeakLog.h */; };
 		43F7CFF91EF0957E00361256 /* TeakLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 43F7CFF71EF0957E00361256 /* TeakLog.m */; };
+		60C5892B7BEFA03C1966E5AD /* TeakClaimPoll.m in Sources */ = {isa = PBXBuildFile; fileRef = 0612074E03743D105DBDBD42 /* TeakClaimPoll.m */; };
 		671169322A30FD8800B168B0 /* TeakHealthCheck.m in Sources */ = {isa = PBXBuildFile; fileRef = 671169312A30FD8800B168B0 /* TeakHealthCheck.m */; };
 		67BDC2242992F599004DC7DB /* TeakOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 67BDC2222992F599004DC7DB /* TeakOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		67BDC2252992F599004DC7DB /* TeakOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 67BDC2232992F599004DC7DB /* TeakOperation.m */; };
 		67FBB69B2937FFCE00854807 /* TeakChannelStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 67FBB6992937FFCE00854807 /* TeakChannelStatus.h */; };
 		67FBB69C2937FFCE00854807 /* TeakChannelStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 67FBB69A2937FFCE00854807 /* TeakChannelStatus.m */; };
+		6B5DC0F0520DBA0020699519 /* TeakClaimPoll.h in Headers */ = {isa = PBXBuildFile; fileRef = D8A5F46066E657AC921AA52A /* TeakClaimPoll.h */; };
+		EF49F2274395529694808152 /* TeakClaimPoll.h in Headers */ = {isa = PBXBuildFile; fileRef = D8A5F46066E657AC921AA52A /* TeakClaimPoll.h */; };
 		FA34DA4B2D75FD9400D1C1C5 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FA34DA4A2D75FD9400D1C1C5 /* PrivacyInfo.xcprivacy */; };
 		FA34DA5A2D76014900D1C1C5 /* TeakNotificationServiceCore.m in Sources */ = {isa = PBXBuildFile; fileRef = 43E601BB1FFEF879003A09C5 /* TeakNotificationServiceCore.m */; };
 		FA34DA5B2D76014900D1C1C5 /* TeakNotificationViewControllerCore.m in Sources */ = {isa = PBXBuildFile; fileRef = 43E601BD1FFEF879003A09C5 /* TeakNotificationViewControllerCore.m */; };
@@ -304,6 +308,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0612074E03743D105DBDBD42 /* TeakClaimPoll.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakClaimPoll.m; sourceTree = "<group>"; };
 		4301A94A233AD13F001DBF60 /* AdditionalDataEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AdditionalDataEvent.h; sourceTree = "<group>"; };
 		4301A94B233AD13F001DBF60 /* AdditionalDataEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AdditionalDataEvent.m; sourceTree = "<group>"; };
 		4306C02420F7DD8500216F18 /* TeakPushState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TeakPushState.h; sourceTree = "<group>"; };
@@ -435,6 +440,7 @@
 		67BDC2232992F599004DC7DB /* TeakOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TeakOperation.m; sourceTree = "<group>"; };
 		67FBB6992937FFCE00854807 /* TeakChannelStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TeakChannelStatus.h; sourceTree = "<group>"; };
 		67FBB69A2937FFCE00854807 /* TeakChannelStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TeakChannelStatus.m; sourceTree = "<group>"; };
+		D8A5F46066E657AC921AA52A /* TeakClaimPoll.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TeakClaimPoll.h; sourceTree = "<group>"; };
 		FA34DA4A2D75FD9400D1C1C5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		FA34DA522D7600CC00D1C1C5 /* TeakExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TeakExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA34DA622D76017700D1C1C5 /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
@@ -592,6 +598,8 @@
 				67BDC2222992F599004DC7DB /* TeakOperation.h */,
 				67BDC2232992F599004DC7DB /* TeakOperation.m */,
 				671169312A30FD8800B168B0 /* TeakHealthCheck.m */,
+				D8A5F46066E657AC921AA52A /* TeakClaimPoll.h */,
+				0612074E03743D105DBDBD42 /* TeakClaimPoll.m */,
 			);
 			path = Teak;
 			sourceTree = "<group>";
@@ -756,6 +764,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		40CEAF27376E00F21AD85A4D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		431C98071C7E611F00B19DD5 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -806,6 +821,7 @@
 				438372731D34285A00B01F44 /* TeakDeviceConfiguration.h in Headers */,
 				4347A2CA22402D57001A3A8A /* tommath_superclass.h in Headers */,
 				FAFEC6F92A607508005E6AD2 /* TeakChannelCategory.h in Headers */,
+				EF49F2274395529694808152 /* TeakClaimPoll.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -870,6 +886,7 @@
 				FAA143472D70E21D009C3996 /* TeakMPInt.h in Headers */,
 				FAA143482D70E21D009C3996 /* TeakIntegrationChecker.h in Headers */,
 				FAA143492D70E21D009C3996 /* TeakWaitForDeepLink.h in Headers */,
+				6B5DC0F0520DBA0020699519 /* TeakClaimPoll.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -883,6 +900,7 @@
 				430E64631FB62EEE008DE15B /* Sources */,
 				430E64641FB62EEE008DE15B /* Frameworks */,
 				430E64651FB62EEE008DE15B /* Resources */,
+				40CEAF27376E00F21AD85A4D /* Headers */,
 			);
 			buildRules = (
 			);
@@ -927,8 +945,6 @@
 			dependencies = (
 			);
 			name = ExtensionFramework;
-			packageProductDependencies = (
-			);
 			productName = ExtensionFramework;
 			productReference = FA34DA522D7600CC00D1C1C5 /* TeakExtension.framework */;
 			productType = "com.apple.product-type.framework";
@@ -948,8 +964,6 @@
 			dependencies = (
 			);
 			name = Framework;
-			packageProductDependencies = (
-			);
 			productName = Framework;
 			productReference = FAA142B72D70E057009C3996 /* Teak.framework */;
 			productType = "com.apple.product-type.framework";
@@ -1180,6 +1194,7 @@
 				4347A2CF22402DFB001A3A8A /* bn_fast_s_mp_sqr.c in Sources */,
 				437C7934204A00F3006BD4B9 /* RemoteConfigurationEvent.m in Sources */,
 				439815BF1FA27799005303F1 /* PushRegistrationEvent.m in Sources */,
+				1C81FA798A430194391516D8 /* TeakClaimPoll.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1281,6 +1296,7 @@
 				FAA143112D70E0F5009C3996 /* TeakUserConfiguration.m in Sources */,
 				FAA143122D70E0F5009C3996 /* TeakOperation.m in Sources */,
 				FAA143132D70E0F5009C3996 /* TeakHealthCheck.m in Sources */,
+				60C5892B7BEFA03C1966E5AD /* TeakClaimPoll.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Teak/Configuration/TeakRemoteConfiguration.h
+++ b/Teak/Configuration/TeakRemoteConfiguration.h
@@ -15,6 +15,15 @@
 @property (nonatomic, readonly) NSTimeInterval claimPollInitialDelay;
 @property (nonatomic, readonly) NSTimeInterval claimPollCeiling;
 
+/// Cross-SDK fallback values for the click-time JWT-claim poll cadence.
+/// These are the source-of-truth defaults — both this class's
+/// ``-initForSession:`` and any callers that don't have a live remote
+/// configuration on hand should read from these accessors rather than
+/// re-declaring the literal seconds. Server config overrides live on the
+/// per-instance ``claimPollInitialDelay`` / ``claimPollCeiling`` properties.
++ (NSTimeInterval)defaultClaimPollInitialDelay;
++ (NSTimeInterval)defaultClaimPollCeiling;
+
 - (TeakRemoteConfiguration* _Nullable)initForSession:(TeakSession* _Nonnull)session;
 - (nonnull NSDictionary*)to_h;
 @end

--- a/Teak/Configuration/TeakRemoteConfiguration.h
+++ b/Teak/Configuration/TeakRemoteConfiguration.h
@@ -12,6 +12,8 @@
 @property (nonatomic, readonly) BOOL enhancedIntegrationChecks;
 @property (nonatomic, readonly) int heartbeatInterval;
 @property (strong, nonatomic, readonly) NSArray* _Nonnull channelCategories;
+@property (nonatomic, readonly) NSTimeInterval claimPollInitialDelay;
+@property (nonatomic, readonly) NSTimeInterval claimPollCeiling;
 
 - (TeakRemoteConfiguration* _Nullable)initForSession:(TeakSession* _Nonnull)session;
 - (nonnull NSDictionary*)to_h;

--- a/Teak/Configuration/TeakRemoteConfiguration.m
+++ b/Teak/Configuration/TeakRemoteConfiguration.m
@@ -24,6 +24,14 @@
 
 @implementation TeakRemoteConfiguration
 
++ (NSTimeInterval)defaultClaimPollInitialDelay {
+  return 2.0;
+}
+
++ (NSTimeInterval)defaultClaimPollCeiling {
+  return 30.0;
+}
+
 /// Parse a millisecond-valued integer field from a settings.json reply,
 /// returning seconds (an NSTimeInterval). When the field is absent, NSNull,
 /// or non-numeric, the caller's fallback is returned unchanged. Carrot's
@@ -144,9 +152,9 @@
     self.channelCategories = @[];
     // Click-time JWT-claim poll cadence. Server-config overrides via
     // claim_poll_initial_delay_ms / claim_poll_ceiling_ms when present;
-    // these are the cross-SDK fallback values.
-    self.claimPollInitialDelay = 2.0;
-    self.claimPollCeiling = 30.0;
+    // until then the cross-SDK fallback class-method values apply.
+    self.claimPollInitialDelay = [TeakRemoteConfiguration defaultClaimPollInitialDelay];
+    self.claimPollCeiling = [TeakRemoteConfiguration defaultClaimPollCeiling];
     __weak typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
       __strong typeof(self) blockSelf = weakSelf;

--- a/Teak/Configuration/TeakRemoteConfiguration.m
+++ b/Teak/Configuration/TeakRemoteConfiguration.m
@@ -18,9 +18,24 @@
 @property (nonatomic, readwrite) BOOL enhancedIntegrationChecks;
 @property (nonatomic, readwrite) int heartbeatInterval;
 @property (strong, nonatomic, readwrite) NSArray* _Nonnull channelCategories;
+@property (nonatomic, readwrite) NSTimeInterval claimPollInitialDelay;
+@property (nonatomic, readwrite) NSTimeInterval claimPollCeiling;
 @end
 
 @implementation TeakRemoteConfiguration
+
+/// Parse a millisecond-valued integer field from a settings.json reply,
+/// returning seconds (an NSTimeInterval). When the field is absent, NSNull,
+/// or non-numeric, the caller's fallback is returned unchanged. Carrot's
+/// GamesController#settings emits these as nullable integer columns; this
+/// helper bridges the wire/SDK unit boundary in one place.
++ (NSTimeInterval)secondsFromReply:(NSDictionary*)reply
+                               key:(NSString*)key
+                          fallback:(NSTimeInterval)fallback {
+  id raw = reply[key];
+  if (![raw isKindOfClass:[NSNumber class]]) return fallback;
+  return [(NSNumber*)raw doubleValue] / 1000.0;
+}
 
 + (BOOL)validateClaimMode:(nullable NSString*)configuredClaimMode againstSupported:(nullable id)supportedClaimModes {
   if (configuredClaimMode == nil || ![supportedClaimModes isKindOfClass:[NSArray class]]) {
@@ -127,6 +142,11 @@
     self.dynamicParameters = @{};
     self.heartbeatInterval = 60;
     self.channelCategories = @[];
+    // Click-time JWT-claim poll cadence. Server-config overrides via
+    // claim_poll_initial_delay_ms / claim_poll_ceiling_ms when present;
+    // these are the cross-SDK fallback values.
+    self.claimPollInitialDelay = 2.0;
+    self.claimPollCeiling = 30.0;
     __weak typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
       __strong typeof(self) blockSelf = weakSelf;
@@ -182,6 +202,16 @@
                                                       }
                                                       teak_catch_report;
                                                     }
+
+                                                    // Click-time JWT-claim poll cadence — server values override the
+                                                    // SDK-baked fallback. A null/missing field leaves the fallback in
+                                                    // place (the property is initialized to the fallback in init).
+                                                    self.claimPollInitialDelay = [TeakRemoteConfiguration secondsFromReply:reply
+                                                                                                                       key:@"claim_poll_initial_delay_ms"
+                                                                                                                  fallback:self.claimPollInitialDelay];
+                                                    self.claimPollCeiling = [TeakRemoteConfiguration secondsFromReply:reply
+                                                                                                                  key:@"claim_poll_ceiling_ms"
+                                                                                                             fallback:self.claimPollCeiling];
 
                                                     // Batching/endpoint configuration
                                                     self.endpointConfigurations = reply[@"endpoint_configurations"];

--- a/Teak/Core/TeakLaunchData.m
+++ b/Teak/Core/TeakLaunchData.m
@@ -262,8 +262,22 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
 }
 
 - (NSDictionary*)to_h {
+  // Every blob carries the same eleven keys. Bare LaunchData populates only
+  // launch_link; subclasses overwrite the slots they know. Keys absent on a
+  // subclass remain present-with-NSNull on the wire, so cross-SDK readers can
+  // address each key by name without per-launch-class branching.
   NSMutableDictionary* dictionary = [[NSMutableDictionary alloc] init];
   dictionary[@"launch_link"] = TeakValueOrNSNull(self.launchUrl.absoluteString);
+  dictionary[@"teakScheduleName"] = [NSNull null];
+  dictionary[@"teakScheduleId"] = [NSNull null];
+  dictionary[@"teakCreativeName"] = [NSNull null];
+  dictionary[@"teakCreativeId"] = [NSNull null];
+  dictionary[@"teakRewardId"] = [NSNull null];
+  dictionary[@"teakChannelName"] = [NSNull null];
+  dictionary[@"teakDeepLink"] = [NSNull null];
+  dictionary[@"teakOptOutCategory"] = [NSNull null];
+  dictionary[@"teakNotifId"] = [NSNull null];
+  dictionary[@"teakSystemActivityId"] = [NSNull null];
   return dictionary;
 }
 
@@ -364,8 +378,16 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
   dictionary[@"teakCreativeId"] = TeakValueOrNSNull(self.creativeId);
   dictionary[@"teakRewardId"] = TeakValueOrNSNull(self.rewardId);
   dictionary[@"teakChannelName"] = TeakValueOrNSNull(self.channelName);
-  dictionary[@"teakDeepLink"] = TeakLink_WillHandleDeepLink(self.launchUrl) ? self.launchUrl.absoluteString : [NSNull null];
-  dictionary[@"teakOptOutCategory"] = TeakValueOrNSNull(self.optOutCategory);
+  // teakDeepLink carries the inner deep link the host game routes on (the
+  // teak_deep_link query-param value, or the dashboard-mapped link), gated by
+  // TeakLink_WillHandleDeepLink so non-routable URLs surface as null. The
+  // outer launch URL would publish the rewardlink shortlink on the rewardlink
+  // path, which is not what the host game routes on.
+  dictionary[@"teakDeepLink"] = TeakLink_WillHandleDeepLink(self.deepLink) ? self.deepLink.absoluteString : [NSNull null];
+  // Opt-out category defaults to the literal "teak" bucket when the source
+  // omitted an explicit category. This matches Android's mint behavior so a
+  // host game receives the same default across SDKs.
+  dictionary[@"teakOptOutCategory"] = self.optOutCategory != nil ? self.optOutCategory : @"teak";
   return dictionary;
 }
 
@@ -462,6 +484,11 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
 - (NSDictionary*)to_h {
   NSMutableDictionary* dictionary = (NSMutableDictionary*)[super to_h];
   dictionary[@"teakSystemActivityId"] = TeakValueOrNSNull(self.systemActivityId);
+  // A live-activity tap has no notification or attributed-URL source from
+  // which to derive an opt-out category; the spec mints null in this slot for
+  // LA blobs. The "teak" default in TeakAttributedLaunchData applies only to
+  // sources that *could* have declared an explicit category but didn't.
+  dictionary[@"teakOptOutCategory"] = [NSNull null];
   return dictionary;
 }
 

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -18,8 +18,42 @@ extern NSString* _Nonnull const TeakNotificationAppLaunch;
  */
 extern NSString* _Nonnull const TeakOnReward;
 
+/**
+ * Use this named notification to listen for the JWT-issued response when an
+ * app is configured for client-side JWT reward claims.
+ *
+ * The notification's userInfo carries the JWT token, event id, reward,
+ * claim source, teak reward id, and the launch-data attribution fields so
+ * the host game can render reward UI and forward the JWT to its own
+ * backend.
+ */
 extern NSString* _Nonnull const TeakOnRewardJwtIssued;
+
+/**
+ * Use this named notification to listen for the pending-claim response when
+ * an app is configured for server-side JWT reward claims.
+ *
+ * The notification's userInfo carries the event id (used by the SDK's
+ * click-time poll loop) plus the reward and attribution context so the host
+ * game can render an optimistic surface while the claim is in flight.
+ */
 extern NSString* _Nonnull const TeakOnRewardClaimPending;
+
+/**
+ * Use this named notification to listen for the resolved-claim response from
+ * the SDK's click-time poll loop. Fires when the server reaches a terminal
+ * state (completed or failed) for a previously-pending claim.
+ *
+ * The notification's userInfo carries the polled status, the customer's
+ * server response, and the launch-data attribution fields.
+ *
+ * Delivery is at-least-once: if the SDK's `/claim_ack` post fails (network
+ * blip, app backgrounded mid-flight), the server's session-start sweep will
+ * resurface the same resolved claim on the next launch and fire this
+ * notification again with the same `event_id`. Host games SHOULD idempotent-
+ * key any reward grant on the `event_id` field of the userInfo dictionary
+ * so a duplicate delivery doesn't grant the reward twice.
+ */
 extern NSString* _Nonnull const TeakOnRewardClaimResolved;
 
 /**

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -26,6 +26,11 @@ extern NSString* _Nonnull const TeakOnReward;
  * claim source, teak reward id, and the launch-data attribution fields so
  * the host game can render reward UI and forward the JWT to its own
  * backend.
+ *
+ * Access the wire-reply fields via the ``TeakRewardKey...`` constants below
+ * (e.g. ``userInfo[TeakRewardKeyJwtToken]``). Launch-data attribution fields
+ * use the existing ``teakCamelCase`` keys (e.g. ``teakRewardId``,
+ * ``teakNotifId``, ``teakScheduleId``).
  */
 extern NSString* _Nonnull const TeakOnRewardJwtIssued;
 
@@ -36,6 +41,8 @@ extern NSString* _Nonnull const TeakOnRewardJwtIssued;
  * The notification's userInfo carries the event id (used by the SDK's
  * click-time poll loop) plus the reward and attribution context so the host
  * game can render an optimistic surface while the claim is in flight.
+ *
+ * Access the wire-reply fields via the ``TeakRewardKey...`` constants below.
  */
 extern NSString* _Nonnull const TeakOnRewardClaimPending;
 
@@ -45,16 +52,43 @@ extern NSString* _Nonnull const TeakOnRewardClaimPending;
  * state (completed or failed) for a previously-pending claim.
  *
  * The notification's userInfo carries the polled status, the customer's
- * server response, and the launch-data attribution fields.
+ * server response, and the launch-data attribution fields. Access the
+ * wire-reply fields via the ``TeakRewardKey...`` constants below.
  *
  * Delivery is at-least-once: if the SDK's `/claim_ack` post fails (network
  * blip, app backgrounded mid-flight), the server's session-start sweep will
  * resurface the same resolved claim on the next launch and fire this
- * notification again with the same `event_id`. Host games SHOULD idempotent-
- * key any reward grant on the `event_id` field of the userInfo dictionary
- * so a duplicate delivery doesn't grant the reward twice.
+ * notification again with the same ``TeakRewardKeyEventId``. Host games
+ * SHOULD idempotent-key any reward grant on that field so a duplicate
+ * delivery doesn't grant the reward twice.
  */
 extern NSString* _Nonnull const TeakOnRewardClaimResolved;
+
+/**
+ * Keys for the ``userInfo`` dictionary on ``TeakOnRewardJwtIssued``,
+ * ``TeakOnRewardClaimPending``, and ``TeakOnRewardClaimResolved``.
+ *
+ * The wire reply from the server uses snake_case field names; these
+ * constants are the canonical access path so host games don't depend on
+ * the literal strings. Launch-data attribution fields (``teakRewardId``,
+ * ``teakNotifId``, ``teakScheduleId``, etc.) keep their existing
+ * ``teakCamelCase`` names.
+ *
+ * ``TeakRewardKeyId`` (the snake_case ``teak_reward_id`` from the server)
+ * is the reward the server authoritatively granted on this click; the
+ * launch-data ``teakRewardId`` field is the reward this launch was
+ * *attributed to* (from the URL or notification payload). The two can
+ * differ on proxy reward routes, and both are preserved on the same
+ * userInfo dictionary as distinct fields.
+ */
+extern NSString* _Nonnull const TeakRewardKeyEventId;
+extern NSString* _Nonnull const TeakRewardKeyStatus;
+extern NSString* _Nonnull const TeakRewardKeyJwtToken;
+extern NSString* _Nonnull const TeakRewardKeyReward;
+extern NSString* _Nonnull const TeakRewardKeyClaimSource;
+extern NSString* _Nonnull const TeakRewardKeyId;
+extern NSString* _Nonnull const TeakRewardKeyCustomerResponse;
+extern NSString* _Nonnull const TeakRewardKeyCustomerStatusCode;
 
 /**
  * Use this named notification to listen for when your app receives a Teak notification while in the foreground.

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -18,6 +18,10 @@ extern NSString* _Nonnull const TeakNotificationAppLaunch;
  */
 extern NSString* _Nonnull const TeakOnReward;
 
+extern NSString* _Nonnull const TeakOnRewardJwtIssued;
+extern NSString* _Nonnull const TeakOnRewardClaimPending;
+extern NSString* _Nonnull const TeakOnRewardClaimResolved;
+
 /**
  * Use this named notification to listen for when your app receives a Teak notification while in the foreground.
  * 	[[NSNotificationCenter defaultCenter] addObserver:self

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -34,6 +34,9 @@
 
 NSString* const TeakNotificationAppLaunch = @"TeakNotificationAppLaunch";
 NSString* const TeakOnReward = @"TeakOnReward";
+NSString* const TeakOnRewardJwtIssued = @"TeakOnRewardJwtIssued";
+NSString* const TeakOnRewardClaimPending = @"TeakOnRewardClaimPending";
+NSString* const TeakOnRewardClaimResolved = @"TeakOnRewardClaimResolved";
 NSString* const TeakForegroundNotification = @"TeakForegroundNotification";
 NSString* const TeakConfigurationData = @"TeakConfigurationData";
 NSString* const TeakAdditionalData = @"TeakAdditionalData";

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -44,6 +44,15 @@ NSString* const TeakLaunchedFromLink = @"TeakLaunchedFromLink";
 NSString* const TeakPostLaunchSummary = @"TeakPostLaunchSummary";
 NSString* const TeakUserData = @"TeakUserData";
 
+NSString* const TeakRewardKeyEventId = @"event_id";
+NSString* const TeakRewardKeyStatus = @"status";
+NSString* const TeakRewardKeyJwtToken = @"token";
+NSString* const TeakRewardKeyReward = @"reward";
+NSString* const TeakRewardKeyClaimSource = @"claim_source";
+NSString* const TeakRewardKeyId = @"teak_reward_id";
+NSString* const TeakRewardKeyCustomerResponse = @"customer_response";
+NSString* const TeakRewardKeyCustomerStatusCode = @"customer_status_code";
+
 NSString* const TeakOptOutIdfa = @"opt_out_idfa";
 NSString* const TeakOptOutPushKey = @"opt_out_push_key";
 NSString* const TeakOptOutFacebook = @"opt_out_facebook";

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -1,23 +1,57 @@
 #import <Foundation/Foundation.h>
 
 @class TeakAttributedLaunchData;
+@class TeakSession;
 
+/// Click-time polling for server_jwt-mode claims.
+///
+/// When a click response carries `status: 'claim_pending'`, the SDK starts a
+/// poll loop against `GET /claim_status?event_id=...` on an exponential
+/// backoff schedule until the server returns a terminal status (completed or
+/// failed). On terminal status, the loop:
+///
+/// 1. Fires `TeakOnRewardClaimResolved` carrying the polled reply merged with
+///    launch-data attribution context (in-session optimization: the SDK reads
+///    its own launch-data state instead of round-tripping the server-stored
+///    `session_attribution` blob).
+/// 2. POSTs `POST /claim_ack` so the server can mark the claim as
+///    acknowledged and skip it on the next session-start sweep.
+///
+/// All timing happens on `[NSRunLoop mainRunLoop]` via NSTimer; the poll
+/// stops when the session expires or the SDK observes a terminal state.
 @interface TeakClaimPoll : NSObject
 
+/// Computes the delay for the next poll attempt. `attempt` is the
+/// zero-indexed attempt count: `nextDelayAfter:0` is the initial delay,
+/// `nextDelayAfter:1` is the second poll's delay, etc. The schedule is
+/// `min(initialDelay * 2^attempt, ceiling)`.
 + (NSTimeInterval)nextDelayAfter:(NSUInteger)attempt
                     initialDelay:(NSTimeInterval)initialDelay
                          ceiling:(NSTimeInterval)ceiling;
 
+/// Returns YES if a `/claim_status` reply's `status` field indicates a
+/// terminal (no-further-polling-needed) state. The two terminal states are
+/// `completed` and `failed`; everything else (including unknown / nil /
+/// empty) keeps the poll running.
 + (BOOL)isTerminalStatus:(NSString*)status;
 
+/// Builds the userInfo dictionary for the `TeakOnRewardClaimResolved`
+/// notification. Merges the `/claim_status` reply with the launch-data
+/// `to_h` attribution fields. When `launchData` is nil, returns the reply
+/// alone — defensive against an unusual mid-session teardown.
 + (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
                                 withLaunchData:(TeakAttributedLaunchData*)launchData;
 
+/// Begin polling `/claim_status` for the given event id. The poll uses
+/// `initialDelay` for the first attempt and doubles up to `ceiling` for each
+/// subsequent attempt. Calling repeatedly with the same `eventId` is a no-op
+/// (the existing poll continues; no second poll is started).
 + (void)startPollForEventId:(NSString*)eventId
                  launchData:(TeakAttributedLaunchData*)launchData
                initialDelay:(NSTimeInterval)initialDelay
                     ceiling:(NSTimeInterval)ceiling;
 
+/// Cancel any in-flight polls. Called when the session expires.
 + (void)cancelAllPolls;
 
 @end

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -17,8 +17,8 @@
 /// 2. POSTs `POST /claim_ack` so the server can mark the claim as
 ///    acknowledged and skip it on the next session-start sweep. Ack failure
 ///    is retried on the same session up to a small bounded budget; if all
-///    retries exhaust, the claim is dropped and C-699's session-start sweep
-///    re-surfaces it on next launch.
+///    retries exhaust, the claim is dropped and the session-start sweep on
+///    next launch re-surfaces it.
 ///
 /// All timing happens on `[NSRunLoop mainRunLoop]` via NSTimer.
 ///

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -39,19 +39,35 @@
 /// notification. Merges the `/claim_status` reply with the launch-data
 /// `to_h` attribution fields. When `launchData` is nil, returns the reply
 /// alone — defensive against an unusual mid-session teardown.
+///
+/// Key convention: wire reply keys are snake_case (`event_id`, `status`,
+/// `reward`, `customer_response`, `customer_status_code`, `teak_reward_id`),
+/// attribution keys are teakCamelCase (`teakRewardId`, `teakNotifId`, etc).
+/// They never alias the same logical id at the dict-key level — both
+/// `teakRewardId` (the reward this launch was attributed to, from the URL or
+/// notification payload) and `teak_reward_id` (the reward the server
+/// authoritatively granted on this specific click) can coexist on the
+/// resolved-event userInfo and are distinct fields.
 + (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
                                 withLaunchData:(TeakAttributedLaunchData*)launchData;
 
 /// Begin polling `/claim_status` for the given event id. The poll uses
 /// `initialDelay` for the first attempt and doubles up to `ceiling` for each
-/// subsequent attempt. Calling repeatedly with the same `eventId` is a no-op
-/// (the existing poll continues; no second poll is started).
+/// subsequent attempt. Dedupe is "at most one poll per event id at a time":
+/// if a timer is scheduled OR a request is in flight for the same eventId,
+/// a second call is a no-op.
 + (void)startPollForEventId:(NSString*)eventId
                  launchData:(TeakAttributedLaunchData*)launchData
                initialDelay:(NSTimeInterval)initialDelay
                     ceiling:(NSTimeInterval)ceiling;
 
-/// Cancel any in-flight polls. Called when the session expires.
+/// Cancel all in-flight polls. Called when the session expires. Pending
+/// timers are invalidated immediately. In-flight `/claim_status` requests
+/// can't be canceled mid-flight, but their completion handlers detect the
+/// session change via a generation counter and drop the reply rather than
+/// firing `TeakOnRewardClaimResolved` against a session the host game no
+/// longer remembers initiating. Cross-session resolutions are picked up by
+/// the session-start sweep on next launch.
 + (void)cancelAllPolls;
 
 @end

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -15,10 +15,21 @@
 ///    its own launch-data state instead of round-tripping the server-stored
 ///    `session_attribution` blob).
 /// 2. POSTs `POST /claim_ack` so the server can mark the claim as
-///    acknowledged and skip it on the next session-start sweep.
+///    acknowledged and skip it on the next session-start sweep. Ack failure
+///    is retried on the same session up to a small bounded budget; if all
+///    retries exhaust, the claim is dropped and C-699's session-start sweep
+///    re-surfaces it on next launch.
 ///
-/// All timing happens on `[NSRunLoop mainRunLoop]` via NSTimer; the poll
-/// stops when the session expires or the SDK observes a terminal state.
+/// All timing happens on `[NSRunLoop mainRunLoop]` via NSTimer.
+///
+/// Each in-flight claim holds a weak reference to the TeakSession that
+/// started it. The Expiring state is a may-resume transition (the user
+/// briefly opens Notification Center, App Switcher, etc.) and is *not* a
+/// reason to cancel — polling continues across the flicker because the
+/// session pointer is unchanged. Only the truly-terminal Expired transition
+/// cancels in-flight claims. If the originating session is replaced
+/// mid-poll (logout/login), in-flight replies see a session mismatch on the
+/// weak ref and drop themselves.
 @interface TeakClaimPoll : NSObject
 
 /// Computes the delay for the next poll attempt. `attempt` is the
@@ -53,21 +64,20 @@
 
 /// Begin polling `/claim_status` for the given event id. The poll uses
 /// `initialDelay` for the first attempt and doubles up to `ceiling` for each
-/// subsequent attempt. Dedupe is "at most one poll per event id at a time":
-/// if a timer is scheduled OR a request is in flight for the same eventId,
-/// a second call is a no-op.
+/// subsequent attempt. Dedupe is "the SDK is responsible for delivering this
+/// event_id exactly once": if an in-flight claim already exists for the same
+/// eventId — whether scheduled, mid-request, or post-resolve awaiting ack —
+/// a second start is a no-op.
 + (void)startPollForEventId:(NSString*)eventId
                  launchData:(TeakAttributedLaunchData*)launchData
                initialDelay:(NSTimeInterval)initialDelay
                     ceiling:(NSTimeInterval)ceiling;
 
-/// Cancel all in-flight polls. Called when the session expires. Pending
-/// timers are invalidated immediately. In-flight `/claim_status` requests
-/// can't be canceled mid-flight, but their completion handlers detect the
-/// session change via a generation counter and drop the reply rather than
-/// firing `TeakOnRewardClaimResolved` against a session the host game no
-/// longer remembers initiating. Cross-session resolutions are picked up by
-/// the session-start sweep on next launch.
+/// Cancel all in-flight claims. Called from the Expired session transition.
+/// Pending timers are invalidated and the in-flight dictionary is cleared;
+/// any /claim_status or /claim_ack reply that arrives after cancel sees an
+/// empty dictionary and drops silently. Cross-session resolutions are
+/// picked up by the session-start sweep on next launch.
 + (void)cancelAllPolls;
 
 @end

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+
+@class TeakAttributedLaunchData;
+
+@interface TeakClaimPoll : NSObject
+
++ (NSTimeInterval)nextDelayAfter:(NSUInteger)attempt
+                    initialDelay:(NSTimeInterval)initialDelay
+                         ceiling:(NSTimeInterval)ceiling;
+
++ (BOOL)isTerminalStatus:(NSString*)status;
+
++ (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
+                                withLaunchData:(TeakAttributedLaunchData*)launchData;
+
++ (void)startPollForEventId:(NSString*)eventId
+                 launchData:(TeakAttributedLaunchData*)launchData
+               initialDelay:(NSTimeInterval)initialDelay
+                    ceiling:(NSTimeInterval)ceiling;
+
++ (void)cancelAllPolls;
+
+@end

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -1,0 +1,29 @@
+#import "TeakClaimPoll.h"
+
+@implementation TeakClaimPoll
+
++ (NSTimeInterval)nextDelayAfter:(NSUInteger)attempt
+                    initialDelay:(NSTimeInterval)initialDelay
+                         ceiling:(NSTimeInterval)ceiling {
+  return 0.0;
+}
+
++ (BOOL)isTerminalStatus:(NSString*)status {
+  return NO;
+}
+
++ (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
+                                withLaunchData:(TeakAttributedLaunchData*)launchData {
+  return nil;
+}
+
++ (void)startPollForEventId:(NSString*)eventId
+                 launchData:(TeakAttributedLaunchData*)launchData
+               initialDelay:(NSTimeInterval)initialDelay
+                    ceiling:(NSTimeInterval)ceiling {
+}
+
++ (void)cancelAllPolls {
+}
+
+@end

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -6,8 +6,8 @@
 
 // Bounded /claim_ack retry budget. Counts the initial attempt, so 3 means
 // "send once, retry up to two times." After exhaustion the claim is dropped
-// from the in-flight dictionary and the server's session-start sweep
-// (C-699) will re-surface the claim on the next launch.
+// from the in-flight dictionary; the session-start sweep on next launch
+// will re-surface the claim.
 static const NSUInteger kAckMaxAttempts = 3;
 
 // Per-event-id state held in the in-flight dictionary. An entry exists from
@@ -230,8 +230,8 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   }
 
   if (claim.ackAttempt >= kAckMaxAttempts) {
-    // Budget exhausted on this session. Drop; C-699's session-start sweep
-    // will re-surface the claim on next launch.
+    // Budget exhausted on this session. Drop; the session-start sweep on
+    // next launch will re-surface the claim.
     TeakLog_i(@"claim_ack.retry_exhausted", @{@"event_id" : eventId, @"attempts" : @(claim.ackAttempt)});
     [[TeakClaimPoll inflightClaims] removeObjectForKey:eventId];
     return;

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -92,6 +92,7 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
       // SDK is already responsible for delivering this event_id. Re-entrant
       // start is a no-op — the existing claim continues with its own session
       // ref, timer, and ack-retry state.
+      TeakLog_i(@"claim_poll.start.duplicate", @{@"event_id" : eventId});
       return;
     }
 
@@ -142,6 +143,7 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   TeakInflightClaim* claim = [TeakClaimPoll inflightClaims][eventId];
   if (claim == nil) {
     // Cancelled between schedule and fire. Nothing to do.
+    TeakLog_i(@"claim_poll.timer.cancelled", @{@"event_id" : eventId});
     return;
   }
 
@@ -161,7 +163,8 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
 + (void)handleClaimStatusReply:(NSDictionary*)reply forEventId:(NSString*)eventId {
   TeakInflightClaim* claim = [TeakClaimPoll inflightClaims][eventId];
   if (claim == nil) {
-    // Cancelled while the request was in flight. Drop the reply silently.
+    // Cancelled while the request was in flight. Drop the reply.
+    TeakLog_i(@"claim_poll.reply.cancelled", @{@"event_id" : eventId});
     return;
   }
 
@@ -205,6 +208,7 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   TeakInflightClaim* claim = [TeakClaimPoll inflightClaims][eventId];
   if (claim == nil) {
     // Cancelled between resolve and ack. Drop.
+    TeakLog_i(@"claim_ack.cancelled", @{@"event_id" : eventId});
     return;
   }
 

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -4,10 +4,25 @@
 #import "TeakLaunchData.h"
 #import "TeakSession.h"
 
-// In-flight polls are keyed by event_id. The dictionary is mutated only on
-// the main thread (NSTimer fires on its scheduling run loop, and we schedule
-// on the main run loop).
-static NSMutableDictionary<NSString*, NSTimer*>* sActivePolls = nil;
+// In-flight polls are keyed by event_id. Values are either an NSTimer (delay
+// before next attempt) or the kInFlightSentinel (request issued, awaiting
+// reply). Either way, a non-nil value means "this event_id is being polled
+// for"; +startPollForEventId: refuses to start a duplicate. The dictionary is
+// mutated only on the main thread (NSTimer fires on its scheduling run loop,
+// and every other write dispatches to main).
+static NSMutableDictionary<NSString*, id>* sActivePolls = nil;
+
+// Bumped by +cancelAllPolls. Each pollTimerFired: captures the current
+// generation; when its completion block runs, if the generation has moved
+// the request is from a session that has since expired and we drop it.
+// Avoids late /claim_status replies firing TeakOnRewardClaimResolved against
+// a session the host game doesn't remember initiating.
+static uint64_t sPollGeneration = 0;
+
+// Sentinel value for "request in flight, no timer scheduled." Any non-nil
+// value satisfies the dedupe check; using a distinct singleton makes the
+// state legible in the debugger.
+static id kInFlightSentinel = nil;
 
 @implementation TeakClaimPoll
 
@@ -15,6 +30,7 @@ static NSMutableDictionary<NSString*, NSTimer*>* sActivePolls = nil;
   static dispatch_once_t once;
   dispatch_once(&once, ^{
     sActivePolls = [[NSMutableDictionary alloc] init];
+    kInFlightSentinel = [NSObject new];
   });
   return sActivePolls;
 }
@@ -76,9 +92,13 @@ static NSMutableDictionary<NSString*, NSTimer*>* sActivePolls = nil;
   dispatch_async(dispatch_get_main_queue(), ^{
     NSMutableDictionary* polls = [TeakClaimPoll activePolls];
     for (NSString* key in polls.allKeys) {
-      [polls[key] invalidate];
+      id slot = polls[key];
+      if ([slot isKindOfClass:[NSTimer class]]) {
+        [(NSTimer*)slot invalidate];
+      }
     }
     [polls removeAllObjects];
+    sPollGeneration++;
   });
 }
 
@@ -116,21 +136,36 @@ static NSMutableDictionary<NSString*, NSTimer*>* sActivePolls = nil;
   id launchDataValue = userInfo[@"launch_data"];
   TeakAttributedLaunchData* launchData = (launchDataValue == [NSNull null]) ? nil : launchDataValue;
 
-  // Clear the timer slot before we send the request — the next attempt will
-  // re-key when it schedules.
-  [[TeakClaimPoll activePolls] removeObjectForKey:eventId];
+  // Replace the timer slot with the in-flight sentinel — keeps dedupe truthy
+  // for the duration of the request so a re-entrant +startPollForEventId:
+  // sees an existing poll. The slot is cleared by the completion handler
+  // (terminal → fire+ack path) or replaced by the next timer (continue-poll
+  // path).
+  [[TeakClaimPoll activePolls] setObject:kInFlightSentinel forKey:eventId];
+
+  // Snapshot the generation for the completion's session-still-alive check.
+  uint64_t generation = sPollGeneration;
 
   [TeakClaimPoll sendClaimStatusRequestForEventId:eventId
                                        completion:^(NSDictionary* reply) {
-                                         NSString* status = reply[@"status"];
-                                         if ([TeakClaimPoll isTerminalStatus:status]) {
-                                           [TeakClaimPoll fireResolvedAndAck:reply
-                                                                      eventId:eventId
-                                                                   launchData:launchData];
-                                           return;
-                                         }
-
                                          dispatch_async(dispatch_get_main_queue(), ^{
+                                           if (generation != sPollGeneration) {
+                                             // Session expired between request-send and reply.
+                                             // Drop the reply; cancelAllPolls already cleared the
+                                             // dictionary entry.
+                                             TeakLog_i(@"claim_poll.reply.stale", @{@"event_id" : eventId});
+                                             return;
+                                           }
+
+                                           NSString* status = reply[@"status"];
+                                           if ([TeakClaimPoll isTerminalStatus:status]) {
+                                             [[TeakClaimPoll activePolls] removeObjectForKey:eventId];
+                                             [TeakClaimPoll fireResolvedAndAck:reply
+                                                                        eventId:eventId
+                                                                     launchData:launchData];
+                                             return;
+                                           }
+
                                            [TeakClaimPoll scheduleNextPollForEventId:eventId
                                                                            launchData:launchData
                                                                               attempt:attempt + 1

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -4,35 +4,46 @@
 #import "TeakLaunchData.h"
 #import "TeakSession.h"
 
-// In-flight polls are keyed by event_id. Values are either an NSTimer (delay
-// before next attempt) or the kInFlightSentinel (request issued, awaiting
-// reply). Either way, a non-nil value means "this event_id is being polled
-// for"; +startPollForEventId: refuses to start a duplicate. The dictionary is
-// mutated only on the main thread (NSTimer fires on its scheduling run loop,
-// and every other write dispatches to main).
-static NSMutableDictionary<NSString*, id>* sActivePolls = nil;
+// Bounded /claim_ack retry budget. Counts the initial attempt, so 3 means
+// "send once, retry up to two times." After exhaustion the claim is dropped
+// from the in-flight dictionary and the server's session-start sweep
+// (C-699) will re-surface the claim on the next launch.
+static const NSUInteger kAckMaxAttempts = 3;
 
-// Bumped by +cancelAllPolls. Each pollTimerFired: captures the current
-// generation; when its completion block runs, if the generation has moved
-// the request is from a session that has since expired and we drop it.
-// Avoids late /claim_status replies firing TeakOnRewardClaimResolved against
-// a session the host game doesn't remember initiating.
-static uint64_t sPollGeneration = 0;
+// Per-event-id state held in the in-flight dictionary. An entry exists from
+// the first start-poll call through final ack (or ack-retry exhaustion).
+// The originatingSession weak-ref is the source of truth for "is this poll
+// still relevant?" — same TeakSession instance during the Expiring→Active
+// flicker means the poll continues; a replaced session (logout/login,
+// Expired+new) means the entry's reply will be dropped.
+@interface TeakInflightClaim : NSObject
+@property (nonatomic, weak) TeakSession* originatingSession;
+@property (nonatomic, copy) NSString* eventId;
+@property (nonatomic, strong) TeakAttributedLaunchData* launchData;
+@property (nonatomic, strong, nullable) NSTimer* nextPollTimer;
+@property (nonatomic, assign) NSUInteger pollAttempt;
+@property (nonatomic, assign) NSTimeInterval initialDelay;
+@property (nonatomic, assign) NSTimeInterval ceiling;
+@property (nonatomic, assign) NSUInteger ackAttempt;
+@end
 
-// Sentinel value for "request in flight, no timer scheduled." Any non-nil
-// value satisfies the dedupe check; using a distinct singleton makes the
-// state legible in the debugger.
-static id kInFlightSentinel = nil;
+@implementation TeakInflightClaim
+@end
+
+// In-flight click-time claims keyed by event_id. An entry exists for as long
+// as the SDK is responsible for delivering a resolved event for that id —
+// from start-poll through ack-success (or ack-retry exhaustion). Mutated
+// only on the main thread.
+static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil;
 
 @implementation TeakClaimPoll
 
-+ (NSMutableDictionary*)activePolls {
++ (NSMutableDictionary*)inflightClaims {
   static dispatch_once_t once;
   dispatch_once(&once, ^{
-    sActivePolls = [[NSMutableDictionary alloc] init];
-    kInFlightSentinel = [NSObject new];
+    sInflightClaims = [[NSMutableDictionary alloc] init];
   });
-  return sActivePolls;
+  return sInflightClaims;
 }
 
 #pragma mark - Pure helpers
@@ -62,7 +73,7 @@ static id kInFlightSentinel = nil;
   return userInfo;
 }
 
-#pragma mark - Production poll loop
+#pragma mark - Lifecycle
 
 + (void)startPollForEventId:(NSString*)eventId
                  launchData:(TeakAttributedLaunchData*)launchData
@@ -73,154 +84,217 @@ static id kInFlightSentinel = nil;
     return;
   }
 
+  TeakSession* originatingSession = [TeakSession currentSessionOrNil];
+
   dispatch_async(dispatch_get_main_queue(), ^{
-    NSMutableDictionary* polls = [TeakClaimPoll activePolls];
-    if (polls[eventId] != nil) {
-      // A poll is already in flight for this event id — don't start a second.
+    NSMutableDictionary* claims = [TeakClaimPoll inflightClaims];
+    if (claims[eventId] != nil) {
+      // SDK is already responsible for delivering this event_id. Re-entrant
+      // start is a no-op — the existing claim continues with its own session
+      // ref, timer, and ack-retry state.
       return;
     }
 
-    [TeakClaimPoll scheduleNextPollForEventId:eventId
-                                    launchData:launchData
-                                       attempt:0
-                                  initialDelay:initialDelay
-                                       ceiling:ceiling];
+    TeakInflightClaim* claim = [[TeakInflightClaim alloc] init];
+    claim.originatingSession = originatingSession;
+    claim.eventId = eventId;
+    claim.launchData = launchData;
+    claim.pollAttempt = 0;
+    claim.initialDelay = initialDelay;
+    claim.ceiling = ceiling;
+    claim.ackAttempt = 0;
+    claims[eventId] = claim;
+
+    [TeakClaimPoll scheduleNextPollForClaim:claim];
   });
 }
 
 + (void)cancelAllPolls {
   dispatch_async(dispatch_get_main_queue(), ^{
-    NSMutableDictionary* polls = [TeakClaimPoll activePolls];
-    for (NSString* key in polls.allKeys) {
-      id slot = polls[key];
-      if ([slot isKindOfClass:[NSTimer class]]) {
-        [(NSTimer*)slot invalidate];
-      }
+    NSMutableDictionary<NSString*, TeakInflightClaim*>* claims = [TeakClaimPoll inflightClaims];
+    for (NSString* key in claims.allKeys) {
+      [claims[key].nextPollTimer invalidate];
     }
-    [polls removeAllObjects];
-    sPollGeneration++;
+    [claims removeAllObjects];
   });
 }
 
-+ (void)scheduleNextPollForEventId:(NSString*)eventId
-                        launchData:(TeakAttributedLaunchData*)launchData
-                           attempt:(NSUInteger)attempt
-                      initialDelay:(NSTimeInterval)initialDelay
-                           ceiling:(NSTimeInterval)ceiling {
-  NSTimeInterval delay = [TeakClaimPoll nextDelayAfter:attempt
-                                          initialDelay:initialDelay
-                                               ceiling:ceiling];
+#pragma mark - Internal — poll loop
 
-  NSDictionary* userInfo = @{
-    @"event_id" : eventId,
-    @"attempt" : @(attempt),
-    @"initial_delay" : @(initialDelay),
-    @"ceiling" : @(ceiling),
-    @"launch_data" : launchData != nil ? (id)launchData : (id)[NSNull null],
-  };
++ (void)scheduleNextPollForClaim:(TeakInflightClaim*)claim {
+  NSTimeInterval delay = [TeakClaimPoll nextDelayAfter:claim.pollAttempt
+                                          initialDelay:claim.initialDelay
+                                               ceiling:claim.ceiling];
 
-  NSTimer* timer = [NSTimer scheduledTimerWithTimeInterval:delay
-                                                    target:self
-                                                  selector:@selector(pollTimerFired:)
-                                                  userInfo:userInfo
-                                                   repeats:NO];
-  [TeakClaimPoll activePolls][eventId] = timer;
+  // Pass the eventId in the timer userInfo so the fired callback can look up
+  // the (still-current) claim in the dictionary. The claim object itself
+  // isn't passed on the timer to avoid keeping a stale snapshot if the
+  // dictionary entry is replaced or removed.
+  claim.nextPollTimer = [NSTimer scheduledTimerWithTimeInterval:delay
+                                                         target:self
+                                                       selector:@selector(pollTimerFired:)
+                                                       userInfo:@{@"event_id" : claim.eventId}
+                                                        repeats:NO];
 }
 
 + (void)pollTimerFired:(NSTimer*)timer {
-  NSDictionary* userInfo = timer.userInfo;
-  NSString* eventId = userInfo[@"event_id"];
-  NSUInteger attempt = [userInfo[@"attempt"] unsignedIntegerValue];
-  NSTimeInterval initialDelay = [userInfo[@"initial_delay"] doubleValue];
-  NSTimeInterval ceiling = [userInfo[@"ceiling"] doubleValue];
-  id launchDataValue = userInfo[@"launch_data"];
-  TeakAttributedLaunchData* launchData = (launchDataValue == [NSNull null]) ? nil : launchDataValue;
+  NSString* eventId = timer.userInfo[@"event_id"];
+  TeakInflightClaim* claim = [TeakClaimPoll inflightClaims][eventId];
+  if (claim == nil) {
+    // Cancelled between schedule and fire. Nothing to do.
+    return;
+  }
 
-  // Replace the timer slot with the in-flight sentinel — keeps dedupe truthy
-  // for the duration of the request so a re-entrant +startPollForEventId:
-  // sees an existing poll. The slot is cleared by the completion handler
-  // (terminal → fire+ack path) or replaced by the next timer (continue-poll
-  // path).
-  [[TeakClaimPoll activePolls] setObject:kInFlightSentinel forKey:eventId];
+  if ([TeakClaimPoll claimSessionIsStale:claim]) {
+    [TeakClaimPoll dropClaim:claim reason:@"session_stale"];
+    return;
+  }
 
-  // Snapshot the generation for the completion's session-still-alive check.
-  uint64_t generation = sPollGeneration;
-
-  [TeakClaimPoll sendClaimStatusRequestForEventId:eventId
-                                       completion:^(NSDictionary* reply) {
-                                         dispatch_async(dispatch_get_main_queue(), ^{
-                                           if (generation != sPollGeneration) {
-                                             // Session expired between request-send and reply.
-                                             // Drop the reply; cancelAllPolls already cleared the
-                                             // dictionary entry.
-                                             TeakLog_i(@"claim_poll.reply.stale", @{@"event_id" : eventId});
-                                             return;
-                                           }
-
-                                           NSString* status = reply[@"status"];
-                                           if ([TeakClaimPoll isTerminalStatus:status]) {
-                                             [[TeakClaimPoll activePolls] removeObjectForKey:eventId];
-                                             [TeakClaimPoll fireResolvedAndAck:reply
-                                                                        eventId:eventId
-                                                                     launchData:launchData];
-                                             return;
-                                           }
-
-                                           [TeakClaimPoll scheduleNextPollForEventId:eventId
-                                                                           launchData:launchData
-                                                                              attempt:attempt + 1
-                                                                         initialDelay:initialDelay
-                                                                              ceiling:ceiling];
-                                         });
-                                       }];
+  [TeakClaimPoll sendClaimStatusRequestForClaim:claim
+                                     completion:^(NSDictionary* reply) {
+                                       dispatch_async(dispatch_get_main_queue(), ^{
+                                         [TeakClaimPoll handleClaimStatusReply:reply forEventId:eventId];
+                                       });
+                                     }];
 }
 
-+ (void)fireResolvedAndAck:(NSDictionary*)reply
-                   eventId:(NSString*)eventId
-                launchData:(TeakAttributedLaunchData*)launchData {
-  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
-                                                          withLaunchData:launchData];
++ (void)handleClaimStatusReply:(NSDictionary*)reply forEventId:(NSString*)eventId {
+  TeakInflightClaim* claim = [TeakClaimPoll inflightClaims][eventId];
+  if (claim == nil) {
+    // Cancelled while the request was in flight. Drop the reply silently.
+    return;
+  }
 
+  if ([TeakClaimPoll claimSessionIsStale:claim]) {
+    [TeakClaimPoll dropClaim:claim reason:@"session_stale"];
+    return;
+  }
+
+  NSString* status = reply[@"status"];
+  if ([TeakClaimPoll isTerminalStatus:status]) {
+    [TeakClaimPoll fireResolvedAndAckForClaim:claim reply:reply];
+    return;
+  }
+
+  claim.pollAttempt += 1;
+  [TeakClaimPoll scheduleNextPollForClaim:claim];
+}
+
+#pragma mark - Internal — resolve + ack
+
++ (void)fireResolvedAndAckForClaim:(TeakInflightClaim*)claim reply:(NSDictionary*)reply {
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
+                                                          withLaunchData:claim.launchData];
+
+  // Fire the resolved event first; ack second. Per cross-SDK contract: host
+  // games observe the reward grant before the server marks it acked. Ack
+  // failure is retriable and does not block resolved-event delivery.
   [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
     [[NSNotificationCenter defaultCenter] postNotificationName:TeakOnRewardClaimResolved
                                                         object:session
                                                       userInfo:userInfo];
-    [TeakClaimPoll sendClaimAckRequestForEventId:eventId session:session];
+    TeakLog_i(@"claim_resolved.delivered", @{@"event_id" : claim.eventId});
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [TeakClaimPoll attemptAckForEventId:claim.eventId session:session];
+    });
   }];
+}
+
++ (void)attemptAckForEventId:(NSString*)eventId session:(TeakSession*)session {
+  TeakInflightClaim* claim = [TeakClaimPoll inflightClaims][eventId];
+  if (claim == nil) {
+    // Cancelled between resolve and ack. Drop.
+    return;
+  }
+
+  claim.ackAttempt += 1;
+  [TeakClaimPoll sendClaimAckRequestForEventId:eventId
+                                       session:session
+                                    completion:^(BOOL success) {
+                                      dispatch_async(dispatch_get_main_queue(), ^{
+                                        [TeakClaimPoll handleAckResult:success forEventId:eventId session:session];
+                                      });
+                                    }];
+}
+
++ (void)handleAckResult:(BOOL)success forEventId:(NSString*)eventId session:(TeakSession*)session {
+  TeakInflightClaim* claim = [TeakClaimPoll inflightClaims][eventId];
+  if (claim == nil) {
+    return;
+  }
+
+  if (success) {
+    [[TeakClaimPoll inflightClaims] removeObjectForKey:eventId];
+    return;
+  }
+
+  if (claim.ackAttempt >= kAckMaxAttempts) {
+    // Budget exhausted on this session. Drop; C-699's session-start sweep
+    // will re-surface the claim on next launch.
+    TeakLog_i(@"claim_ack.retry_exhausted", @{@"event_id" : eventId, @"attempts" : @(claim.ackAttempt)});
+    [[TeakClaimPoll inflightClaims] removeObjectForKey:eventId];
+    return;
+  }
+
+  // Backoff between ack retries uses the same shape as the poll backoff.
+  NSTimeInterval delay = [TeakClaimPoll nextDelayAfter:claim.ackAttempt - 1
+                                          initialDelay:claim.initialDelay
+                                               ceiling:claim.ceiling];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(),
+                 ^{
+                   [TeakClaimPoll attemptAckForEventId:eventId session:session];
+                 });
+}
+
+#pragma mark - Internal — helpers
+
++ (BOOL)claimSessionIsStale:(TeakInflightClaim*)claim {
+  TeakSession* originating = claim.originatingSession;
+  if (originating == nil) return YES;
+  TeakSession* current = [TeakSession currentSessionOrNil];
+  return originating != current;
+}
+
++ (void)dropClaim:(TeakInflightClaim*)claim reason:(NSString*)reason {
+  TeakLog_i(@"claim_poll.dropped", @{@"event_id" : claim.eventId, @"reason" : reason});
+  [claim.nextPollTimer invalidate];
+  claim.nextPollTimer = nil;
+  [[TeakClaimPoll inflightClaims] removeObjectForKey:claim.eventId];
 }
 
 #pragma mark - Wire calls
 
-+ (void)sendClaimStatusRequestForEventId:(NSString*)eventId
-                              completion:(void (^)(NSDictionary* reply))completion {
++ (void)sendClaimStatusRequestForClaim:(TeakInflightClaim*)claim
+                            completion:(void (^)(NSDictionary* reply))completion {
   [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
     NSString* hostname = [NSString stringWithFormat:@"rewards.%@", kTeakHostname];
     NSURLComponents* components = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"https://%@/claim_status", hostname]];
     components.queryItems = @[
       [NSURLQueryItem queryItemWithName:@"teak_app_id" value:session.appConfiguration.appId],
       [NSURLQueryItem queryItemWithName:@"clicking_user_id" value:session.userId],
-      [NSURLQueryItem queryItemWithName:@"event_id" value:eventId],
+      [NSURLQueryItem queryItemWithName:@"event_id" value:claim.eventId],
     ];
 
     NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:components.URL];
     request.HTTPMethod = @"GET";
 
-    TeakLog_i(@"claim_poll.request.send", @{@"event_id" : eventId});
+    TeakLog_i(@"claim_poll.request.send", @{@"event_id" : claim.eventId});
 
     NSURLSession* urlSession = [Teak URLSessionWithoutDelegate];
     NSURLSessionDataTask* task = [urlSession dataTaskWithRequest:request
                                                completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
                                                  NSDictionary* reply = @{};
                                                  if (error == nil && data != nil) {
-                                                   NSError* parseError = nil;
                                                    id parsed = [NSJSONSerialization JSONObjectWithData:data
                                                                                                options:0
-                                                                                                 error:&parseError];
+                                                                                                 error:nil];
                                                    if ([parsed isKindOfClass:[NSDictionary class]]) {
                                                      reply = parsed;
                                                    }
                                                  } else if (error != nil) {
-                                                   TeakLog_e(@"claim_poll.request.error", @{@"event_id" : eventId, @"error" : error.localizedDescription});
+                                                   TeakLog_e(@"claim_poll.request.error", @{@"event_id" : claim.eventId, @"error" : error.localizedDescription});
                                                  }
                                                  completion(reply);
                                                }];
@@ -228,7 +302,9 @@ static id kInFlightSentinel = nil;
   }];
 }
 
-+ (void)sendClaimAckRequestForEventId:(NSString*)eventId session:(TeakSession*)session {
++ (void)sendClaimAckRequestForEventId:(NSString*)eventId
+                              session:(TeakSession*)session
+                           completion:(void (^)(BOOL success))completion {
   NSString* hostname = [NSString stringWithFormat:@"rewards.%@", kTeakHostname];
   NSURLComponents* components = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"https://%@/claim_ack", hostname]];
 
@@ -248,11 +324,21 @@ static id kInFlightSentinel = nil;
   NSURLSession* urlSession = [Teak URLSessionWithoutDelegate];
   NSURLSessionDataTask* task = [urlSession dataTaskWithRequest:request
                                              completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-                                               if (error != nil) {
-                                                 TeakLog_e(@"claim_ack.request.error", @{@"event_id" : eventId, @"error" : error.localizedDescription});
+                                               BOOL ok = NO;
+                                               if (error == nil) {
+                                                 if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+                                                   NSInteger code = ((NSHTTPURLResponse*)response).statusCode;
+                                                   ok = (code >= 200 && code < 300);
+                                                 } else {
+                                                   ok = YES;
+                                                 }
                                                } else {
+                                                 TeakLog_e(@"claim_ack.request.error", @{@"event_id" : eventId, @"error" : error.localizedDescription});
+                                               }
+                                               if (ok) {
                                                  TeakLog_i(@"claim_ack.request.reply", @{@"event_id" : eventId});
                                                }
+                                               completion(ok);
                                              }];
   [task resume];
 }

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -186,6 +186,14 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
 #pragma mark - Internal — resolve + ack
 
 + (void)fireResolvedAndAckForClaim:(TeakInflightClaim*)claim reply:(NSDictionary*)reply {
+  // Entry-point log paired with claim_resolved.delivered below: a trace can
+  // distinguish "we observed terminal status and queued the event" from "we
+  // actually delivered to the host game." If userId-ready never fires
+  // (e.g. login never completes), the queued delivery doesn't run and the
+  // delivered log is silent — but this received log proves the SDK saw
+  // the resolution.
+  TeakLog_i(@"claim_resolved.received", @{@"event_id" : claim.eventId});
+
   NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
                                                           withLaunchData:claim.launchData];
 

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -1,29 +1,225 @@
 #import "TeakClaimPoll.h"
+#import "Teak+Internal.h"
+#import "TeakHelpers.h"
+#import "TeakLaunchData.h"
+#import "TeakSession.h"
+
+// In-flight polls are keyed by event_id. The dictionary is mutated only on
+// the main thread (NSTimer fires on its scheduling run loop, and we schedule
+// on the main run loop).
+static NSMutableDictionary<NSString*, NSTimer*>* sActivePolls = nil;
 
 @implementation TeakClaimPoll
+
++ (NSMutableDictionary*)activePolls {
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    sActivePolls = [[NSMutableDictionary alloc] init];
+  });
+  return sActivePolls;
+}
+
+#pragma mark - Pure helpers
 
 + (NSTimeInterval)nextDelayAfter:(NSUInteger)attempt
                     initialDelay:(NSTimeInterval)initialDelay
                          ceiling:(NSTimeInterval)ceiling {
-  return 0.0;
+  NSTimeInterval delay = initialDelay * pow(2.0, (double)attempt);
+  if (delay > ceiling) return ceiling;
+  return delay;
 }
 
 + (BOOL)isTerminalStatus:(NSString*)status {
-  return NO;
+  if (![status isKindOfClass:[NSString class]]) return NO;
+  return [status isEqualToString:@"completed"] || [status isEqualToString:@"failed"];
 }
 
 + (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
                                 withLaunchData:(TeakAttributedLaunchData*)launchData {
-  return nil;
+  NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] init];
+  if (launchData != nil) {
+    [userInfo addEntriesFromDictionary:[launchData to_h]];
+  }
+  if ([reply isKindOfClass:[NSDictionary class]]) {
+    [userInfo addEntriesFromDictionary:reply];
+  }
+  return userInfo;
 }
+
+#pragma mark - Production poll loop
 
 + (void)startPollForEventId:(NSString*)eventId
                  launchData:(TeakAttributedLaunchData*)launchData
                initialDelay:(NSTimeInterval)initialDelay
                     ceiling:(NSTimeInterval)ceiling {
+  if (eventId == nil || eventId.length == 0) {
+    TeakLog_e(@"claim_poll.error", @"event_id must not be nil or empty");
+    return;
+  }
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSMutableDictionary* polls = [TeakClaimPoll activePolls];
+    if (polls[eventId] != nil) {
+      // A poll is already in flight for this event id — don't start a second.
+      return;
+    }
+
+    [TeakClaimPoll scheduleNextPollForEventId:eventId
+                                    launchData:launchData
+                                       attempt:0
+                                  initialDelay:initialDelay
+                                       ceiling:ceiling];
+  });
 }
 
 + (void)cancelAllPolls {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSMutableDictionary* polls = [TeakClaimPoll activePolls];
+    for (NSString* key in polls.allKeys) {
+      [polls[key] invalidate];
+    }
+    [polls removeAllObjects];
+  });
+}
+
++ (void)scheduleNextPollForEventId:(NSString*)eventId
+                        launchData:(TeakAttributedLaunchData*)launchData
+                           attempt:(NSUInteger)attempt
+                      initialDelay:(NSTimeInterval)initialDelay
+                           ceiling:(NSTimeInterval)ceiling {
+  NSTimeInterval delay = [TeakClaimPoll nextDelayAfter:attempt
+                                          initialDelay:initialDelay
+                                               ceiling:ceiling];
+
+  NSDictionary* userInfo = @{
+    @"event_id" : eventId,
+    @"attempt" : @(attempt),
+    @"initial_delay" : @(initialDelay),
+    @"ceiling" : @(ceiling),
+    @"launch_data" : launchData != nil ? (id)launchData : (id)[NSNull null],
+  };
+
+  NSTimer* timer = [NSTimer scheduledTimerWithTimeInterval:delay
+                                                    target:self
+                                                  selector:@selector(pollTimerFired:)
+                                                  userInfo:userInfo
+                                                   repeats:NO];
+  [TeakClaimPoll activePolls][eventId] = timer;
+}
+
++ (void)pollTimerFired:(NSTimer*)timer {
+  NSDictionary* userInfo = timer.userInfo;
+  NSString* eventId = userInfo[@"event_id"];
+  NSUInteger attempt = [userInfo[@"attempt"] unsignedIntegerValue];
+  NSTimeInterval initialDelay = [userInfo[@"initial_delay"] doubleValue];
+  NSTimeInterval ceiling = [userInfo[@"ceiling"] doubleValue];
+  id launchDataValue = userInfo[@"launch_data"];
+  TeakAttributedLaunchData* launchData = (launchDataValue == [NSNull null]) ? nil : launchDataValue;
+
+  // Clear the timer slot before we send the request — the next attempt will
+  // re-key when it schedules.
+  [[TeakClaimPoll activePolls] removeObjectForKey:eventId];
+
+  [TeakClaimPoll sendClaimStatusRequestForEventId:eventId
+                                       completion:^(NSDictionary* reply) {
+                                         NSString* status = reply[@"status"];
+                                         if ([TeakClaimPoll isTerminalStatus:status]) {
+                                           [TeakClaimPoll fireResolvedAndAck:reply
+                                                                      eventId:eventId
+                                                                   launchData:launchData];
+                                           return;
+                                         }
+
+                                         dispatch_async(dispatch_get_main_queue(), ^{
+                                           [TeakClaimPoll scheduleNextPollForEventId:eventId
+                                                                           launchData:launchData
+                                                                              attempt:attempt + 1
+                                                                         initialDelay:initialDelay
+                                                                              ceiling:ceiling];
+                                         });
+                                       }];
+}
+
++ (void)fireResolvedAndAck:(NSDictionary*)reply
+                   eventId:(NSString*)eventId
+                launchData:(TeakAttributedLaunchData*)launchData {
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
+                                                          withLaunchData:launchData];
+
+  [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
+    [[NSNotificationCenter defaultCenter] postNotificationName:TeakOnRewardClaimResolved
+                                                        object:session
+                                                      userInfo:userInfo];
+    [TeakClaimPoll sendClaimAckRequestForEventId:eventId session:session];
+  }];
+}
+
+#pragma mark - Wire calls
+
++ (void)sendClaimStatusRequestForEventId:(NSString*)eventId
+                              completion:(void (^)(NSDictionary* reply))completion {
+  [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
+    NSString* hostname = [NSString stringWithFormat:@"rewards.%@", kTeakHostname];
+    NSURLComponents* components = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"https://%@/claim_status", hostname]];
+    components.queryItems = @[
+      [NSURLQueryItem queryItemWithName:@"teak_app_id" value:session.appConfiguration.appId],
+      [NSURLQueryItem queryItemWithName:@"clicking_user_id" value:session.userId],
+      [NSURLQueryItem queryItemWithName:@"event_id" value:eventId],
+    ];
+
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:components.URL];
+    request.HTTPMethod = @"GET";
+
+    TeakLog_i(@"claim_poll.request.send", @{@"event_id" : eventId});
+
+    NSURLSession* urlSession = [Teak URLSessionWithoutDelegate];
+    NSURLSessionDataTask* task = [urlSession dataTaskWithRequest:request
+                                               completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
+                                                 NSDictionary* reply = @{};
+                                                 if (error == nil && data != nil) {
+                                                   NSError* parseError = nil;
+                                                   id parsed = [NSJSONSerialization JSONObjectWithData:data
+                                                                                               options:0
+                                                                                                 error:&parseError];
+                                                   if ([parsed isKindOfClass:[NSDictionary class]]) {
+                                                     reply = parsed;
+                                                   }
+                                                 } else if (error != nil) {
+                                                   TeakLog_e(@"claim_poll.request.error", @{@"event_id" : eventId, @"error" : error.localizedDescription});
+                                                 }
+                                                 completion(reply);
+                                               }];
+    [task resume];
+  }];
+}
+
++ (void)sendClaimAckRequestForEventId:(NSString*)eventId session:(TeakSession*)session {
+  NSString* hostname = [NSString stringWithFormat:@"rewards.%@", kTeakHostname];
+  NSURLComponents* components = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"https://%@/claim_ack", hostname]];
+
+  NSDictionary* payload = @{
+    @"teak_app_id" : session.appConfiguration.appId,
+    @"clicking_user_id" : session.userId,
+    @"event_id" : eventId,
+  };
+
+  NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:components.URL];
+  request.HTTPMethod = @"POST";
+  request.HTTPBody = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
+  [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+
+  TeakLog_i(@"claim_ack.request.send", @{@"event_id" : eventId});
+
+  NSURLSession* urlSession = [Teak URLSessionWithoutDelegate];
+  NSURLSessionDataTask* task = [urlSession dataTaskWithRequest:request
+                                             completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
+                                               if (error != nil) {
+                                                 TeakLog_e(@"claim_ack.request.error", @{@"event_id" : eventId, @"error" : error.localizedDescription});
+                                               } else {
+                                                 TeakLog_i(@"claim_ack.request.reply", @{@"event_id" : eventId});
+                                               }
+                                             }];
+  [task resume];
 }
 
 @end

--- a/Teak/TeakReward.h
+++ b/Teak/TeakReward.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+@class TeakAttributedLaunchData;
+
 typedef enum : int {
   kTeakRewardStatusUnknown = -1,                ///< An unknown error occured while processing the reward.
   kTeakRewardStatusGrantReward = 0,             ///< Valid reward claim, grant the user the reward.
@@ -23,4 +25,8 @@ typedef void (^RewardCompleted)(void);
 @property (nonatomic, copy) RewardCompleted _Nullable onComplete;
 
 + (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId;
++ (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId
+                           withLaunchData:(nullable TeakAttributedLaunchData*)launchData;
+
++ (nullable NSString*)sessionAttributionStringFromLaunchData:(nullable TeakAttributedLaunchData*)launchData;
 @end

--- a/Teak/TeakReward.h
+++ b/Teak/TeakReward.h
@@ -28,5 +28,10 @@ typedef void (^RewardCompleted)(void);
 + (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId
                            withLaunchData:(nullable TeakAttributedLaunchData*)launchData;
 
+/// Mints a JSON-encoded `session_attribution` blob from the launch data's
+/// canonical wire shape (`launchData.to_h`). Returns nil when `launchData`
+/// is nil so callers can omit the param from the click request rather than
+/// sending an empty value. Exposed for unit testing of the round-trip; the
+/// production caller is `+rewardForRewardId:withLaunchData:`.
 + (nullable NSString*)sessionAttributionStringFromLaunchData:(nullable TeakAttributedLaunchData*)launchData;
 @end

--- a/Teak/TeakReward.m
+++ b/Teak/TeakReward.m
@@ -48,6 +48,17 @@
                                     self.json];
 }
 
++ (TeakReward*)rewardForRewardId:(NSString*)teakRewardId withLaunchData:(id)launchData {
+  // TODO: real impl in next commit — for now route to legacy path so the
+  // rest of the SDK keeps working while tests for the new behavior land red.
+  return [TeakReward rewardForRewardId:teakRewardId];
+}
+
++ (NSString*)sessionAttributionStringFromLaunchData:(id)launchData {
+  // TODO: real impl in next commit.
+  return nil;
+}
+
 + (TeakReward*)rewardForRewardId:(NSString*)teakRewardId {
   if (teakRewardId == nil || teakRewardId.length == 0) {
     TeakLog_e(@"reward.error", @"teakRewardId must not be nil or empty");

--- a/Teak/TeakReward.m
+++ b/Teak/TeakReward.m
@@ -1,5 +1,6 @@
 #import "TeakReward.h"
 #import "Teak+Internal.h"
+#import "TeakLaunchData.h"
 #import "TeakRequest.h"
 #import "TeakSession.h"
 #import "TeakHelpers.h"
@@ -48,18 +49,26 @@
                                     self.json];
 }
 
-+ (TeakReward*)rewardForRewardId:(NSString*)teakRewardId withLaunchData:(id)launchData {
-  // TODO: real impl in next commit — for now route to legacy path so the
-  // rest of the SDK keeps working while tests for the new behavior land red.
-  return [TeakReward rewardForRewardId:teakRewardId];
-}
-
-+ (NSString*)sessionAttributionStringFromLaunchData:(id)launchData {
-  // TODO: real impl in next commit.
-  return nil;
-}
-
 + (TeakReward*)rewardForRewardId:(NSString*)teakRewardId {
+  return [TeakReward rewardForRewardId:teakRewardId withLaunchData:nil];
+}
+
++ (NSString*)sessionAttributionStringFromLaunchData:(TeakAttributedLaunchData*)launchData {
+  if (launchData == nil) return nil;
+
+  NSDictionary* wireShape = [launchData to_h];
+  NSError* error = nil;
+  NSData* data = [NSJSONSerialization dataWithJSONObject:wireShape
+                                                 options:0
+                                                   error:&error];
+  if (error != nil || data == nil) {
+    TeakLog_e(@"reward.session_attribution.encode_error", error);
+    return nil;
+  }
+  return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
++ (TeakReward*)rewardForRewardId:(NSString*)teakRewardId withLaunchData:(TeakAttributedLaunchData*)launchData {
   if (teakRewardId == nil || teakRewardId.length == 0) {
     TeakLog_e(@"reward.error", @"teakRewardId must not be nil or empty");
     return nil;
@@ -69,13 +78,23 @@
   ret.completed = NO;
   ret.rewardStatus = kTeakRewardStatusUnknown;
 
+  NSString* sessionAttribution = [TeakReward sessionAttributionStringFromLaunchData:launchData];
+
   [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
     NSString* urlString = [NSString stringWithFormat:@"/%@/clicks", teakRewardId];
+
+    NSMutableDictionary* payload = [NSMutableDictionary dictionaryWithDictionary:@{
+      @"clicking_user_id" : session.userId,
+      @"claim_mode" : session.appConfiguration.claimMode,
+    }];
+    if (sessionAttribution != nil) {
+      payload[@"session_attribution"] = sessionAttribution;
+    }
+
     TeakRequest* request = [TeakRequest requestWithSession:session
                                                forHostname:[NSString stringWithFormat:@"rewards.%@", kTeakHostname]
                                               withEndpoint:urlString
-                                               withPayload:@{@"clicking_user_id" : session.userId,
-                                                             @"claim_mode" : session.appConfiguration.claimMode}
+                                               withPayload:payload
                                                     method:TeakRequest_POST
                                                   callback:^(NSDictionary* reply) {
                                                     NSMutableDictionary* rewardResponse = [NSMutableDictionary dictionaryWithDictionary:reply[@"response"]];

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -653,6 +653,12 @@ DefineTeakState(Expired, (@[]));
   }];
 }
 
+// TODO: real impl in next commit — for now returns nil so the stub-targeted
+// tests fail at runtime (the value-comparison assertions match against nil).
++ (NSNotification*)dispatchClickResponse:(NSDictionary*)reply forLaunchData:(TeakAttributedLaunchData*)launchData {
+  return nil;
+}
+
 + (void)checkLaunchDataForRewardAndDispatchEvents:(nonnull TeakAttributedLaunchData*)launchData {
   if (launchData.rewardId == nil) return;
 

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -674,31 +674,23 @@ DefineTeakState(Expired, (@[]));
 /// statuses fan out to the new TeakOnRewardJwtIssued / TeakOnRewardClaimPending
 /// surfaces. On `claim_pending` the SDK additionally starts a click-time poll
 /// against /claim_status that fires TeakOnRewardClaimResolved on terminal
-/// status. Returns the notification it posted (for testability — production
-/// callers ignore the return value).
+/// status. Returns the notification it dispatched (for testability —
+/// production callers ignore the return value; the same notification is
+/// posted once the user id is ready).
 + (NSNotification*)dispatchClickResponse:(NSDictionary*)reply forLaunchData:(TeakAttributedLaunchData*)launchData {
-  NSString* wireStatus = reply[@"status"];
+  // Default initial delay 2s, ceiling 30s — chosen to keep the first poll close
+  // to claim-completion latency while preventing busy-loops if the customer
+  // backend is slow. Tracked for promotion to remote config in C-721; until
+  // then these are the cross-SDK fallback values.
+  static const NSTimeInterval kClaimPollInitialDelay = 2.0;
+  static const NSTimeInterval kClaimPollCeiling = 30.0;
 
+  NSString* wireStatus = reply[@"status"];
   NSString* notificationName = TeakOnReward;
   if ([wireStatus isEqualToString:@"token_issued"]) {
     notificationName = TeakOnRewardJwtIssued;
   } else if ([wireStatus isEqualToString:@"claim_pending"]) {
     notificationName = TeakOnRewardClaimPending;
-  }
-
-  NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] init];
-  if (launchData != nil) {
-    [userInfo addEntriesFromDictionary:[launchData to_h]];
-  }
-  [userInfo addEntriesFromDictionary:reply];
-
-  // Default initial delay 2s, ceiling 30s — chosen to keep the first poll close
-  // to claim-completion latency while preventing busy-loops if the customer
-  // backend is slow.
-  static const NSTimeInterval kClaimPollInitialDelay = 2.0;
-  static const NSTimeInterval kClaimPollCeiling = 30.0;
-
-  if ([wireStatus isEqualToString:@"claim_pending"]) {
     NSString* eventId = reply[@"event_id"];
     if ([eventId isKindOfClass:[NSString class]] && eventId.length > 0) {
       [TeakClaimPoll startPollForEventId:eventId
@@ -708,13 +700,20 @@ DefineTeakState(Expired, (@[]));
     }
   }
 
+  NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] init];
+  if (launchData != nil) {
+    [userInfo addEntriesFromDictionary:[launchData to_h]];
+  }
+  [userInfo addEntriesFromDictionary:reply];
+
   NSNotification* note = [NSNotification notificationWithName:notificationName
                                                        object:nil
                                                      userInfo:userInfo];
   [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
-    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName
-                                                        object:session
-                                                      userInfo:userInfo];
+    NSNotification* sessionNote = [NSNotification notificationWithName:note.name
+                                                                object:session
+                                                              userInfo:note.userInfo];
+    [[NSNotificationCenter defaultCenter] postNotification:sessionNote];
   }];
   return note;
 }
@@ -861,12 +860,6 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
     } else if (newValue == [TeakSession Expiring]) {
       self.endDate = [[NSDate alloc] init];
 
-      // Click-time claim polls don't outlive their session — they fire from
-      // an in-session click and the resolved-event payload is read from the
-      // launch-data state we still hold. The session-start sweep handles
-      // claims that resolve after the app closes.
-      [TeakClaimPoll cancelAllPolls];
-
       // Stop heartbeat, Expiring->Expiring is possible, so no invalid data here
       if (self.heartbeat != nil) {
         dispatch_source_cancel(self.heartbeat);
@@ -918,6 +911,15 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), self.reportDurationBlock);
       }
     } else if (newValue == [TeakSession Expired]) {
+      // Click-time claim polls live as long as the session that started them.
+      // Expiring is a may-resume state (the user briefly opens Notification
+      // Center, App Switcher, etc.), so polling continues across that
+      // transition; in-flight replies validate against the session reference
+      // they were started under and drop if the session has been replaced.
+      // Only on Expired — the truly-terminal transition — do we tear timers
+      // down and abandon the in-flight tracking. Anything that resolves
+      // after Expired is picked up by the session-start sweep on next launch.
+      [TeakClaimPoll cancelAllPolls];
     }
   }
 }

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -678,12 +678,13 @@ DefineTeakState(Expired, (@[]));
 /// production callers ignore the return value; the same notification is
 /// posted once the user id is ready).
 + (NSNotification*)dispatchClickResponse:(NSDictionary*)reply forLaunchData:(TeakAttributedLaunchData*)launchData {
-  // Default initial delay 2s, ceiling 30s — chosen to keep the first poll close
-  // to claim-completion latency while preventing busy-loops if the customer
-  // backend is slow. These are the cross-SDK fallback values; the SDK reads
-  // them from server config when available.
-  static const NSTimeInterval kClaimPollInitialDelay = 2.0;
-  static const NSTimeInterval kClaimPollCeiling = 30.0;
+  // Cross-SDK fallback for the poll cadence. Used only when there's no
+  // current session (test paths) or no remote configuration on it. Live
+  // sessions read the values from TeakRemoteConfiguration, which itself
+  // initializes to the same defaults and overrides them from the
+  // /games/.../settings.json reply.
+  static const NSTimeInterval kClaimPollInitialDelayFallback = 2.0;
+  static const NSTimeInterval kClaimPollCeilingFallback = 30.0;
 
   NSString* wireStatus = reply[@"status"];
   NSString* notificationName = TeakOnReward;
@@ -693,10 +694,13 @@ DefineTeakState(Expired, (@[]));
     notificationName = TeakOnRewardClaimPending;
     NSString* eventId = reply[@"event_id"];
     if ([eventId isKindOfClass:[NSString class]] && eventId.length > 0) {
+      TeakRemoteConfiguration* remoteConfig = [TeakSession currentSessionOrNil].remoteConfiguration;
+      NSTimeInterval initialDelay = remoteConfig != nil ? remoteConfig.claimPollInitialDelay : kClaimPollInitialDelayFallback;
+      NSTimeInterval ceiling = remoteConfig != nil ? remoteConfig.claimPollCeiling : kClaimPollCeilingFallback;
       [TeakClaimPoll startPollForEventId:eventId
                               launchData:launchData
-                            initialDelay:kClaimPollInitialDelay
-                                 ceiling:kClaimPollCeiling];
+                            initialDelay:initialDelay
+                                 ceiling:ceiling];
     }
   }
 

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -3,6 +3,7 @@
 #import "FacebookAccessTokenEvent.h"
 #import "Teak+Internal.h"
 #import "TeakAppConfiguration.h"
+#import "TeakClaimPoll.h"
 #import "TeakDebugConfiguration.h"
 #import "TeakDeviceConfiguration.h"
 #import "TeakLaunchData.h"
@@ -653,32 +654,69 @@ DefineTeakState(Expired, (@[]));
   }];
 }
 
-// TODO: real impl in next commit — for now returns nil so the stub-targeted
-// tests fail at runtime (the value-comparison assertions match against nil).
-+ (NSNotification*)dispatchClickResponse:(NSDictionary*)reply forLaunchData:(TeakAttributedLaunchData*)launchData {
-  return nil;
-}
-
 + (void)checkLaunchDataForRewardAndDispatchEvents:(nonnull TeakAttributedLaunchData*)launchData {
   if (launchData.rewardId == nil) return;
 
-  TeakReward* reward = [TeakReward rewardForRewardId:launchData.rewardId];
+  TeakReward* reward = [TeakReward rewardForRewardId:launchData.rewardId withLaunchData:launchData];
   if (reward == nil) return;
 
   __weak TeakReward* tempWeakReward = reward;
   reward.onComplete = ^() {
     __strong TeakReward* blockReward = tempWeakReward;
     if (blockReward.json != nil) {
-      NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] initWithDictionary:[launchData to_h]];
-      [userInfo addEntriesFromDictionary:blockReward.json];
-
-      [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:TeakOnReward
-                                                            object:session
-                                                          userInfo:userInfo];
-      }];
+      [TeakSession dispatchClickResponse:blockReward.json forLaunchData:launchData];
     }
   };
+}
+
+/// Branches the click response on its wire `status` field. Legacy and
+/// gate-rejection statuses ride the existing TeakOnReward event; JWT-mode
+/// statuses fan out to the new TeakOnRewardJwtIssued / TeakOnRewardClaimPending
+/// surfaces. On `claim_pending` the SDK additionally starts a click-time poll
+/// against /claim_status that fires TeakOnRewardClaimResolved on terminal
+/// status. Returns the notification it posted (for testability — production
+/// callers ignore the return value).
++ (NSNotification*)dispatchClickResponse:(NSDictionary*)reply forLaunchData:(TeakAttributedLaunchData*)launchData {
+  NSString* wireStatus = reply[@"status"];
+
+  NSString* notificationName = TeakOnReward;
+  if ([wireStatus isEqualToString:@"token_issued"]) {
+    notificationName = TeakOnRewardJwtIssued;
+  } else if ([wireStatus isEqualToString:@"claim_pending"]) {
+    notificationName = TeakOnRewardClaimPending;
+  }
+
+  NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] init];
+  if (launchData != nil) {
+    [userInfo addEntriesFromDictionary:[launchData to_h]];
+  }
+  [userInfo addEntriesFromDictionary:reply];
+
+  // Default initial delay 2s, ceiling 30s — chosen to keep the first poll close
+  // to claim-completion latency while preventing busy-loops if the customer
+  // backend is slow.
+  static const NSTimeInterval kClaimPollInitialDelay = 2.0;
+  static const NSTimeInterval kClaimPollCeiling = 30.0;
+
+  if ([wireStatus isEqualToString:@"claim_pending"]) {
+    NSString* eventId = reply[@"event_id"];
+    if ([eventId isKindOfClass:[NSString class]] && eventId.length > 0) {
+      [TeakClaimPoll startPollForEventId:eventId
+                              launchData:launchData
+                            initialDelay:kClaimPollInitialDelay
+                                 ceiling:kClaimPollCeiling];
+    }
+  }
+
+  NSNotification* note = [NSNotification notificationWithName:notificationName
+                                                       object:nil
+                                                     userInfo:userInfo];
+  [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
+    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName
+                                                        object:session
+                                                      userInfo:userInfo];
+  }];
+  return note;
 }
 
 + (void)checkLaunchDataForNotificationAndDispatchEvents:(nonnull TeakAttributedLaunchData*)launchData {
@@ -822,6 +860,12 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
       }
     } else if (newValue == [TeakSession Expiring]) {
       self.endDate = [[NSDate alloc] init];
+
+      // Click-time claim polls don't outlive their session — they fire from
+      // an in-session click and the resolved-event payload is read from the
+      // launch-data state we still hold. The session-start sweep handles
+      // claims that resolve after the app closes.
+      [TeakClaimPoll cancelAllPolls];
 
       // Stop heartbeat, Expiring->Expiring is possible, so no invalid data here
       if (self.heartbeat != nil) {

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -678,14 +678,6 @@ DefineTeakState(Expired, (@[]));
 /// production callers ignore the return value; the same notification is
 /// posted once the user id is ready).
 + (NSNotification*)dispatchClickResponse:(NSDictionary*)reply forLaunchData:(TeakAttributedLaunchData*)launchData {
-  // Cross-SDK fallback for the poll cadence. Used only when there's no
-  // current session (test paths) or no remote configuration on it. Live
-  // sessions read the values from TeakRemoteConfiguration, which itself
-  // initializes to the same defaults and overrides them from the
-  // /games/.../settings.json reply.
-  static const NSTimeInterval kClaimPollInitialDelayFallback = 2.0;
-  static const NSTimeInterval kClaimPollCeilingFallback = 30.0;
-
   NSString* wireStatus = reply[@"status"];
   NSString* notificationName = TeakOnReward;
   if ([wireStatus isEqualToString:@"token_issued"]) {
@@ -694,9 +686,13 @@ DefineTeakState(Expired, (@[]));
     notificationName = TeakOnRewardClaimPending;
     NSString* eventId = reply[@"event_id"];
     if ([eventId isKindOfClass:[NSString class]] && eventId.length > 0) {
+      // Live sessions read the server-overridable values from their
+      // remoteConfiguration; the no-session fallback (test paths, pre-init
+      // window) reads the same defaults from the class-method source of
+      // truth. No literal seconds live in this file.
       TeakRemoteConfiguration* remoteConfig = [TeakSession currentSessionOrNil].remoteConfiguration;
-      NSTimeInterval initialDelay = remoteConfig != nil ? remoteConfig.claimPollInitialDelay : kClaimPollInitialDelayFallback;
-      NSTimeInterval ceiling = remoteConfig != nil ? remoteConfig.claimPollCeiling : kClaimPollCeilingFallback;
+      NSTimeInterval initialDelay = remoteConfig != nil ? remoteConfig.claimPollInitialDelay : [TeakRemoteConfiguration defaultClaimPollInitialDelay];
+      NSTimeInterval ceiling = remoteConfig != nil ? remoteConfig.claimPollCeiling : [TeakRemoteConfiguration defaultClaimPollCeiling];
       [TeakClaimPoll startPollForEventId:eventId
                               launchData:launchData
                             initialDelay:initialDelay

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -680,8 +680,8 @@ DefineTeakState(Expired, (@[]));
 + (NSNotification*)dispatchClickResponse:(NSDictionary*)reply forLaunchData:(TeakAttributedLaunchData*)launchData {
   // Default initial delay 2s, ceiling 30s — chosen to keep the first poll close
   // to claim-completion latency while preventing busy-loops if the customer
-  // backend is slow. Tracked for promotion to remote config in C-721; until
-  // then these are the cross-SDK fallback values.
+  // backend is slow. These are the cross-SDK fallback values; the SDK reads
+  // them from server config when available.
   static const NSTimeInterval kClaimPollInitialDelay = 2.0;
   static const NSTimeInterval kClaimPollCeiling = 30.0;
 


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-698

## Summary

Implements the iOS SDK's click-time side of the JWT-mode reward surface. Adds three new `NSNotification` names (`TeakOnRewardJwtIssued`, `TeakOnRewardClaimPending`, `TeakOnRewardClaimResolved`); branches the click reply on its wire `status` field; mints `session_attribution` from `launchData.to_h` at click-request-build time; runs a click-time `NSTimer` exponential-backoff poll against `/claim_status` for `claim_pending` claims; fires the resolved event and POSTs `/claim_ack` on terminal status. Does NOT include the session-start sweep (that's C-699, blocked by this).

The PR also absorbs the iOS-side spec parity work from `taro/docs/session_attribution_spec.md`: `TeakLaunchData.to_h` now emits the canonical eleven-key wire shape (drift item 1, all-keys-always-present); `teakDeepLink` surfaces the resolved deep link instead of the outer launch URL (drift item 2); `teakOptOutCategory` defaults to the literal "teak" on attributed launches (drift item 3), with the `TeakLiveActivityLaunchData` override returning to NSNull per the LA fixture.

## Key decisions

- **In-session optimization for resolved events.** The `TeakOnRewardClaimResolved` userInfo merges the polled reply with `launchData.to_h` (the SDK's in-memory launch-data state) instead of consuming the server-persisted `session_attribution` blob. Per the spec, the click-time poll fires within the same session as the click, so the SDK still has the launch-data state and can skip the round-trip. C-699's session-start sweep is what consumes the persisted blob for cross-session resolutions.
- **Status branch is conservative on unknowns.** Unknown wire statuses fall back to `TeakOnReward` rather than fanning out to a new event, matching how host games already handle the legacy reward enum's `unknown` value. Forward-compatible: future enum values render as legacy events that existing host code already routes.
- **TDD discipline as two commits.** Commit 1 adds the tests + production stubs (compiles, 83 tests fail at runtime). Commit 2 swaps the stubs for the real implementation (all 154 tests pass). Reviewer can read the contract before the implementation.

## Test plan

- [x] `bundle exec fastlane test` → 154 tests, 0 failures (was 129; +25 new tests across `SessionAttributionSpecParityTests`, `JwtModeRewardEventsTests`, `ClaimStatusPollTests`).
- [x] Spec-parity tests round-trip the canonical wire shape for unattributed / rewardlink / notification / live-activity launches.
- [x] Status-branch tests cover `grant_reward` / `token_issued` / `claim_pending` / `claim_mode_unsupported` / unknown.
- [x] Backoff tests cover initial-delay / doubling / ceiling-clamp at multiple base values.
- [ ] Manual verification against a live taro `claim_pending` flow — gated on the rest of the simplify-rewards integration landing (C-699 / Carrot side / ARB integration).

## Readers left behind

Nothing intentionally deferred from C-698's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)