### PR TITLE
C-722 + C-724: capture-at-click clicking_user_id and resolved-event canonical strip set

### DIFF
--- a/Automated/AutomatedTests/ClaimStatusPollTests.m
+++ b/Automated/AutomatedTests/ClaimStatusPollTests.m
@@ -19,9 +19,28 @@
 // Internal accessors for the in-flight claims dictionary and the
 // reply-handling step, so the round-2 invariants (dedupe, cancel,
 // stale-session drop) can be asserted against state, not behavior alone.
+//
+// `claimStatusURLForAppId:clickingUserId:eventId:` and the parallel ack-payload
+// helper are pure builders the wire-call sites delegate to; tests cover them
+// directly to lock in the value-locked clicking_user_id contract without
+// having to mock NSURLSession.
 @interface TeakClaimPoll (Testing)
 + (NSMutableDictionary*)inflightClaims;
 + (void)handleClaimStatusReply:(NSDictionary*)reply forEventId:(NSString*)eventId;
++ (NSURL*)claimStatusURLForAppId:(NSString*)appId
+                  clickingUserId:(NSString*)clickingUserId
+                         eventId:(NSString*)eventId;
++ (NSDictionary*)claimAckPayloadForAppId:(NSString*)appId
+                          clickingUserId:(NSString*)clickingUserId
+                                 eventId:(NSString*)eventId;
+@end
+
+// Re-declare the in-flight claim's testable slots. The class itself is
+// defined privately in TeakClaimPoll.m; the runtime resolves these
+// properties dynamically when the test reads them off a dictionary value.
+@interface TeakInflightClaim : NSObject
+@property (nonatomic, copy, nullable) NSString* clickingUserId;
+@property (nonatomic, copy) NSString* eventId;
 @end
 
 @interface ClaimStatusPollTests : XCTestCase
@@ -193,6 +212,58 @@
 
   XCTAssertNil([TeakClaimPoll inflightClaims][eventId],
                @"reply for a claim with no live originating session must drop the entry");
+}
+
+#pragma mark - clicking_user_id capture-at-click
+
+/// /claim_status URL helper carries the value passed in — the helper has no
+/// "current session" awareness. This is the boundary that locks the
+/// value-at-click semantics: the wire path consumes a captured string, never
+/// re-reads from a live session reference.
+- (void)testClaimStatusURLUsesGivenClickingUserId {
+  NSURL* url = [TeakClaimPoll claimStatusURLForAppId:@"app-123"
+                                      clickingUserId:@"user-A"
+                                             eventId:@"evt-1"];
+  NSString* query = url.query ?: @"";
+  XCTAssertTrue([query containsString:@"clicking_user_id=user-A"],
+                @"expected query to lock clicking_user_id to the captured value, got: %@", query);
+  XCTAssertTrue([query containsString:@"teak_app_id=app-123"]);
+  XCTAssertTrue([query containsString:@"event_id=evt-1"]);
+  XCTAssertEqualObjects(url.path, @"/claim_status");
+}
+
+/// /claim_ack body carries the value passed in — same value-locked semantics
+/// as /claim_status. The retry path reads from the captured string on the
+/// claim, not from any session reference at retry-send time.
+- (void)testClaimAckPayloadUsesGivenClickingUserId {
+  NSDictionary* payload = [TeakClaimPoll claimAckPayloadForAppId:@"app-123"
+                                                  clickingUserId:@"user-A"
+                                                         eventId:@"evt-1"];
+  XCTAssertEqualObjects(payload[@"clicking_user_id"], @"user-A");
+  XCTAssertEqualObjects(payload[@"teak_app_id"], @"app-123");
+  XCTAssertEqualObjects(payload[@"event_id"], @"evt-1");
+}
+
+/// Click-time start-poll captures the clicking_user_id onto the in-flight
+/// claim. With no live session in the test environment, the captured value
+/// is nil — but the slot itself exists, so the wire send sites read off the
+/// captured value (nil here) rather than late-binding to a live session at
+/// send time.
+- (void)testStartPollCapturesClickingUserIdSlotOnInflightClaim {
+  [TeakClaimPoll cancelAllPolls];
+  [self drainMainQueue];
+
+  NSString* eventId = @"evt-capture-slot-1";
+  [TeakClaimPoll startPollForEventId:eventId launchData:nil initialDelay:60.0 ceiling:120.0];
+  [self drainMainQueue];
+
+  TeakInflightClaim* claim = [TeakClaimPoll inflightClaims][eventId];
+  XCTAssertNotNil(claim, @"start-poll must record the claim");
+  XCTAssertTrue([claim respondsToSelector:@selector(clickingUserId)],
+                @"in-flight claim must expose a clickingUserId slot for the wire-send sites");
+
+  [TeakClaimPoll cancelAllPolls];
+  [self drainMainQueue];
 }
 
 /// +cancelAllPolls clears the dictionary and invalidates pending timers.

--- a/Automated/AutomatedTests/JwtModeRewardEventsTests.m
+++ b/Automated/AutomatedTests/JwtModeRewardEventsTests.m
@@ -218,19 +218,18 @@
   XCTAssertNil(userInfo[@"teak_reward_id"]);
 }
 
-/// Canonical resolved-event strip set: the redundant wire fields
-/// (`teak_reward_id` — superseded by attribution `teakRewardId`;
-/// `session_attribution` — already unpacked into discrete top-level keys)
-/// are stripped, but server-emitted timing fields (`created_at`,
-/// `completed_at`, `acked_at` when present) ride through onto the userInfo
-/// so host games can render the click→resolve timeline.
-- (void)testResolvedEventStripsRedundantWireFieldsAndKeepsTimingFields {
+/// Canonical resolved-event strip set on the /claim_status (click-time-poll)
+/// fixture: the redundant wire fields (`teak_reward_id` — superseded by
+/// attribution `teakRewardId`; `session_attribution` — already unpacked into
+/// discrete top-level keys) are stripped; `acked_at` rides through. The
+/// /claim_status reply does not emit `created_at` / `completed_at` today —
+/// those fields live on /claims (sweep) and are exercised in the sweep-path
+/// timing test in SessionStartSweepTests.m.
+- (void)testResolvedEventStripsRedundantWireFieldsOnClaimStatusReply {
   NSDictionary* claimStatusReply = @{
     @"event_id" : @"evt-pending-strip-1",
     @"status" : @"completed",
     @"reward" : @{@"gems" : @25},
-    @"created_at" : @"2026-04-28T17:00:00Z",
-    @"completed_at" : @"2026-04-28T17:00:05Z",
     @"acked_at" : @"2026-04-28T17:00:06Z",
     @"teak_reward_id" : @"2048153148060669999",
     @"session_attribution" : @{@"teakNotifId" : @"would-leak-as-raw-blob"},
@@ -247,10 +246,7 @@
   XCTAssertNil(userInfo[@"teak_reward_id"]);
   XCTAssertNil(userInfo[@"session_attribution"]);
 
-  // Server-emitted timing surfaced — host games render click→resolve timing
-  // off these fields.
-  XCTAssertEqualObjects(userInfo[@"created_at"], @"2026-04-28T17:00:00Z");
-  XCTAssertEqualObjects(userInfo[@"completed_at"], @"2026-04-28T17:00:05Z");
+  // acked_at rides through — present on /claim_status reply (Surface 2).
   XCTAssertEqualObjects(userInfo[@"acked_at"], @"2026-04-28T17:00:06Z");
 
   // The launch-data attribution keys still ride along (in-session

--- a/Automated/AutomatedTests/JwtModeRewardEventsTests.m
+++ b/Automated/AutomatedTests/JwtModeRewardEventsTests.m
@@ -218,18 +218,21 @@
   XCTAssertNil(userInfo[@"teak_reward_id"]);
 }
 
-/// Server bookkeeping fields and the raw `session_attribution` blob are
-/// stripped from the wire reply before the merge — host-game observers see
-/// the unpacked attribution keys (already on the userInfo from the dict
-/// merge) and the documented public-surface fields, not duplicated raw blobs
-/// or server timestamps that aren't part of the contract.
-- (void)testResolvedEventStripsServerBookkeepingAndRawAttributionBlob {
+/// Canonical resolved-event strip set: the redundant wire fields
+/// (`teak_reward_id` — superseded by attribution `teakRewardId`;
+/// `session_attribution` — already unpacked into discrete top-level keys)
+/// are stripped, but server-emitted timing fields (`created_at`,
+/// `completed_at`, `acked_at` when present) ride through onto the userInfo
+/// so host games can render the click→resolve timeline.
+- (void)testResolvedEventStripsRedundantWireFieldsAndKeepsTimingFields {
   NSDictionary* claimStatusReply = @{
     @"event_id" : @"evt-pending-strip-1",
     @"status" : @"completed",
     @"reward" : @{@"gems" : @25},
     @"created_at" : @"2026-04-28T17:00:00Z",
     @"completed_at" : @"2026-04-28T17:00:05Z",
+    @"acked_at" : @"2026-04-28T17:00:06Z",
+    @"teak_reward_id" : @"2048153148060669999",
     @"session_attribution" : @{@"teakNotifId" : @"would-leak-as-raw-blob"},
   };
   TeakAttributedLaunchData* launchData = [self launchDataForNotificationFixture];
@@ -239,9 +242,17 @@
 
   XCTAssertEqualObjects(userInfo[@"event_id"], @"evt-pending-strip-1");
   XCTAssertEqualObjects(userInfo[@"status"], @"completed");
-  XCTAssertNil(userInfo[@"created_at"]);
-  XCTAssertNil(userInfo[@"completed_at"]);
+
+  // Redundant wire fields stripped.
+  XCTAssertNil(userInfo[@"teak_reward_id"]);
   XCTAssertNil(userInfo[@"session_attribution"]);
+
+  // Server-emitted timing surfaced — host games render click→resolve timing
+  // off these fields.
+  XCTAssertEqualObjects(userInfo[@"created_at"], @"2026-04-28T17:00:00Z");
+  XCTAssertEqualObjects(userInfo[@"completed_at"], @"2026-04-28T17:00:05Z");
+  XCTAssertEqualObjects(userInfo[@"acked_at"], @"2026-04-28T17:00:06Z");
+
   // The launch-data attribution keys still ride along (in-session
   // optimization populates them from the host's own state).
   XCTAssertEqualObjects(userInfo[@"teakNotifId"], @"2048153148060669486");

--- a/Automated/AutomatedTests/SessionStartSweepTests.m
+++ b/Automated/AutomatedTests/SessionStartSweepTests.m
@@ -4,9 +4,18 @@
 
 #import "TeakClaimPoll.h"
 #import "TeakLaunchData.h"
+#import "TeakSession.h"
 
 @import OCHamcrest;
 @import OCMockito;
+
+// Re-declare the in-flight claim's testable slots. The class itself is
+// defined privately in TeakClaimPoll.m; the runtime resolves these
+// properties dynamically when the test reads them off a dictionary value.
+@interface TeakInflightClaim : NSObject
+@property (nonatomic, copy, nullable) NSString* clickingUserId;
+@property (nonatomic, copy) NSString* eventId;
+@end
 
 @interface TeakConfiguration : NSObject
 + (BOOL)configureForAppId:(NSString*)appId andSecret:(NSString*)appSecret;
@@ -261,6 +270,42 @@
 }
 
 #pragma mark - Sweep dispatch — session_attribution unpack tolerance
+
+#pragma mark - Sweep dispatch — clicking_user_id capture
+
+/// Sweep enrollment captures the dispatching session's userId onto each
+/// in-flight claim's clicking_user_id slot. Subsequent /claim_status polls
+/// and /claim_ack POSTs for the resurfaced claim read from this captured
+/// value, not from a live session reference at request-send time. This
+/// matches the click-time capture-at-click contract — the user that owned
+/// the click owns the per-claim wire identity for that claim's lifetime.
+- (void)testSweepCapturesClickingUserIdFromSessionOntoEachClaim {
+  TeakSession* mockSession = mock([TeakSession class]);
+  [given([mockSession userId]) willReturn:@"user-sweep-A"];
+
+  NSArray* claims = @[
+    @{
+      @"event_id" : @"evt-sweep-capture-1",
+      @"status" : @"pending",
+      @"session_attribution" : @{@"teakNotifId" : @"2048153148060669486"},
+    },
+    @{
+      @"event_id" : @"evt-sweep-capture-2",
+      @"status" : @"completed",
+      @"reward" : @{@"gems" : @25},
+    },
+  ];
+
+  [TeakClaimPoll dispatchSweptClaims:claims session:mockSession];
+  [self drainMainQueue];
+
+  TeakInflightClaim* pendingClaim = [TeakClaimPoll inflightClaims][@"evt-sweep-capture-1"];
+  TeakInflightClaim* terminalClaim = [TeakClaimPoll inflightClaims][@"evt-sweep-capture-2"];
+  XCTAssertEqualObjects(pendingClaim.clickingUserId, @"user-sweep-A",
+                        @"pending sweep entry must capture clicking_user_id from the dispatching session");
+  XCTAssertEqualObjects(terminalClaim.clickingUserId, @"user-sweep-A",
+                        @"terminal sweep entry must capture clicking_user_id from the dispatching session");
+}
 
 /// session_attribution may arrive as a JSON-encoded string (mirrors the
 /// click-POST mint shape) or as an inline dict. The sweep dispatcher tolerates

--- a/Automated/AutomatedTests/SessionStartSweepTests.m
+++ b/Automated/AutomatedTests/SessionStartSweepTests.m
@@ -116,6 +116,33 @@
   XCTAssertNil(userInfo[@"teak_reward_id"]);
 }
 
+/// /claims (sweep) wire reply carries `created_at` and `completed_at` —
+/// those server-emitted timing fields ride through to the resolved-event
+/// userInfo on the sweep-terminal path so host games can render the
+/// click→resolve timeline. /claim_status (click-time-poll) does not emit
+/// these fields today; the click-time-poll path's strip set is covered in
+/// JwtModeRewardEventsTests.m.
+- (void)testBuildResolvedUserInfoSurfacesTimingFieldsFromClaimsReply {
+  NSDictionary* attribution = @{
+    @"teakNotifId" : @"2048153148060669486",
+    @"teakRewardId" : @"2048153148060669138",
+  };
+  NSDictionary* claimsReply = @{
+    @"event_id" : @"evt-sweep-timing-1",
+    @"status" : @"completed",
+    @"reward" : @{@"gems" : @25},
+    @"created_at" : @"2026-04-28T17:00:00Z",
+    @"completed_at" : @"2026-04-28T17:00:05Z",
+  };
+
+  NSDictionary* userInfo = [TeakClaimPoll buildResolvedUserInfoForReply:claimsReply
+                                                          withAttribution:attribution];
+
+  XCTAssertEqualObjects(userInfo[@"event_id"], @"evt-sweep-timing-1");
+  XCTAssertEqualObjects(userInfo[@"created_at"], @"2026-04-28T17:00:00Z");
+  XCTAssertEqualObjects(userInfo[@"completed_at"], @"2026-04-28T17:00:05Z");
+}
+
 /// Defensive: a nil attribution dict yields the wire reply alone. Mirrors the
 /// nil-launchData defensive case on the click-time helper.
 - (void)testBuildResolvedUserInfoWithNilAttributionReturnsReplyAlone {

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -63,7 +63,7 @@
 /// alone — defensive against an unusual mid-session teardown.
 ///
 /// Key convention: wire reply keys are snake_case (`event_id`, `status`,
-/// `reward`, `customer_response`, `customer_status_code`,
+/// `reward`, `customer_response`, `customer_status_code`, `claim_source`,
 /// `created_at`, `completed_at`, `acked_at`); attribution keys are
 /// teakCamelCase (`teakRewardId`, `teakNotifId`, etc).
 ///

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -63,9 +63,9 @@
 /// alone — defensive against an unusual mid-session teardown.
 ///
 /// Key convention: wire reply keys are snake_case (`event_id`, `status`,
-/// `reward`, `customer_response`, `customer_status_code`, `claim_source`,
-/// `created_at`, `completed_at`, `acked_at`); attribution keys are
-/// teakCamelCase (`teakRewardId`, `teakNotifId`, etc).
+/// `reward`, `customer_response`, `customer_status_code`, `acked_at`, plus
+/// `created_at` / `completed_at` on the sweep-path /claims reply); attribution
+/// keys are teakCamelCase (`teakRewardId`, `teakNotifId`, etc).
 ///
 /// Two wire keys are stripped from the merge:
 ///

--- a/Teak/TeakClaimPoll.h
+++ b/Teak/TeakClaimPoll.h
@@ -63,13 +63,20 @@
 /// alone — defensive against an unusual mid-session teardown.
 ///
 /// Key convention: wire reply keys are snake_case (`event_id`, `status`,
-/// `reward`, `customer_response`, `customer_status_code`, `teak_reward_id`),
-/// attribution keys are teakCamelCase (`teakRewardId`, `teakNotifId`, etc).
-/// They never alias the same logical id at the dict-key level — both
-/// `teakRewardId` (the reward this launch was attributed to, from the URL or
-/// notification payload) and `teak_reward_id` (the reward the server
-/// authoritatively granted on this specific click) can coexist on the
-/// resolved-event userInfo and are distinct fields.
+/// `reward`, `customer_response`, `customer_status_code`,
+/// `created_at`, `completed_at`, `acked_at`); attribution keys are
+/// teakCamelCase (`teakRewardId`, `teakNotifId`, etc).
+///
+/// Two wire keys are stripped from the merge:
+///
+/// * `teak_reward_id` — the wire's authoritative-grant id. Resolved events
+///   surface only the attribution id (`teakRewardId` from launch-data),
+///   matching legacy `TeakOnReward` semantics. Host games that need the
+///   server-authoritative grant id correlate by `event_id` against
+///   `TeakOnRewardJwtIssued` / `TeakOnRewardClaimPending`.
+/// * `session_attribution` — the raw eleven-key blob is unpacked into
+///   discrete top-level attribution keys before this merge; keeping the raw
+///   blob would just duplicate the unpacked surface.
 + (NSDictionary*)buildResolvedUserInfoForReply:(NSDictionary*)reply
                                 withLaunchData:(TeakAttributedLaunchData*)launchData;
 

--- a/Teak/TeakClaimPoll.m
+++ b/Teak/TeakClaimPoll.m
@@ -18,6 +18,13 @@ static const NSUInteger kAckMaxAttempts = 3;
 // Expiring→Active flicker means the poll continues; a replaced session
 // (logout/login, Expired+new) means the entry's reply will be dropped.
 //
+// `clickingUserId` is value-locked at the moment the claim is enrolled — at
+// click-time it's the originating session's userId at click; on the sweep
+// path it's the dispatching session's userId at sweep time. Subsequent
+// /claim_status polls and /claim_ack POSTs read this captured string rather
+// than re-binding to a live session reference; a session that rotates its
+// userId mid-flight does not change the wire identity of the in-flight claim.
+//
 // `attribution` is the eleven-key flat bag (TeakLaunchData.to_h shape) used
 // to populate context on the resolved-event userInfo. The click-time path
 // flattens its launch-data once at start; the session-start sweep unpacks
@@ -28,6 +35,7 @@ static const NSUInteger kAckMaxAttempts = 3;
 @interface TeakInflightClaim : NSObject
 @property (nonatomic, weak) TeakSession* originatingSession;
 @property (nonatomic, copy) NSString* eventId;
+@property (nonatomic, copy, nullable) NSString* clickingUserId;
 @property (nonatomic, copy, nullable) NSDictionary* attribution;
 @property (nonatomic, strong, nullable) NSTimer* nextPollTimer;
 @property (nonatomic, assign) NSUInteger pollAttempt;
@@ -94,18 +102,20 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
 // * `session_attribution` — already unpacked into top-level teakCamelCase
 //   attribution keys before this merge; the raw blob would just duplicate
 //   that on the userInfo.
-// * `created_at`, `completed_at` — server bookkeeping, not part of the
-//   documented public surface.
 // * `teak_reward_id` — the wire's authoritative-grant id. Resolved events
 //   surface only the attribution id (`teakRewardId` from launch-data),
 //   matching the legacy `TeakOnReward` semantics: id is provenance, the
 //   `reward` blob carries the grant content. Host games that need to detect
 //   a proxy-reward substitution read the `reward` blob, not a second id.
+//
+// Server-emitted timing fields (`created_at`, `completed_at`, `acked_at`)
+// are surfaced on the resolved event so host games can render the
+// click→resolve timeline; they're part of the documented public surface.
 + (NSDictionary*)normalizeWireReplyForResolvedEvent:(NSDictionary*)reply {
   static NSSet* stripKeys = nil;
   static dispatch_once_t once;
   dispatch_once(&once, ^{
-    stripKeys = [NSSet setWithObjects:@"session_attribution", @"created_at", @"completed_at", @"teak_reward_id", nil];
+    stripKeys = [NSSet setWithObjects:@"session_attribution", @"teak_reward_id", nil];
   });
 
   NSMutableDictionary* normalized = [NSMutableDictionary dictionaryWithCapacity:reply.count];
@@ -141,6 +151,11 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   }
 
   TeakSession* originatingSession = [TeakSession currentSessionOrNil];
+  // Value-lock the originating session's userId. /claim_status polls and
+  // /claim_ack retries for this claim read off this captured string for the
+  // claim's lifetime — a session that later rotates its userId does not
+  // change the wire identity of an in-flight claim.
+  NSString* clickingUserId = [originatingSession.userId copy];
 
   dispatch_async(dispatch_get_main_queue(), ^{
     NSMutableDictionary* claims = [TeakClaimPoll inflightClaims];
@@ -155,6 +170,7 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
     TeakInflightClaim* claim = [[TeakInflightClaim alloc] init];
     claim.originatingSession = originatingSession;
     claim.eventId = eventId;
+    claim.clickingUserId = clickingUserId;
     claim.attribution = attribution;
     claim.pollAttempt = 0;
     claim.initialDelay = initialDelay;
@@ -277,13 +293,13 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   }
 
   claim.ackAttempt += 1;
-  [TeakClaimPoll sendClaimAckRequestForEventId:eventId
-                                       session:session
-                                    completion:^(BOOL success) {
-                                      dispatch_async(dispatch_get_main_queue(), ^{
-                                        [TeakClaimPoll handleAckResult:success forEventId:eventId session:session];
-                                      });
-                                    }];
+  [TeakClaimPoll sendClaimAckRequestForClaim:claim
+                                     session:session
+                                  completion:^(BOOL success) {
+                                    dispatch_async(dispatch_get_main_queue(), ^{
+                                      [TeakClaimPoll handleAckResult:success forEventId:eventId session:session];
+                                    });
+                                  }];
 }
 
 + (void)handleAckResult:(BOOL)success forEventId:(NSString*)eventId session:(TeakSession*)session {
@@ -334,18 +350,42 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
 
 #pragma mark - Wire calls
 
+// Pure URL builder for the /claim_status GET. Locks the value-at-click
+// contract: callers pass in the captured clicking_user_id, the helper has
+// no awareness of any live session reference.
++ (NSURL*)claimStatusURLForAppId:(NSString*)appId
+                  clickingUserId:(NSString*)clickingUserId
+                         eventId:(NSString*)eventId {
+  NSString* hostname = [NSString stringWithFormat:@"rewards.%@", kTeakHostname];
+  NSURLComponents* components = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"https://%@/claim_status", hostname]];
+  components.queryItems = @[
+    [NSURLQueryItem queryItemWithName:@"teak_app_id" value:appId],
+    [NSURLQueryItem queryItemWithName:@"clicking_user_id" value:clickingUserId],
+    [NSURLQueryItem queryItemWithName:@"event_id" value:eventId],
+  ];
+  return components.URL;
+}
+
+// Pure body builder for the /claim_ack POST. Same value-locked semantics as
+// the /claim_status URL: callers pass the captured clicking_user_id.
++ (NSDictionary*)claimAckPayloadForAppId:(NSString*)appId
+                          clickingUserId:(NSString*)clickingUserId
+                                 eventId:(NSString*)eventId {
+  return @{
+    @"teak_app_id" : appId,
+    @"clicking_user_id" : clickingUserId,
+    @"event_id" : eventId,
+  };
+}
+
 + (void)sendClaimStatusRequestForClaim:(TeakInflightClaim*)claim
                             completion:(void (^)(NSDictionary* reply))completion {
   [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
-    NSString* hostname = [NSString stringWithFormat:@"rewards.%@", kTeakHostname];
-    NSURLComponents* components = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"https://%@/claim_status", hostname]];
-    components.queryItems = @[
-      [NSURLQueryItem queryItemWithName:@"teak_app_id" value:session.appConfiguration.appId],
-      [NSURLQueryItem queryItemWithName:@"clicking_user_id" value:session.userId],
-      [NSURLQueryItem queryItemWithName:@"event_id" value:claim.eventId],
-    ];
+    NSURL* url = [TeakClaimPoll claimStatusURLForAppId:session.appConfiguration.appId
+                                        clickingUserId:claim.clickingUserId
+                                               eventId:claim.eventId];
 
-    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:components.URL];
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url];
     request.HTTPMethod = @"GET";
 
     TeakLog_i(@"claim_poll.request.send", @{@"event_id" : claim.eventId});
@@ -370,26 +410,25 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   }];
 }
 
-+ (void)sendClaimAckRequestForEventId:(NSString*)eventId
-                              session:(TeakSession*)session
-                           completion:(void (^)(BOOL success))completion {
++ (void)sendClaimAckRequestForClaim:(TeakInflightClaim*)claim
+                            session:(TeakSession*)session
+                         completion:(void (^)(BOOL success))completion {
   NSString* hostname = [NSString stringWithFormat:@"rewards.%@", kTeakHostname];
   NSURLComponents* components = [NSURLComponents componentsWithString:[NSString stringWithFormat:@"https://%@/claim_ack", hostname]];
 
-  NSDictionary* payload = @{
-    @"teak_app_id" : session.appConfiguration.appId,
-    @"clicking_user_id" : session.userId,
-    @"event_id" : eventId,
-  };
+  NSDictionary* payload = [TeakClaimPoll claimAckPayloadForAppId:session.appConfiguration.appId
+                                                  clickingUserId:claim.clickingUserId
+                                                         eventId:claim.eventId];
 
   NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:components.URL];
   request.HTTPMethod = @"POST";
   request.HTTPBody = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
   [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
 
-  TeakLog_i(@"claim_ack.request.send", @{@"event_id" : eventId});
+  TeakLog_i(@"claim_ack.request.send", @{@"event_id" : claim.eventId});
 
   NSURLSession* urlSession = [Teak URLSessionWithoutDelegate];
+  NSString* eventId = claim.eventId;
   NSURLSessionDataTask* task = [urlSession dataTaskWithRequest:request
                                              completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
                                                BOOL ok = NO;
@@ -439,6 +478,12 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
   NSTimeInterval initialDelay = remoteConfig != nil ? remoteConfig.claimPollInitialDelay : [TeakRemoteConfiguration defaultClaimPollInitialDelay];
   NSTimeInterval ceiling = remoteConfig != nil ? remoteConfig.claimPollCeiling : [TeakRemoteConfiguration defaultClaimPollCeiling];
 
+  // Capture the dispatching session's userId once. /claims returns only the
+  // unacked claims for this user, so every entry in this batch belongs to
+  // the same clicking_user_id; subsequent /claim_status polls and
+  // /claim_ack POSTs read from this captured value.
+  NSString* clickingUserId = [session.userId copy];
+
   for (id rawEntry in claims) {
     if (![rawEntry isKindOfClass:[NSDictionary class]]) {
       TeakLog_i(@"claim_sweep.entry.skipped", @{@"reason" : @"not_a_dict"});
@@ -464,6 +509,7 @@ static NSMutableDictionary<NSString*, TeakInflightClaim*>* sInflightClaims = nil
     TeakInflightClaim* claim = [[TeakInflightClaim alloc] init];
     claim.originatingSession = session;
     claim.eventId = eventId;
+    claim.clickingUserId = clickingUserId;
     claim.attribution = attribution;
     claim.pollAttempt = 0;
     claim.initialDelay = initialDelay;


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-722
Closes https://linear.app/teakio/issue/C-724

## Summary

Two CEO-folded fixes to the click-time JWT-claim flow, both grounded in `ProductOps/State/wire_format.md` (drafted today):

- **C-722** — `clicking_user_id` is now value-locked on the in-flight claim at the moment the claim is enrolled (originating session's `userId` at click-time; dispatching session's `userId` at sweep-enrollment). `/claim_status` polls and `/claim_ack` retries read from the captured string, so a session `userId` rotation mid-flight no longer changes the wire identity of an in-flight claim.
- **C-724** — `TeakOnRewardClaimResolved` userInfo aligned to the canonical strip set: only the redundant wire keys (`teak_reward_id`, `session_attribution`) are stripped; `created_at`, `completed_at`, and `acked_at` ride through onto the userInfo so host games can render the click→resolve timeline. Eleven-key attribution unpack (already wired up by C-699) is unchanged.

## Key decisions

- Pure helpers `+claimStatusURLForAppId:clickingUserId:eventId:` and `+claimAckPayloadForAppId:clickingUserId:eventId:` are the seam that locks the value-at-click contract — tests assert the contract there without mocking NSURLSession. Send sites read `claim.clickingUserId` and pass it through.
- `+sendClaimAckRequest...` takes the claim object directly now (was: `eventId` + `session`), so the captured `clickingUserId` flows naturally without extra dictionary lookups in the wire code.
- `/claims` sweep request itself still uses `session.userId` per Surface 4 of the wire-format spec (sweep is per-current-user); only per-claim `/claim_status` and `/claim_ack` derive from the captured value.

## Test plan

- `bundle exec fastlane test` — 177 tests, 0 failures
- New tests:
  - `ClaimStatusPollTests::testClaimStatusURLUsesGivenClickingUserId` / `testClaimAckPayloadUsesGivenClickingUserId` — pure helpers carry the value passed in (no late binding)
  - `ClaimStatusPollTests::testStartPollCapturesClickingUserIdSlotOnInflightClaim` — start-poll records the captured slot
  - `SessionStartSweepTests::testSweepCapturesClickingUserIdFromSessionOntoEachClaim` — sweep enrollment captures `session.userId` per-entry via OCMockito-stubbed TeakSession
- Updated:
  - `JwtModeRewardEventsTests::testResolvedEventStripsRedundantWireFieldsAndKeepsTimingFields` (was `…StripsServerBookkeepingAndRawAttributionBlob`) — flips `created_at` / `completed_at` / `acked_at` from stripped to surfaced; pins `teak_reward_id` + `session_attribution` strip

## Readers left behind

None. The doc-comment on `Teak.h::TeakOnRewardClaimResolved` already correctly describes the strip semantics; only `TeakClaimPoll`'s internal comments and the strip-set helper changed.