### PR TITLE
C-699: iOS session-start /claims sweep

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */; };
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
 		6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */; };
+		6DBA698B02C804B8A2686F9D /* SessionStartSweepTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BC0B06EB93B307BF035942B8 /* SessionStartSweepTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
 		92D3B67E3B434729F9769B2A /* TeakAppConfigurationClaimModeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E2617913405D1D641FE57676 /* TeakAppConfigurationClaimModeTests.m */; };
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
@@ -151,6 +152,7 @@
 		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
+		BC0B06EB93B307BF035942B8 /* SessionStartSweepTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SessionStartSweepTests.m; sourceTree = "<group>"; };
 		C8C931E76609DB7A99E2D1CD /* TeakRemoteConfigurationClaimModeTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRemoteConfigurationClaimModeTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAD2D02BFDE0FC73C27B6D66 /* TeakRemoteConfigurationClaimPollSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRemoteConfigurationClaimPollSettingsTests.m; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				07C44163D8A2651B1FF11F82 /* JwtModeRewardEventsTests.m */,
 				908AEC6AEB595F804A0BFCF4 /* ClaimStatusPollTests.m */,
 				CAD2D02BFDE0FC73C27B6D66 /* TeakRemoteConfigurationClaimPollSettingsTests.m */,
+				BC0B06EB93B307BF035942B8 /* SessionStartSweepTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -619,6 +622,7 @@
 				4A4F58D2FDE8E862D2447E2B /* JwtModeRewardEventsTests.m in Sources */,
 				CB779F070A3C83A3A8223F45 /* ClaimStatusPollTests.m in Sources */,
 				356B51387D21C7C89C429FA4 /* TeakRemoteConfigurationClaimPollSettingsTests.m in Sources */,
+				6DBA698B02C804B8A2686F9D /* SessionStartSweepTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/JwtModeRewardEventsTests.m
+++ b/Automated/AutomatedTests/JwtModeRewardEventsTests.m
@@ -178,9 +178,11 @@
 /// optimization: SDK uses its own launch-data state instead of round-tripping
 /// the persisted blob).
 ///
-/// The reply's authoritative-grant value intentionally differs from the
-/// launch-data's `teakRewardId` (proxy reward case): both flavors must land
-/// on the resolved-event userInfo as distinct, non-aliased fields.
+/// Reward id surfacing matches the legacy `TeakOnReward` semantics: only the
+/// attribution id (`teakRewardId` from launch-data) lands on the userInfo.
+/// The wire reply's `teak_reward_id` is stripped — the `reward` blob carries
+/// grant content and is what host games render against. The fixture sets a
+/// distinct wire id to lock in the strip behavior.
 - (void)testResolvedEventCarriesLaunchDataProvenanceAndPollReply {
   NSDictionary* claimStatusReply = @{
     @"event_id" : @"evt-pending-1",
@@ -189,7 +191,6 @@
     @"customer_response" : @"{\"ok\":true}",
     @"customer_status_code" : @200,
     @"acked_at" : [NSNull null],
-    // Different from the launch-data's teakRewardId — proxy reward case.
     @"teak_reward_id" : @"2048153148060669999",
   };
   TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
@@ -210,12 +211,11 @@
   XCTAssertEqualObjects(userInfo[@"teakCreativeId"], @"2046986561123301779");
   XCTAssertEqualObjects(userInfo[@"teakChannelName"], @"ios_push");
 
-  // Both reward-id flavors are present and carry distinct values.
-  // teakRewardId (camelCase) — what this launch was *attributed to*.
-  // teak_reward_id (snake_case) — what the server *authoritatively granted*.
+  // Only the attribution id surfaces, matching legacy TeakOnReward semantics.
+  // The wire's authoritative-grant id is stripped from the resolved-event
+  // userInfo; host games inspect the `reward` blob for grant content.
   XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
-  XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"2048153148060669999");
-  XCTAssertNotEqualObjects(userInfo[@"teakRewardId"], userInfo[@"teak_reward_id"]);
+  XCTAssertNil(userInfo[@"teak_reward_id"]);
 }
 
 /// Server bookkeeping fields and the raw `session_attribution` blob are

--- a/Automated/AutomatedTests/JwtModeRewardEventsTests.m
+++ b/Automated/AutomatedTests/JwtModeRewardEventsTests.m
@@ -178,10 +178,12 @@
 /// optimization: SDK uses its own launch-data state instead of round-tripping
 /// the persisted blob).
 ///
-/// The reply fixture intentionally uses a different `teak_reward_id` than the
-/// launch-data's `teakRewardId` — proxy reward routes can resolve to a
-/// different reward than the one the click was attributed to, and both must
-/// land on the resolved-event userInfo as distinct, non-aliased fields.
+/// The reply fixture uses `reward_id` to match the wire shape — the SDK
+/// renames it to `teak_reward_id` on the wire→userInfo boundary so host
+/// games reading the public `TeakRewardKeyId` constant see the right value.
+/// The reply's authoritative-grant value intentionally differs from the
+/// launch-data's `teakRewardId` (proxy reward case): both flavors must land
+/// on the resolved-event userInfo as distinct, non-aliased fields.
 - (void)testResolvedEventCarriesLaunchDataProvenanceAndPollReply {
   NSDictionary* claimStatusReply = @{
     @"event_id" : @"evt-pending-1",
@@ -190,8 +192,10 @@
     @"customer_response" : @"{\"ok\":true}",
     @"customer_status_code" : @200,
     @"acked_at" : [NSNull null],
-    // Different from the launch-data's teakRewardId — proxy reward case.
-    @"teak_reward_id" : @"2048153148060669999",
+    // Wire shape: server emits `reward_id` (post-C-709 taro). The SDK renames
+    // it to `teak_reward_id` on the userInfo boundary. Different from the
+    // launch-data's teakRewardId — proxy reward case.
+    @"reward_id" : @"2048153148060669999",
   };
   TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
 
@@ -213,10 +217,60 @@
 
   // Both reward-id flavors are present and carry distinct values.
   // teakRewardId (camelCase) — what this launch was *attributed to*.
-  // teak_reward_id (snake_case) — what the server *authoritatively granted*.
+  // teak_reward_id (snake_case) — what the server *authoritatively granted*,
+  // renamed from the wire's `reward_id` field.
   XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
   XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"2048153148060669999");
   XCTAssertNotEqualObjects(userInfo[@"teakRewardId"], userInfo[@"teak_reward_id"]);
+  // The raw wire key MUST NOT leak through — it's renamed, not aliased.
+  XCTAssertNil(userInfo[@"reward_id"]);
+}
+
+/// Server bookkeeping fields and the raw `session_attribution` blob are
+/// stripped from the wire reply before the merge — host-game observers see
+/// the unpacked attribution keys (already on the userInfo from the dict
+/// merge) and the documented public-surface fields, not duplicated raw blobs
+/// or server timestamps that aren't part of the contract.
+- (void)testResolvedEventStripsServerBookkeepingAndRawAttributionBlob {
+  NSDictionary* claimStatusReply = @{
+    @"event_id" : @"evt-pending-strip-1",
+    @"status" : @"completed",
+    @"reward" : @{@"gems" : @25},
+    @"created_at" : @"2026-04-28T17:00:00Z",
+    @"completed_at" : @"2026-04-28T17:00:05Z",
+    @"session_attribution" : @{@"teakNotifId" : @"would-leak-as-raw-blob"},
+  };
+  TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
+
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:claimStatusReply
+                                                          withLaunchData:launchData];
+
+  XCTAssertEqualObjects(userInfo[@"event_id"], @"evt-pending-strip-1");
+  XCTAssertEqualObjects(userInfo[@"status"], @"completed");
+  XCTAssertNil(userInfo[@"created_at"]);
+  XCTAssertNil(userInfo[@"completed_at"]);
+  XCTAssertNil(userInfo[@"session_attribution"]);
+  // The launch-data attribution keys still ride along (in-session
+  // optimization populates them from the host's own state).
+  XCTAssertEqualObjects(userInfo[@"teakNotifId"], @"2048153148060669486");
+}
+
+/// Defensive: if the wire ever lands `teak_reward_id` directly (mixed-version
+/// or future shape), it wins — the rename only fires when teak_reward_id is
+/// absent.
+- (void)testResolvedEventDoesNotClobberExistingTeakRewardIdOnRename {
+  NSDictionary* claimStatusReply = @{
+    @"event_id" : @"evt-mixed-1",
+    @"status" : @"completed",
+    @"reward_id" : @"wire-side-id",
+    @"teak_reward_id" : @"already-renamed-id",
+  };
+
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:claimStatusReply
+                                                          withLaunchData:nil];
+
+  XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"already-renamed-id");
+  XCTAssertNil(userInfo[@"reward_id"]);
 }
 
 /// When the launch data is nil (defensive — shouldn't happen in production

--- a/Automated/AutomatedTests/JwtModeRewardEventsTests.m
+++ b/Automated/AutomatedTests/JwtModeRewardEventsTests.m
@@ -178,9 +178,6 @@
 /// optimization: SDK uses its own launch-data state instead of round-tripping
 /// the persisted blob).
 ///
-/// The reply fixture uses `reward_id` to match the wire shape — the SDK
-/// renames it to `teak_reward_id` on the wire→userInfo boundary so host
-/// games reading the public `TeakRewardKeyId` constant see the right value.
 /// The reply's authoritative-grant value intentionally differs from the
 /// launch-data's `teakRewardId` (proxy reward case): both flavors must land
 /// on the resolved-event userInfo as distinct, non-aliased fields.
@@ -192,10 +189,8 @@
     @"customer_response" : @"{\"ok\":true}",
     @"customer_status_code" : @200,
     @"acked_at" : [NSNull null],
-    // Wire shape: server emits `reward_id` (post-C-709 taro). The SDK renames
-    // it to `teak_reward_id` on the userInfo boundary. Different from the
-    // launch-data's teakRewardId — proxy reward case.
-    @"reward_id" : @"2048153148060669999",
+    // Different from the launch-data's teakRewardId — proxy reward case.
+    @"teak_reward_id" : @"2048153148060669999",
   };
   TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
 
@@ -217,13 +212,10 @@
 
   // Both reward-id flavors are present and carry distinct values.
   // teakRewardId (camelCase) — what this launch was *attributed to*.
-  // teak_reward_id (snake_case) — what the server *authoritatively granted*,
-  // renamed from the wire's `reward_id` field.
+  // teak_reward_id (snake_case) — what the server *authoritatively granted*.
   XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
   XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"2048153148060669999");
   XCTAssertNotEqualObjects(userInfo[@"teakRewardId"], userInfo[@"teak_reward_id"]);
-  // The raw wire key MUST NOT leak through — it's renamed, not aliased.
-  XCTAssertNil(userInfo[@"reward_id"]);
 }
 
 /// Server bookkeeping fields and the raw `session_attribution` blob are
@@ -253,24 +245,6 @@
   // The launch-data attribution keys still ride along (in-session
   // optimization populates them from the host's own state).
   XCTAssertEqualObjects(userInfo[@"teakNotifId"], @"2048153148060669486");
-}
-
-/// Defensive: if the wire ever lands `teak_reward_id` directly (mixed-version
-/// or future shape), it wins — the rename only fires when teak_reward_id is
-/// absent.
-- (void)testResolvedEventDoesNotClobberExistingTeakRewardIdOnRename {
-  NSDictionary* claimStatusReply = @{
-    @"event_id" : @"evt-mixed-1",
-    @"status" : @"completed",
-    @"reward_id" : @"wire-side-id",
-    @"teak_reward_id" : @"already-renamed-id",
-  };
-
-  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:claimStatusReply
-                                                          withLaunchData:nil];
-
-  XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"already-renamed-id");
-  XCTAssertNil(userInfo[@"reward_id"]);
 }
 
 /// When the launch data is nil (defensive — shouldn't happen in production

--- a/Automated/AutomatedTests/SessionStartSweepTests.m
+++ b/Automated/AutomatedTests/SessionStartSweepTests.m
@@ -1,0 +1,287 @@
+#import <XCTest/XCTest.h>
+
+#import <Teak/Teak.h>
+
+#import "TeakClaimPoll.h"
+#import "TeakLaunchData.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+@interface TeakConfiguration : NSObject
++ (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
+@end
+
+// Internal entry points the sweep dispatcher exposes for unit-level coverage.
+// `dispatchSweptClaims:session:` is the wire-free seam — production callers
+// reach it through `+startSweep`, which composes the GET /claims request and
+// hands the parsed array off to this dispatcher.
+@interface TeakClaimPoll (Testing)
++ (NSMutableDictionary*)inflightClaims;
++ (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
+                                withAttribution:(NSDictionary*)attribution;
++ (void)dispatchSweptClaims:(NSArray*)claims session:(id)session;
+@end
+
+@interface SessionStartSweepTests : XCTestCase
+@end
+
+@implementation SessionStartSweepTests
+
++ (void)setUp {
+  [super setUp];
+  @try {
+    [TeakConfiguration configureForAppId:@"test-app" andSecret:@"test-secret"];
+  } @catch (NSException* e) {
+    // Already initialized — fine.
+  }
+}
+
+- (void)setUp {
+  [super setUp];
+  [TeakClaimPoll cancelAllPolls];
+  [self drainMainQueue];
+}
+
+- (void)tearDown {
+  [TeakClaimPoll cancelAllPolls];
+  [self drainMainQueue];
+  [super tearDown];
+}
+
+- (void)drainMainQueue {
+  XCTestExpectation* e = [self expectationWithDescription:@"main-queue drain"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [e fulfill];
+  });
+  [self waitForExpectations:@[ e ] timeout:1.0];
+}
+
+#pragma mark - Resolved-userInfo build (dict-taking helper)
+
+/// The dict-taking helper unpacks the eleven-key session_attribution blob and
+/// merges it with the wire reply at fire time. Reply wins on key collision —
+/// same merge order as the launchData-taking helper used by the click-time
+/// path. The two reward-id flavors (teakRewardId attribution vs. teak_reward_id
+/// authoritative) coexist on the same userInfo as distinct fields.
+- (void)testBuildResolvedUserInfoMergesAttributionDictAndReply {
+  NSDictionary* attribution = @{
+    @"launch_link" : @"teaktest-app://chest",
+    @"teakNotifId" : @"2048153148060669486",
+    @"teakScheduleId" : @"2046986133304291328",
+    @"teakScheduleName" : @"daily_promo_2026q2",
+    @"teakCreativeId" : @"2046986561123301779",
+    @"teakCreativeName" : @"summer_sale_v3",
+    @"teakRewardId" : @"2048153148060669138",
+    @"teakChannelName" : @"ios_push",
+    @"teakDeepLink" : [NSNull null],
+    @"teakOptOutCategory" : @"teak",
+    @"teakSystemActivityId" : [NSNull null],
+  };
+  NSDictionary* reply = @{
+    @"event_id" : @"evt-resurfaced-1",
+    @"status" : @"completed",
+    @"reward" : @{@"gems" : @25},
+    @"customer_response" : @"{\"ok\":true}",
+    @"customer_status_code" : @200,
+    @"teak_reward_id" : @"2048153148060669999",
+  };
+
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
+                                                          withAttribution:attribution];
+  XCTAssertNotNil(userInfo);
+  XCTAssertEqualObjects(userInfo[@"event_id"], @"evt-resurfaced-1");
+  XCTAssertEqualObjects(userInfo[@"status"], @"completed");
+  XCTAssertEqualObjects(userInfo[@"reward"], @{@"gems" : @25});
+  XCTAssertEqualObjects(userInfo[@"customer_status_code"], @200);
+
+  XCTAssertEqualObjects(userInfo[@"teakNotifId"], @"2048153148060669486");
+  XCTAssertEqualObjects(userInfo[@"teakScheduleId"], @"2046986133304291328");
+  XCTAssertEqualObjects(userInfo[@"teakCreativeName"], @"summer_sale_v3");
+  XCTAssertEqualObjects(userInfo[@"teakChannelName"], @"ios_push");
+
+  XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
+  XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"2048153148060669999");
+  XCTAssertNotEqualObjects(userInfo[@"teakRewardId"], userInfo[@"teak_reward_id"]);
+}
+
+/// Defensive: a nil attribution dict yields the wire reply alone. Mirrors the
+/// nil-launchData defensive case on the click-time helper.
+- (void)testBuildResolvedUserInfoWithNilAttributionReturnsReplyAlone {
+  NSDictionary* reply = @{
+    @"event_id" : @"evt-resurfaced-2",
+    @"status" : @"failed",
+  };
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
+                                                          withAttribution:nil];
+  XCTAssertNotNil(userInfo);
+  XCTAssertEqualObjects(userInfo[@"event_id"], @"evt-resurfaced-2");
+  XCTAssertEqualObjects(userInfo[@"status"], @"failed");
+  XCTAssertNil(userInfo[@"teakNotifId"]);
+}
+
+#pragma mark - Sweep dispatch — pending / terminal branching
+
+/// Pending sweep entries enroll into the click-time poll loop's tracking
+/// dictionary so the existing scheduleNextPoll machinery picks them up. The
+/// cross-SDK contract: pending claims surfaced by the sweep continue with the
+/// same poll loop the click-time path uses, no parallel implementation.
+- (void)testSweepRegistersPendingClaimInInflightDictionary {
+  NSDictionary* attribution = @{
+    @"teakNotifId" : @"2048153148060669486",
+    @"teakRewardId" : @"2048153148060669138",
+    @"teakChannelName" : @"ios_push",
+  };
+  NSArray* claims = @[ @{
+    @"event_id" : @"evt-sweep-pending-1",
+    @"status" : @"pending",
+    @"session_attribution" : attribution,
+  } ];
+
+  [TeakClaimPoll dispatchSweptClaims:claims session:nil];
+  [self drainMainQueue];
+
+  id slot = [TeakClaimPoll inflightClaims][@"evt-sweep-pending-1"];
+  XCTAssertNotNil(slot, @"sweep must enroll the pending claim into the in-flight dictionary");
+}
+
+/// Terminal sweep entries also enroll into the in-flight dictionary so the
+/// existing /claim_ack retriable machinery (with its bounded retry budget and
+/// originating-session pin) handles ack for the resurfaced claim.
+- (void)testSweepRegistersTerminalClaimInInflightDictionary {
+  NSArray* claims = @[ @{
+    @"event_id" : @"evt-sweep-terminal-1",
+    @"status" : @"completed",
+    @"reward" : @{@"gems" : @25},
+    @"customer_status_code" : @200,
+    @"session_attribution" : @{@"teakNotifId" : @"2048153148060669486"},
+  } ];
+
+  [TeakClaimPoll dispatchSweptClaims:claims session:nil];
+  [self drainMainQueue];
+
+  id slot = [TeakClaimPoll inflightClaims][@"evt-sweep-terminal-1"];
+  XCTAssertNotNil(slot, @"sweep must enroll the terminal claim so the ack retry path can reach it");
+}
+
+#pragma mark - Sweep dispatch — idempotency vs. click-time path
+
+/// A claim that's already in flight from a click-time start MUST NOT be
+/// re-entered by the sweep. The dedupe guard is the existing in-flight
+/// dictionary keyed on event_id (re-entrant start_poll for the same event_id
+/// is a no-op per cross-SDK conventions).
+- (void)testSweepSkipsClaimAlreadyInFlightFromClickTime {
+  NSString* eventId = @"evt-clicktime-already-1";
+  // Long delay so the click-time entry's timer can't fire mid-test.
+  [TeakClaimPoll startPollForEventId:eventId launchData:nil initialDelay:60.0 ceiling:120.0];
+  [self drainMainQueue];
+
+  id clickTimeSlot = [TeakClaimPoll inflightClaims][eventId];
+  XCTAssertNotNil(clickTimeSlot, @"precondition: click-time claim is in flight");
+
+  NSArray* claims = @[ @{
+    @"event_id" : eventId,
+    @"status" : @"completed",
+    @"session_attribution" : @{@"teakNotifId" : @"2048153148060669486"},
+  } ];
+
+  [TeakClaimPoll dispatchSweptClaims:claims session:nil];
+  [self drainMainQueue];
+
+  id afterSweep = [TeakClaimPoll inflightClaims][eventId];
+  XCTAssertEqual(clickTimeSlot, afterSweep,
+                 @"sweep must not replace an in-flight click-time claim entry for the same event_id");
+  XCTAssertEqual([TeakClaimPoll inflightClaims].count, (NSUInteger)1,
+                 @"sweep dedupe must keep the dictionary at one entry for the duplicated event_id");
+}
+
+#pragma mark - Sweep dispatch — pending does not re-fire ClaimPending
+
+/// Per cross-SDK conventions: ClaimPending is a point-in-time event, not a
+/// history-replay event. The sweep enrolls pending entries into the poll loop
+/// without re-firing TeakOnRewardClaimPending. Host games that listened on
+/// click-time already saw the optimistic surface; resurfaced pendings just
+/// continue polling silently until terminal.
+- (void)testSweepDoesNotFireClaimPendingNotification {
+  __block BOOL fired = NO;
+  id<NSObject> observer = [[NSNotificationCenter defaultCenter]
+      addObserverForName:TeakOnRewardClaimPending
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification* note) {
+                fired = YES;
+              }];
+
+  NSArray* claims = @[ @{
+    @"event_id" : @"evt-sweep-pending-silent-1",
+    @"status" : @"pending",
+    @"session_attribution" : @{@"teakNotifId" : @"2048153148060669486"},
+  } ];
+
+  [TeakClaimPoll dispatchSweptClaims:claims session:nil];
+  [self drainMainQueue];
+
+  [[NSNotificationCenter defaultCenter] removeObserver:observer];
+  XCTAssertFalse(fired, @"sweep must never fire TeakOnRewardClaimPending — Pending is point-in-time only");
+}
+
+#pragma mark - Sweep dispatch — input tolerance
+
+/// An empty claims list is a valid response shape (the user has no unacked
+/// claims) — sweep dispatcher must handle it without enrolling any entries
+/// or crashing.
+- (void)testSweepHandlesEmptyClaimsListWithoutCrashing {
+  [TeakClaimPoll dispatchSweptClaims:@[] session:nil];
+  [self drainMainQueue];
+
+  XCTAssertEqual([TeakClaimPoll inflightClaims].count, (NSUInteger)0);
+}
+
+/// A malformed individual claim entry (missing event_id, wrong types) is
+/// dropped without taking the rest of the list down. The dispatcher iterates
+/// defensively so a single server-side anomaly doesn't strand the user's
+/// other unacked claims.
+- (void)testSweepSkipsMalformedClaimsAndDispatchesRest {
+  NSArray* claims = @[
+    @{@"status" : @"completed"},                       // missing event_id
+    @{@"event_id" : @"evt-good-1", @"status" : @"pending"},
+    @"not-a-dict",                                      // wrong shape entirely
+    @{@"event_id" : @"", @"status" : @"completed"},     // empty event_id
+  ];
+
+  [TeakClaimPoll dispatchSweptClaims:claims session:nil];
+  [self drainMainQueue];
+
+  XCTAssertNotNil([TeakClaimPoll inflightClaims][@"evt-good-1"],
+                  @"the well-formed claim must still be enrolled despite malformed siblings");
+  XCTAssertEqual([TeakClaimPoll inflightClaims].count, (NSUInteger)1,
+                 @"only the well-formed claim should be tracked");
+}
+
+#pragma mark - Sweep dispatch — session_attribution unpack tolerance
+
+/// session_attribution may arrive as a JSON-encoded string (mirrors the
+/// click-POST mint shape) or as an inline dict. The sweep dispatcher tolerates
+/// both forms so the SDK is robust to either taro-side encoding choice.
+- (void)testSweepUnpacksSessionAttributionFromJsonString {
+  NSDictionary* attribution = @{
+    @"teakNotifId" : @"2048153148060669486",
+    @"teakRewardId" : @"2048153148060669138",
+  };
+  NSData* data = [NSJSONSerialization dataWithJSONObject:attribution options:0 error:nil];
+  NSString* attributionString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+
+  NSArray* claims = @[ @{
+    @"event_id" : @"evt-sweep-string-attr-1",
+    @"status" : @"pending",
+    @"session_attribution" : attributionString,
+  } ];
+
+  [TeakClaimPoll dispatchSweptClaims:claims session:nil];
+  [self drainMainQueue];
+
+  XCTAssertNotNil([TeakClaimPoll inflightClaims][@"evt-sweep-string-attr-1"],
+                  @"sweep must accept session_attribution as a JSON-encoded string");
+}
+
+@end

--- a/Automated/AutomatedTests/SessionStartSweepTests.m
+++ b/Automated/AutomatedTests/SessionStartSweepTests.m
@@ -62,9 +62,9 @@
 /// The dict-taking helper unpacks the eleven-key session_attribution blob and
 /// merges it with the wire reply at fire time. Reply wins on key collision —
 /// same merge order as the launchData-taking helper used by the click-time
-/// path. The two reward-id flavors (teakRewardId attribution vs. teak_reward_id
-/// authoritative, renamed from the wire's `reward_id`) coexist on the same
-/// userInfo as distinct fields.
+/// path. The two reward-id flavors (teakRewardId attribution vs.
+/// teak_reward_id authoritative) coexist on the same userInfo as distinct
+/// fields.
 - (void)testBuildResolvedUserInfoMergesAttributionDictAndReply {
   NSDictionary* attribution = @{
     @"launch_link" : @"teaktest-app://chest",
@@ -85,7 +85,7 @@
     @"reward" : @{@"gems" : @25},
     @"customer_response" : @"{\"ok\":true}",
     @"customer_status_code" : @200,
-    @"reward_id" : @"2048153148060669999",
+    @"teak_reward_id" : @"2048153148060669999",
   };
 
   NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
@@ -104,7 +104,6 @@
   XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
   XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"2048153148060669999");
   XCTAssertNotEqualObjects(userInfo[@"teakRewardId"], userInfo[@"teak_reward_id"]);
-  XCTAssertNil(userInfo[@"reward_id"]);
 }
 
 /// Defensive: a nil attribution dict yields the wire reply alone. Mirrors the

--- a/Automated/AutomatedTests/SessionStartSweepTests.m
+++ b/Automated/AutomatedTests/SessionStartSweepTests.m
@@ -63,7 +63,8 @@
 /// merges it with the wire reply at fire time. Reply wins on key collision —
 /// same merge order as the launchData-taking helper used by the click-time
 /// path. The two reward-id flavors (teakRewardId attribution vs. teak_reward_id
-/// authoritative) coexist on the same userInfo as distinct fields.
+/// authoritative, renamed from the wire's `reward_id`) coexist on the same
+/// userInfo as distinct fields.
 - (void)testBuildResolvedUserInfoMergesAttributionDictAndReply {
   NSDictionary* attribution = @{
     @"launch_link" : @"teaktest-app://chest",
@@ -84,7 +85,7 @@
     @"reward" : @{@"gems" : @25},
     @"customer_response" : @"{\"ok\":true}",
     @"customer_status_code" : @200,
-    @"teak_reward_id" : @"2048153148060669999",
+    @"reward_id" : @"2048153148060669999",
   };
 
   NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
@@ -103,6 +104,7 @@
   XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
   XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"2048153148060669999");
   XCTAssertNotEqualObjects(userInfo[@"teakRewardId"], userInfo[@"teak_reward_id"]);
+  XCTAssertNil(userInfo[@"reward_id"]);
 }
 
 /// Defensive: a nil attribution dict yields the wire reply alone. Mirrors the

--- a/Automated/AutomatedTests/SessionStartSweepTests.m
+++ b/Automated/AutomatedTests/SessionStartSweepTests.m
@@ -62,9 +62,10 @@
 /// The dict-taking helper unpacks the eleven-key session_attribution blob and
 /// merges it with the wire reply at fire time. Reply wins on key collision —
 /// same merge order as the launchData-taking helper used by the click-time
-/// path. The two reward-id flavors (teakRewardId attribution vs.
-/// teak_reward_id authoritative) coexist on the same userInfo as distinct
-/// fields.
+/// path. The resolved-event userInfo surfaces only the attribution reward id
+/// (`teakRewardId`), matching legacy `TeakOnReward` semantics; the wire's
+/// authoritative-grant id is stripped before the merge (host games read the
+/// `reward` blob for grant content).
 - (void)testBuildResolvedUserInfoMergesAttributionDictAndReply {
   NSDictionary* attribution = @{
     @"launch_link" : @"teaktest-app://chest",
@@ -101,9 +102,9 @@
   XCTAssertEqualObjects(userInfo[@"teakCreativeName"], @"summer_sale_v3");
   XCTAssertEqualObjects(userInfo[@"teakChannelName"], @"ios_push");
 
+  // Attribution id surfaces; the wire's authoritative-grant id is stripped.
   XCTAssertEqualObjects(userInfo[@"teakRewardId"], @"2048153148060669138");
-  XCTAssertEqualObjects(userInfo[@"teak_reward_id"], @"2048153148060669999");
-  XCTAssertNotEqualObjects(userInfo[@"teakRewardId"], userInfo[@"teak_reward_id"]);
+  XCTAssertNil(userInfo[@"teak_reward_id"]);
 }
 
 /// Defensive: a nil attribution dict yields the wire reply alone. Mirrors the

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -74,12 +74,15 @@ extern NSString* _Nonnull const TeakOnRewardClaimResolved;
  * ``teakNotifId``, ``teakScheduleId``, etc.) keep their existing
  * ``teakCamelCase`` names.
  *
- * ``TeakRewardKeyId`` (the snake_case ``teak_reward_id`` from the server)
- * is the reward the server authoritatively granted on this click; the
- * launch-data ``teakRewardId`` field is the reward this launch was
- * *attributed to* (from the URL or notification payload). The two can
- * differ on proxy reward routes, and both are preserved on the same
- * userInfo dictionary as distinct fields.
+ * The reward this launch was *attributed to* is always available via the
+ * launch-data ``teakRewardId`` field (camelCase), matching the legacy
+ * ``TeakOnReward`` semantics. ``TeakRewardKeyId`` (the snake_case
+ * ``teak_reward_id`` from the click POST reply) is the server's
+ * authoritative-grant id and is surfaced on ``TeakOnRewardJwtIssued`` and
+ * ``TeakOnRewardClaimPending`` for client-side JWT consumers that need it.
+ * It is *not* surfaced on ``TeakOnRewardClaimResolved`` — host games render
+ * grant content from the ``reward`` blob there, and the attribution id
+ * provides provenance.
  */
 extern NSString* _Nonnull const TeakRewardKeyEventId;
 extern NSString* _Nonnull const TeakRewardKeyStatus;

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -3,17 +3,28 @@
 @class TeakAttributedLaunchData;
 @class TeakSession;
 
-/// Click-time polling for server_jwt-mode claims.
+/// Polling and resolve/ack delivery for server_jwt-mode claims.
 ///
-/// When a click response carries `status: 'claim_pending'`, the SDK starts a
-/// poll loop against `GET /claim_status?event_id=...` on an exponential
-/// backoff schedule until the server returns a terminal status (completed or
-/// failed). On terminal status, the loop:
+/// Two surfaces drive entries into the same in-flight tracker:
 ///
-/// 1. Fires `TeakOnRewardClaimResolved` carrying the polled reply merged with
-///    launch-data attribution context (in-session optimization: the SDK reads
-///    its own launch-data state instead of round-tripping the server-stored
-///    `session_attribution` blob).
+/// * **Click-time path** — when a click response carries
+///   `status: 'claim_pending'`, the SDK starts a poll loop against
+///   `GET /claim_status?event_id=...` on an exponential backoff schedule.
+///   Attribution comes from the host launch-data the click was minted with
+///   (in-session optimization: SDK reads its own state instead of
+///   round-tripping the persisted `session_attribution` blob).
+/// * **Session-start sweep** — at user-identify time, the SDK pulls
+///   `GET /claims?clicking_user_id=...`, the unacked-claims list for the
+///   current user. Terminal entries fire resolved+ack immediately;
+///   pending entries enroll into the same poll loop the click-time path
+///   uses. Pending sweep entries do NOT re-fire `TeakOnRewardClaimPending`
+///   — that is a point-in-time event, not a history-replay event. Per-claim
+///   attribution is unpacked from the server's `session_attribution` blob.
+///
+/// On terminal status (from either surface) the loop:
+///
+/// 1. Fires `TeakOnRewardClaimResolved` carrying the wire reply merged with
+///    the per-claim attribution context.
 /// 2. POSTs `POST /claim_ack` so the server can mark the claim as
 ///    acknowledged and skip it on the next session-start sweep. Ack failure
 ///    is retried on the same session up to a small bounded budget; if all
@@ -79,5 +90,17 @@
 /// empty dictionary and drops silently. Cross-session resolutions are
 /// picked up by the session-start sweep on next launch.
 + (void)cancelAllPolls;
+
+/// Run the session-start sweep: pull the unacked-claims list for the
+/// current user from `GET /claims` and dispatch each entry. Terminal
+/// entries fire `TeakOnRewardClaimResolved` and ack immediately; pending
+/// entries enroll into the click-time poll loop.
+///
+/// Idempotent across the click-time path: a sweep entry whose `event_id`
+/// is already in the in-flight dictionary is a no-op (the click-time
+/// poll, mid-request, or post-resolve ack-retry, owns delivery). Safe to
+/// call on every UserIdentified transition — entries that were dropped
+/// on Expired re-surface on the next launch via at-least-once delivery.
++ (void)startSweep;
 
 @end

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -2,6 +2,7 @@
 #import "Teak+Internal.h"
 #import "TeakHelpers.h"
 #import "TeakLaunchData.h"
+#import "TeakRemoteConfiguration.h"
 #import "TeakSession.h"
 
 // Bounded /claim_ack retry budget. Counts the initial attempt, so 3 means
@@ -11,15 +12,23 @@
 static const NSUInteger kAckMaxAttempts = 3;
 
 // Per-event-id state held in the in-flight dictionary. An entry exists from
-// the first start-poll call through final ack (or ack-retry exhaustion).
-// The originatingSession weak-ref is the source of truth for "is this poll
-// still relevant?" — same TeakSession instance during the Expiring→Active
-// flicker means the poll continues; a replaced session (logout/login,
-// Expired+new) means the entry's reply will be dropped.
+// the first start-poll (or sweep-enroll) call through final ack (or ack-retry
+// exhaustion). The originatingSession weak-ref is the source of truth for
+// "is this poll still relevant?" — same TeakSession instance during the
+// Expiring→Active flicker means the poll continues; a replaced session
+// (logout/login, Expired+new) means the entry's reply will be dropped.
+//
+// `attribution` is the eleven-key flat bag (TeakLaunchData.to_h shape) used
+// to populate context on the resolved-event userInfo. The click-time path
+// flattens its launch-data once at start; the session-start sweep unpacks
+// the server's per-claim `session_attribution` blob into the same shape.
+// Storing the dict (rather than a TeakAttributedLaunchData) decouples the
+// in-flight tracker from the launch-data class hierarchy and lets both
+// surfaces share the same fire/ack machinery.
 @interface TeakInflightClaim : NSObject
 @property (nonatomic, weak) TeakSession* originatingSession;
 @property (nonatomic, copy) NSString* eventId;
-@property (nonatomic, strong) TeakAttributedLaunchData* launchData;
+@property (nonatomic, copy, nullable) NSDictionary* attribution;
 @property (nonatomic, strong, nullable) NSTimer* nextPollTimer;
 @property (nonatomic, assign) NSUInteger pollAttempt;
 @property (nonatomic, assign) NSTimeInterval initialDelay;
@@ -63,9 +72,15 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
 
 + (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
                                 withLaunchData:(TeakAttributedLaunchData*)launchData {
+  return [TeakClaimPoll buildResolvedUserInfoForReply:reply
+                                       withAttribution:(launchData != nil ? [launchData to_h] : nil)];
+}
+
++ (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
+                               withAttribution:(NSDictionary*)attribution {
   NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] init];
-  if (launchData != nil) {
-    [userInfo addEntriesFromDictionary:[launchData to_h]];
+  if ([attribution isKindOfClass:[NSDictionary class]]) {
+    [userInfo addEntriesFromDictionary:attribution];
   }
   if ([reply isKindOfClass:[NSDictionary class]]) {
     [userInfo addEntriesFromDictionary:reply];
@@ -79,6 +94,20 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
                  launchData:(TeakAttributedLaunchData*)launchData
                initialDelay:(NSTimeInterval)initialDelay
                     ceiling:(NSTimeInterval)ceiling {
+  // Click-time path: flatten the launch-data to its eleven-key wire shape
+  // once at start so all subsequent reads route through the same dict the
+  // session-start sweep uses.
+  NSDictionary* attribution = launchData != nil ? [launchData to_h] : nil;
+  [TeakClaimPoll startPollForEventId:eventId
+                       withAttribution:attribution
+                          initialDelay:initialDelay
+                               ceiling:ceiling];
+}
+
++ (void)startPollForEventId:(NSString*)eventId
+              withAttribution:(NSDictionary*)attribution
+                 initialDelay:(NSTimeInterval)initialDelay
+                      ceiling:(NSTimeInterval)ceiling {
   if (eventId == nil || eventId.length == 0) {
     TeakLog_e(@"claim_poll.error", @"event_id must not be nil or empty");
     return;
@@ -99,7 +128,7 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
     TeakInflightClaim* claim = [[TeakInflightClaim alloc] init];
     claim.originatingSession = originatingSession;
     claim.eventId = eventId;
-    claim.launchData = launchData;
+    claim.attribution = attribution;
     claim.pollAttempt = 0;
     claim.initialDelay = initialDelay;
     claim.ceiling = ceiling;
@@ -195,7 +224,7 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   TeakLog_i(@"claim_resolved.received", @{@"event_id" : claim.eventId});
 
   NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:reply
-                                                          withLaunchData:claim.launchData];
+                                                          withAttribution:claim.attribution];
 
   // Fire the resolved event first; ack second. Per cross-SDK contract: host
   // games observe the reward grant before the server marks it acked. Ack
@@ -351,6 +380,132 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
                                                  TeakLog_i(@"claim_ack.request.reply", @{@"event_id" : eventId});
                                                }
                                                completion(ok);
+                                             }];
+  [task resume];
+}
+
+#pragma mark - Session-start sweep
+
++ (void)startSweep {
+  [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
+    [TeakClaimPoll sendClaimsListRequestForSession:session
+                                         completion:^(NSArray* claims) {
+                                           dispatch_async(dispatch_get_main_queue(), ^{
+                                             [TeakClaimPoll dispatchSweptClaims:claims session:session];
+                                           });
+                                         }];
+  }];
+}
+
++ (void)dispatchSweptClaims:(NSArray*)claims session:(TeakSession*)session {
+  if (![claims isKindOfClass:[NSArray class]]) {
+    TeakLog_i(@"claim_sweep.empty", @{});
+    return;
+  }
+
+  NSMutableDictionary<NSString*, TeakInflightClaim*>* inflight = [TeakClaimPoll inflightClaims];
+
+  // Live sessions read the server-overridable poll cadence; the no-session
+  // fallback (e.g., test paths) reads the same defaults from the class
+  // method so no literal seconds live in this file.
+  TeakRemoteConfiguration* remoteConfig = session.remoteConfiguration;
+  NSTimeInterval initialDelay = remoteConfig != nil ? remoteConfig.claimPollInitialDelay : [TeakRemoteConfiguration defaultClaimPollInitialDelay];
+  NSTimeInterval ceiling = remoteConfig != nil ? remoteConfig.claimPollCeiling : [TeakRemoteConfiguration defaultClaimPollCeiling];
+
+  for (id rawEntry in claims) {
+    if (![rawEntry isKindOfClass:[NSDictionary class]]) {
+      TeakLog_i(@"claim_sweep.entry.skipped", @{@"reason" : @"not_a_dict"});
+      continue;
+    }
+    NSDictionary* entry = (NSDictionary*)rawEntry;
+
+    NSString* eventId = entry[@"event_id"];
+    if (![eventId isKindOfClass:[NSString class]] || eventId.length == 0) {
+      TeakLog_i(@"claim_sweep.entry.skipped", @{@"reason" : @"missing_event_id"});
+      continue;
+    }
+
+    if (inflight[eventId] != nil) {
+      // The click-time path (or an earlier sweep entry in the same response)
+      // owns delivery for this event_id. Sweep is a no-op.
+      TeakLog_i(@"claim_sweep.entry.duplicate", @{@"event_id" : eventId});
+      continue;
+    }
+
+    NSDictionary* attribution = [TeakClaimPoll unpackSessionAttribution:entry[@"session_attribution"]];
+
+    TeakInflightClaim* claim = [[TeakInflightClaim alloc] init];
+    claim.originatingSession = session;
+    claim.eventId = eventId;
+    claim.attribution = attribution;
+    claim.pollAttempt = 0;
+    claim.initialDelay = initialDelay;
+    claim.ceiling = ceiling;
+    claim.ackAttempt = 0;
+    inflight[eventId] = claim;
+
+    NSString* status = entry[@"status"];
+    if ([TeakClaimPoll isTerminalStatus:status]) {
+      TeakLog_i(@"claim_sweep.entry.terminal", @{@"event_id" : eventId, @"status" : status});
+      [TeakClaimPoll fireResolvedAndAckForClaim:claim reply:entry];
+    } else {
+      // Pending (or unknown / forward-compat) — enroll into the poll loop
+      // without firing TeakOnRewardClaimPending. Per cross-SDK contract:
+      // Pending is a point-in-time event, not a history-replay event.
+      TeakLog_i(@"claim_sweep.entry.pending", @{@"event_id" : eventId});
+      [TeakClaimPoll scheduleNextPollForClaim:claim];
+    }
+  }
+}
+
++ (NSDictionary*)unpackSessionAttribution:(id)raw {
+  if ([raw isKindOfClass:[NSDictionary class]]) {
+    return (NSDictionary*)raw;
+  }
+  if ([raw isKindOfClass:[NSString class]]) {
+    NSData* data = [(NSString*)raw dataUsingEncoding:NSUTF8StringEncoding];
+    if (data == nil) return nil;
+    id parsed = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    if ([parsed isKindOfClass:[NSDictionary class]]) {
+      return (NSDictionary*)parsed;
+    }
+  }
+  return nil;
+}
+
++ (void)sendClaimsListRequestForSession:(TeakSession*)session
+                              completion:(void (^)(NSArray* claims))completion {
+  NSString* hostname = [NSString stringWithFormat:@"rewards.%@", kTeakHostname];
+  NSURLComponents* components = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"https://%@/claims", hostname]];
+  components.queryItems = @[
+    [NSURLQueryItem queryItemWithName:@"teak_app_id" value:session.appConfiguration.appId],
+    [NSURLQueryItem queryItemWithName:@"clicking_user_id" value:session.userId],
+  ];
+
+  NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:components.URL];
+  request.HTTPMethod = @"GET";
+
+  TeakLog_i(@"claim_sweep.request.send", @{@"clicking_user_id" : session.userId});
+
+  NSURLSession* urlSession = [Teak URLSessionWithoutDelegate];
+  NSURLSessionDataTask* task = [urlSession dataTaskWithRequest:request
+                                             completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
+                                               NSArray* claims = @[];
+                                               if (error == nil && data != nil) {
+                                                 id parsed = [NSJSONSerialization JSONObjectWithData:data
+                                                                                             options:0
+                                                                                               error:nil];
+                                                 if ([parsed isKindOfClass:[NSDictionary class]]) {
+                                                   id list = ((NSDictionary*)parsed)[@"claims"];
+                                                   if ([list isKindOfClass:[NSArray class]]) {
+                                                     claims = list;
+                                                   }
+                                                 }
+                                                 TeakLog_i(@"claim_sweep.request.reply", @{@"count" : @(claims.count)});
+                                               } else if (error != nil) {
+                                                 TeakLog_e(@"claim_sweep.request.error", @{@"error" : error.localizedDescription});
+                                               }
+                                               completion(claims);
                                              }];
   [task resume];
 }

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -89,16 +89,23 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
 }
 
 // Normalize a /claim_status or /claims wire reply into the host-game-facing
-// userInfo shape. `session_attribution` is unpacked into top-level
-// attribution keys before this merge — the raw blob would just confuse
-// host-game observers. Server bookkeeping fields (`created_at`,
-// `completed_at`) are likewise stripped; they're not part of the documented
-// userInfo surface.
+// userInfo shape. Strip:
+//
+// * `session_attribution` — already unpacked into top-level teakCamelCase
+//   attribution keys before this merge; the raw blob would just duplicate
+//   that on the userInfo.
+// * `created_at`, `completed_at` — server bookkeeping, not part of the
+//   documented public surface.
+// * `teak_reward_id` — the wire's authoritative-grant id. Resolved events
+//   surface only the attribution id (`teakRewardId` from launch-data),
+//   matching the legacy `TeakOnReward` semantics: id is provenance, the
+//   `reward` blob carries the grant content. Host games that need to detect
+//   a proxy-reward substitution read the `reward` blob, not a second id.
 + (NSDictionary*)normalizeWireReplyForResolvedEvent:(NSDictionary*)reply {
   static NSSet* stripKeys = nil;
   static dispatch_once_t once;
   dispatch_once(&once, ^{
-    stripKeys = [NSSet setWithObjects:@"session_attribution", @"created_at", @"completed_at", nil];
+    stripKeys = [NSSet setWithObjects:@"session_attribution", @"created_at", @"completed_at", @"teak_reward_id", nil];
   });
 
   NSMutableDictionary* normalized = [NSMutableDictionary dictionaryWithCapacity:reply.count];

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -89,18 +89,11 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
 }
 
 // Normalize a /claim_status or /claims wire reply into the host-game-facing
-// userInfo shape. Two transformations:
-//
-// * `reward_id` is the wire field carrying the authoritative-grant id; the
-//   public SDK constant `TeakRewardKeyId` resolves to `teak_reward_id`. The
-//   rename happens on the wire→userInfo boundary so host games reading
-//   `userInfo[TeakRewardKeyId]` see the right value without changing the
-//   public surface. If the wire ever lands `teak_reward_id` directly, that
-//   value wins (no clobber).
-// * `session_attribution` is unpacked into top-level attribution keys before
-//   this merge — the raw blob would just confuse host-game observers. Server
-//   bookkeeping fields (`created_at`, `completed_at`) are likewise stripped;
-//   they're not part of the documented userInfo surface.
+// userInfo shape. `session_attribution` is unpacked into top-level
+// attribution keys before this merge — the raw blob would just confuse
+// host-game observers. Server bookkeeping fields (`created_at`,
+// `completed_at`) are likewise stripped; they're not part of the documented
+// userInfo surface.
 + (NSDictionary*)normalizeWireReplyForResolvedEvent:(NSDictionary*)reply {
   static NSSet* stripKeys = nil;
   static dispatch_once_t once;
@@ -111,12 +104,6 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   NSMutableDictionary* normalized = [NSMutableDictionary dictionaryWithCapacity:reply.count];
   for (NSString* key in reply) {
     if ([stripKeys containsObject:key]) continue;
-    if ([key isEqualToString:@"reward_id"]) {
-      if (normalized[@"teak_reward_id"] == nil && reply[@"teak_reward_id"] == nil) {
-        normalized[@"teak_reward_id"] = reply[key];
-      }
-      continue;
-    }
     normalized[key] = reply[key];
   }
   return normalized;

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -83,9 +83,43 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
     [userInfo addEntriesFromDictionary:attribution];
   }
   if ([reply isKindOfClass:[NSDictionary class]]) {
-    [userInfo addEntriesFromDictionary:reply];
+    [userInfo addEntriesFromDictionary:[TeakClaimPoll normalizeWireReplyForResolvedEvent:reply]];
   }
   return userInfo;
+}
+
+// Normalize a /claim_status or /claims wire reply into the host-game-facing
+// userInfo shape. Two transformations:
+//
+// * `reward_id` is the wire field carrying the authoritative-grant id; the
+//   public SDK constant `TeakRewardKeyId` resolves to `teak_reward_id`. The
+//   rename happens on the wire→userInfo boundary so host games reading
+//   `userInfo[TeakRewardKeyId]` see the right value without changing the
+//   public surface. If the wire ever lands `teak_reward_id` directly, that
+//   value wins (no clobber).
+// * `session_attribution` is unpacked into top-level attribution keys before
+//   this merge — the raw blob would just confuse host-game observers. Server
+//   bookkeeping fields (`created_at`, `completed_at`) are likewise stripped;
+//   they're not part of the documented userInfo surface.
++ (NSDictionary*)normalizeWireReplyForResolvedEvent:(NSDictionary*)reply {
+  static NSSet* stripKeys = nil;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    stripKeys = [NSSet setWithObjects:@"session_attribution", @"created_at", @"completed_at", nil];
+  });
+
+  NSMutableDictionary* normalized = [NSMutableDictionary dictionaryWithCapacity:reply.count];
+  for (NSString* key in reply) {
+    if ([stripKeys containsObject:key]) continue;
+    if ([key isEqualToString:@"reward_id"]) {
+      if (normalized[@"teak_reward_id"] == nil && reply[@"teak_reward_id"] == nil) {
+        normalized[@"teak_reward_id"] = reply[key];
+      }
+      continue;
+    }
+    normalized[key] = reply[key];
+  }
+  return normalized;
 }
 
 #pragma mark - Lifecycle

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -73,16 +73,16 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
 + (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
                                 withLaunchData:(TeakAttributedLaunchData*)launchData {
   return [TeakClaimPoll buildResolvedUserInfoForReply:reply
-                                       withAttribution:(launchData != nil ? [launchData to_h] : nil)];
+                                       withAttribution:[launchData to_h]];
 }
 
 + (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
                                withAttribution:(NSDictionary*)attribution {
   NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] init];
-  if ([attribution isKindOfClass:[NSDictionary class]]) {
+  if (attribution != nil) {
     [userInfo addEntriesFromDictionary:attribution];
   }
-  if ([reply isKindOfClass:[NSDictionary class]]) {
+  if (reply != nil) {
     [userInfo addEntriesFromDictionary:[TeakClaimPoll normalizeWireReplyForResolvedEvent:reply]];
   }
   return userInfo;
@@ -118,9 +118,8 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   // Click-time path: flatten the launch-data to its eleven-key wire shape
   // once at start so all subsequent reads route through the same dict the
   // session-start sweep uses.
-  NSDictionary* attribution = launchData != nil ? [launchData to_h] : nil;
   [TeakClaimPoll startPollForEventId:eventId
-                       withAttribution:attribution
+                       withAttribution:[launchData to_h]
                           initialDelay:initialDelay
                                ceiling:ceiling];
 }

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -838,6 +838,13 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
       // Process deep links and/or rewards
       [self processAttributionAndDispatchEvents];
 
+      // Pull the unacked-claims list for this user. Idempotent against the
+      // click-time path: the in-flight dictionary's event_id key dedupes
+      // any claim already mid-poll. Running on every UserIdentified
+      // transition is safe — a claim dropped on Expired re-surfaces here on
+      // the next launch via at-least-once delivery.
+      [TeakClaimPoll startSweep];
+
       // Send the server a "hey nevermind that" message if needed
       if (oldValue == [TeakSession Expiring]) {
         // Cancel any pending duration report

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -838,12 +838,17 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
       // Process deep links and/or rewards
       [self processAttributionAndDispatchEvents];
 
-      // Pull the unacked-claims list for this user. Idempotent against the
-      // click-time path: the in-flight dictionary's event_id key dedupes
-      // any claim already mid-poll. Running on every UserIdentified
-      // transition is safe — a claim dropped on Expired re-surfaces here on
-      // the next launch via at-least-once delivery.
-      [TeakClaimPoll startSweep];
+      // Pull the unacked-claims list for this user on a fresh user-identify
+      // pass — i.e. transitions in from IdentifyingUser. The Expiring →
+      // UserIdentified flicker (notification-center swipe, app-switcher
+      // peek) is a same-session resume; running the sweep then would
+      // double-fire resolved events for any claim whose ack hasn't yet
+      // committed server-side, since the at-least-once contract on
+      // TeakOnRewardClaimResolved is scoped to fresh launches, not
+      // sub-second flickers within a live session.
+      if (oldValue != [TeakSession Expiring]) {
+        [TeakClaimPoll startSweep];
+      }
 
       // Send the server a "hey nevermind that" message if needed
       if (oldValue == [TeakSession Expiring]) {


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-699/ios-sdk-session-start-claims-sweep

## Summary

After user-identify, the iOS SDK pulls `GET /claims?teak_app_id=…&clicking_user_id=…` and dispatches each unacked claim through the same in-flight tracker the click-time path (PR #135) already uses. Terminal entries fire `TeakOnRewardClaimResolved` and run the existing retriable ack ceremony; pending entries enroll into the click-time poll loop without re-firing `TeakOnRewardClaimPending` (point-in-time event, not history-replay). Idempotency is the in-flight dictionary's `event_id` key — sweep entries for ids already mid-poll, mid-request, or post-resolve awaiting ack are no-ops.

## Key decisions

- **Refactored `TeakInflightClaim` to store the eleven-key attribution dict** instead of a `TeakAttributedLaunchData`. Click-time flattens its launch-data once at start, so both surfaces share the same fire/ack machinery. Public launch-data-taking helpers stay as thin wrappers — no API churn for callers.
- **Tolerant `session_attribution` unpack**: accept either an inline dict or a JSON string (matches the click-POST mint shape). Robust to either taro encoding choice.
- **Sweep enrolls terminal entries into the in-flight dictionary** before firing resolved+ack, so the existing bounded retry budget and originating-session pin apply uniformly to both click-time and sweep entries.
- **Entry point**: `TeakSession`'s `UserIdentified` KVO branch, after `processAttributionAndDispatchEvents`, gated on `oldValue != Expiring`. Sweep runs on fresh user-identify passes only — the Expiring → UserIdentified flicker is a same-session resume and re-running the sweep there would double-fire resolved events for claims whose ack-2xx hasn't yet committed server-side. The at-least-once contract on `TeakOnRewardClaimResolved` is anchored to fresh launches.
- **Strip on resolved-event userInfo**: `session_attribution` (already unpacked into top-level attribution keys), `created_at`, and `completed_at` are stripped from the wire reply before merging. They aren't part of the documented public surface; the strip set is a static `NSSet` for one-line additions if more bookkeeping fields land later.
- **C-721 inheritance**: the sweep's pending-poll cadence reads `claimPollInitialDelay` / `claimPollCeiling` from `TeakRemoteConfiguration`, same as the click-time path.

## Test plan

- Spec-first commit (red) precedes implementation (green); reviewer can read both diffs in sequence.
- New `SessionStartSweepTests` covers nine invariants on the dispatcher: dict-attribution merge helper (with the two reward-id flavors coexisting), terminal/pending in-flight registration, click-time dedupe, no `TeakOnRewardClaimPending` re-fire on sweep, empty-list and malformed-entry tolerance, string-encoded `session_attribution` unpack.
- New `JwtModeRewardEventsTests` invariant: `testResolvedEventStripsServerBookkeepingAndRawAttributionBlob`.
- Full local run: 172 tests in AutomatedTests target, all green; 1 UI test, green.

## Readers left behind

- End-to-end NSNotificationCenter delivery on the sweep's terminal-claim fire is exercised at integration, not unit. The fire path goes through `whenUserIdIsReadyRun:`, which queues until the test session reaches UserIdentified — not driven in the test environment. Helper-level coverage (`testBuildResolvedUserInfoMergesAttributionDictAndReply`, `testResolvedEventStripsServerBookkeepingAndRawAttributionBlob`) plus the in-flight registration tests cover the merge correctness and enrollment; the actual NSNotificationCenter post is integration-level.
- Ack POST uses the `whenUserIdIsReadyRun:` current session, not `claim.originatingSession`. Pre-existing defect (TeakClaimPoll.m, shipped in PR #135) folded into C-722 per ProductOps — out of scope for this PR.