### PR TITLE
feat(C-683): auto-add TeakLog events as Sentry breadcrumbs

### DIFF
--- a/Automated/AutomatedTests/LogTests.m
+++ b/Automated/AutomatedTests/LogTests.m
@@ -19,6 +19,10 @@
 @implementation LogTests
 
 - (void)setUp {
+  while ([TeakRavenLocationHelper peekHelper] != nil) {
+    [TeakRavenLocationHelper popHelper];
+  }
+
   self.teakMock = mock([Teak class]);
   [given([self.teakMock enableRemoteLogging]) willReturn:@NO];
   [given([self.teakMock enableDebugOutput]) willReturn:@NO];
@@ -50,9 +54,9 @@
 
   assertThat(helper.breadcrumbs, hasCountOf(1));
   NSDictionary* breadcrumb = helper.breadcrumbs[0];
-  assertThat(breadcrumb[@"category"], is(@"INFO"));
-  assertThat(breadcrumb[@"message"], is(@"test.breadcrumb"));
+  assertThat(breadcrumb[@"category"], is(@"test.breadcrumb"));
   assertThat(breadcrumb[@"data"][@"key"], is(@"value"));
+  assertThat(breadcrumb[@"data"][@"log_level"], is(@"INFO"));
 }
 
 - (void)testLogEventOutsideTryDoesNotCrash {
@@ -64,12 +68,14 @@
   TeakRavenLocationHelper* helper = [TeakRavenLocationHelper pushHelperForFile:__FILE__ line:__LINE__ function:__PRETTY_FUNCTION__];
 
   for (int i = 0; i < 110; i++) {
-    [self.log logEvent:@"test.volume" level:@"INFO" eventData:@{}];
+    [self.log logEvent:@"test.volume" level:@"INFO" eventData:@{@"i" : @(i)}];
   }
 
   [TeakRavenLocationHelper popHelper];
 
   assertThat(helper.breadcrumbs, hasCountOf(100));
+  // Oldest-kept entry is event index 10 (events 0–9 were evicted); verifies FIFO eviction.
+  assertThat(helper.breadcrumbs[0][@"data"][@"i"], equalTo(@10));
 }
 
 @end

--- a/Automated/AutomatedTests/LogTests.m
+++ b/Automated/AutomatedTests/LogTests.m
@@ -1,10 +1,15 @@
 #import <XCTest/XCTest.h>
 
 #import "TeakLog.h"
+#import "TeakRaven.h"
 #import <Teak/Teak.h>
 
 @import OCHamcrest;
 @import OCMockito;
+
+@interface TeakRavenLocationHelper (LogTestAccess)
+@property (strong, nonatomic) NSMutableArray* breadcrumbs;
+@end
 
 @interface LogTests : XCTestCase
 @property (strong, nonatomic) TeakLog* log;
@@ -34,6 +39,37 @@
                });
   [self.log logEvent:@"test" level:@"INFO" eventData:@{}];
   assertThat(listenerCalled, is(@YES));
+}
+
+- (void)testLogEventAddsBreadcrumbToActiveHelper {
+  TeakRavenLocationHelper* helper = [TeakRavenLocationHelper pushHelperForFile:__FILE__ line:__LINE__ function:__PRETTY_FUNCTION__];
+
+  [self.log logEvent:@"test.breadcrumb" level:@"INFO" eventData:@{@"key" : @"value"}];
+
+  [TeakRavenLocationHelper popHelper];
+
+  assertThat(helper.breadcrumbs, hasCountOf(1));
+  NSDictionary* breadcrumb = helper.breadcrumbs[0];
+  assertThat(breadcrumb[@"category"], is(@"INFO"));
+  assertThat(breadcrumb[@"message"], is(@"test.breadcrumb"));
+  assertThat(breadcrumb[@"data"][@"key"], is(@"value"));
+}
+
+- (void)testLogEventOutsideTryDoesNotCrash {
+  XCTAssertNil([TeakRavenLocationHelper peekHelper]);
+  XCTAssertNoThrow([self.log logEvent:@"test.no.helper" level:@"INFO" eventData:@{}]);
+}
+
+- (void)testBreadcrumbCapAt100 {
+  TeakRavenLocationHelper* helper = [TeakRavenLocationHelper pushHelperForFile:__FILE__ line:__LINE__ function:__PRETTY_FUNCTION__];
+
+  for (int i = 0; i < 110; i++) {
+    [self.log logEvent:@"test.volume" level:@"INFO" eventData:@{}];
+  }
+
+  [TeakRavenLocationHelper popHelper];
+
+  assertThat(helper.breadcrumbs, hasCountOf(100));
 }
 
 @end

--- a/Automated/AutomatedTests/LogTests.m
+++ b/Automated/AutomatedTests/LogTests.m
@@ -7,10 +7,6 @@
 @import OCHamcrest;
 @import OCMockito;
 
-@interface TeakRavenLocationHelper (LogTestAccess)
-@property (strong, nonatomic) NSMutableArray* breadcrumbs;
-@end
-
 @interface LogTests : XCTestCase
 @property (strong, nonatomic) TeakLog* log;
 @property (strong, nonatomic) Teak* teakMock;
@@ -19,6 +15,7 @@
 @implementation LogTests
 
 - (void)setUp {
+  [[TeakRavenLocationHelper sharedBreadcrumbs] removeAllObjects];
   while ([TeakRavenLocationHelper peekHelper] != nil) {
     [TeakRavenLocationHelper popHelper];
   }
@@ -45,15 +42,12 @@
   assertThat(listenerCalled, is(@YES));
 }
 
-- (void)testLogEventAddsBreadcrumbToActiveHelper {
-  TeakRavenLocationHelper* helper = [TeakRavenLocationHelper pushHelperForFile:__FILE__ line:__LINE__ function:__PRETTY_FUNCTION__];
-
+- (void)testLogEventAddsBreadcrumb {
   [self.log logEvent:@"test.breadcrumb" level:@"INFO" eventData:@{@"key" : @"value"}];
 
-  [TeakRavenLocationHelper popHelper];
-
-  assertThat(helper.breadcrumbs, hasCountOf(1));
-  NSDictionary* breadcrumb = helper.breadcrumbs[0];
+  NSMutableArray* breadcrumbs = [TeakRavenLocationHelper sharedBreadcrumbs];
+  assertThat(breadcrumbs, hasCountOf(1));
+  NSDictionary* breadcrumb = breadcrumbs[0];
   assertThat(breadcrumb[@"category"], is(@"test.breadcrumb"));
   assertThat(breadcrumb[@"data"][@"key"], is(@"value"));
   assertThat(breadcrumb[@"data"][@"log_level"], is(@"INFO"));
@@ -65,17 +59,14 @@
 }
 
 - (void)testBreadcrumbCapAt100 {
-  TeakRavenLocationHelper* helper = [TeakRavenLocationHelper pushHelperForFile:__FILE__ line:__LINE__ function:__PRETTY_FUNCTION__];
-
   for (int i = 0; i < 110; i++) {
     [self.log logEvent:@"test.volume" level:@"INFO" eventData:@{@"i" : @(i)}];
   }
 
-  [TeakRavenLocationHelper popHelper];
-
-  assertThat(helper.breadcrumbs, hasCountOf(100));
+  NSMutableArray* breadcrumbs = [TeakRavenLocationHelper sharedBreadcrumbs];
+  assertThat(breadcrumbs, hasCountOf(100));
   // Oldest-kept entry is event index 10 (events 0–9 were evicted); verifies FIFO eviction.
-  assertThat(helper.breadcrumbs[0][@"data"][@"i"], equalTo(@10));
+  assertThat(breadcrumbs[0][@"data"][@"i"], equalTo(@10));
 }
 
 @end

--- a/Teak/TeakLog.m
+++ b/Teak/TeakLog.m
@@ -217,6 +217,8 @@ __attribute__((overloadable)) void TeakLog_i(NSString* eventType, NSString* mess
       NSLog(@"Teak: %@", jsonString);
     }
   }
+
+  [[TeakRavenLocationHelper peekHelper] addBreadcrumb:logLevel message:eventType data:eventData file:__FILE__ line:__LINE__];
 }
 @end
 

--- a/Teak/TeakLog.m
+++ b/Teak/TeakLog.m
@@ -218,7 +218,9 @@ __attribute__((overloadable)) void TeakLog_i(NSString* eventType, NSString* mess
     }
   }
 
-  [[TeakRavenLocationHelper peekHelper] addBreadcrumb:logLevel message:eventType data:eventData file:__FILE__ line:__LINE__];
+  NSMutableDictionary* breadcrumbData = [NSMutableDictionary dictionaryWithDictionary:eventData == nil ? @{} : eventData];
+  breadcrumbData[@"log_level"] = logLevel;
+  [[TeakRavenLocationHelper peekHelper] addBreadcrumb:eventType message:nil data:breadcrumbData file:__FILE__ line:__LINE__];
 }
 @end
 

--- a/Teak/TeakLog.m
+++ b/Teak/TeakLog.m
@@ -220,7 +220,7 @@ __attribute__((overloadable)) void TeakLog_i(NSString* eventType, NSString* mess
 
   NSMutableDictionary* breadcrumbData = [NSMutableDictionary dictionaryWithDictionary:eventData == nil ? @{} : eventData];
   breadcrumbData[@"log_level"] = logLevel;
-  [[TeakRavenLocationHelper peekHelper] addBreadcrumb:eventType message:nil data:breadcrumbData file:__FILE__ line:__LINE__];
+  [TeakRavenLocationHelper addBreadcrumb:eventType message:nil data:breadcrumbData file:__FILE__ line:__LINE__];
 }
 @end
 

--- a/Teak/TeakRaven.h
+++ b/Teak/TeakRaven.h
@@ -13,6 +13,9 @@ extern NSString* _Nonnull const TeakRavenLevelFatal;
 + (nullable TeakRavenLocationHelper*)popHelper;
 + (nullable TeakRavenLocationHelper*)peekHelper;
 
++ (void)addBreadcrumb:(nonnull NSString*)category message:(nullable NSString*)message data:(nullable NSDictionary*)data file:(const char* _Nonnull)file line:(int)line;
++ (nonnull NSMutableArray*)sharedBreadcrumbs;
+
 - (void)addBreadcrumb:(nonnull NSString*)category message:(nullable NSString*)message data:(nullable NSDictionary*)data file:(const char* _Nonnull)file line:(int)line;
 
 @end

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -580,6 +580,10 @@ void TeakSignalHandler(int signal) {
   if (message != nil) [breadcrumb setValue:message forKey:@"message"];
 
   [self.breadcrumbs addObject:breadcrumb];
+
+  if ([self.breadcrumbs count] > 100) {
+    [self.breadcrumbs removeObjectAtIndex:0];
+  }
 }
 
 @end

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -23,7 +23,7 @@ extern bool AmIBeingDebugged(void);
 @property (strong, nonatomic) NSString* file;
 @property (strong, nonatomic) NSNumber* line;
 @property (strong, nonatomic) NSString* function;
-@property (strong, nonatomic) NSMutableArray* breadcrumbs;
++ (dispatch_queue_t)breadcrumbQueue;
 @end
 
 @interface TeakRaven ()
@@ -176,7 +176,11 @@ void TeakSignalHandler(int signal) {
       }
     ]
   }];
-  if (helper.breadcrumbs != nil) additions[@"breadcrumbs"] = helper.breadcrumbs;
+  __block NSArray* breadcrumbSnapshot = nil;
+  dispatch_sync([TeakRavenLocationHelper breadcrumbQueue], ^{
+    breadcrumbSnapshot = [[TeakRavenLocationHelper sharedBreadcrumbs] copy];
+  });
+  if (breadcrumbSnapshot.count > 0) additions[@"breadcrumbs"] = breadcrumbSnapshot;
 
   TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:self
                                                             level:TeakRavenLevelError
@@ -562,9 +566,25 @@ void TeakSignalHandler(int signal) {
   return self;
 }
 
-- (void)addBreadcrumb:(nonnull NSString*)category message:(NSString*)message data:(NSDictionary*)data file:(const char*)file line:(int)line {
-  if (self.breadcrumbs == nil) self.breadcrumbs = [[NSMutableArray alloc] init];
++ (dispatch_queue_t)breadcrumbQueue {
+  static dispatch_queue_t queue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    queue = dispatch_queue_create("io.teak.breadcrumbs", DISPATCH_QUEUE_SERIAL);
+  });
+  return queue;
+}
 
++ (NSMutableArray*)sharedBreadcrumbs {
+  static NSMutableArray* breadcrumbs;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    breadcrumbs = [[NSMutableArray alloc] init];
+  });
+  return breadcrumbs;
+}
+
++ (void)addBreadcrumb:(nonnull NSString*)category message:(NSString*)message data:(NSDictionary*)data file:(const char*)file line:(int)line {
   NSMutableDictionary* fullData = [NSMutableDictionary dictionaryWithDictionary:@{
     @"file" : [NSString stringWithUTF8String:(strrchr(file, '/') ?: file - 1) + 1],
     @"line" : [NSNumber numberWithInt:line]
@@ -576,16 +596,20 @@ void TeakSignalHandler(int signal) {
     @"category" : category == nil ? @"unknown" : category,
     @"data" : fullData
   }];
-
   if (message != nil) [breadcrumb setValue:message forKey:@"message"];
 
-  static const NSUInteger kTeakBreadcrumbCapacity = 100;
+  dispatch_sync([TeakRavenLocationHelper breadcrumbQueue], ^{
+    static const NSUInteger kTeakBreadcrumbCapacity = 100;
+    NSMutableArray* breadcrumbs = [TeakRavenLocationHelper sharedBreadcrumbs];
+    [breadcrumbs addObject:breadcrumb];
+    if ([breadcrumbs count] > kTeakBreadcrumbCapacity) {
+      [breadcrumbs removeObjectAtIndex:0];
+    }
+  });
+}
 
-  [self.breadcrumbs addObject:breadcrumb];
-
-  if ([self.breadcrumbs count] > kTeakBreadcrumbCapacity) {
-    [self.breadcrumbs removeObjectAtIndex:0];
-  }
+- (void)addBreadcrumb:(nonnull NSString*)category message:(NSString*)message data:(NSDictionary*)data file:(const char*)file line:(int)line {
+  [TeakRavenLocationHelper addBreadcrumb:category message:message data:data file:file line:line];
 }
 
 @end

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -579,9 +579,11 @@ void TeakSignalHandler(int signal) {
 
   if (message != nil) [breadcrumb setValue:message forKey:@"message"];
 
+  static const NSUInteger kTeakBreadcrumbCapacity = 100;
+
   [self.breadcrumbs addObject:breadcrumb];
 
-  if ([self.breadcrumbs count] > 100) {
+  if ([self.breadcrumbs count] > kTeakBreadcrumbCapacity) {
     [self.breadcrumbs removeObjectAtIndex:0];
   }
 }


### PR DESCRIPTION
Closes https://linear.app/teakio/issue/C-683/ios-sdk-auto-add-teaklog-events-as-sentry-breadcrumbs

## Summary
- Sentry reports were missing most SDK context because TeakLog_i/TeakLog_e events never appeared as breadcrumbs — only a handful of manually-placed `teak_log_breadcrumb` macro calls did.
- `logEvent:level:eventData:` now adds every event to a session-scoped global breadcrumb store on `TeakRavenLocationHelper`. Works whether or not a `teak_try` scope is active.
- `reportWithHelper:` snapshots the store at report time (via the same serial queue) and includes it in the Sentry payload. Breadcrumbs are not cleared after send — the next exception sees full history.
- Store is bounded at 100 entries (FIFO) to match Sentry's default and keep memory bounded.

## Key decisions
- **Global store, not per-helper:** breadcrumbs accumulate across the entire session so Sentry sees history leading up to a crash, not just events inside one `teak_try` block.
- **Serial dispatch queue (`io.teak.breadcrumbs`):** all array mutations and snapshot reads are serialized on a dedicated queue; dict is built on the caller's thread so the timestamp is captured at call time.
- **`eventType` as Sentry `category`** (e.g. `configuration.device`, `request.send`) — gives useful Sentry groupings. `log_level` is preserved in the data dict.

## Test plan
Three unit tests in `LogTests.m`: breadcrumb lands in the global store with correct category/data; no crash when called outside a `teak_try` scope; cap holds at 100 after 110 events with FIFO eviction verified. All pass: `bundle exec fastlane test`.

## Follow-up scope
- Existing `teak_log_breadcrumb` macro call sites (TeakLink.m, TeakRequest.m, SKPaymentObserver.m) are now redundant — they still write to the global store via the instance method, but the same events go through TeakLog anyway. Flagged for follow-up cleanup.