### PR TITLE
fix(C-615): capture session under lock in deferred whenUserIdIsReady callbacks

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		43B4618F22A1EB54004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619922A20FDC004AC636 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4618E22A1EB54004AC636 /* AdSupport.framework */; };
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
+		440EB1A255029FAF5B1ACEB9 /* TeakSessionDeferredCallbackTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2286E8051950D4EC6E1C79EF /* TeakSessionDeferredCallbackTests.m */; };
 		55AAEB0EF3B9E90616642C8E /* LiveActivityUpdateSchedulingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 741732706353CEBB41D0AE37 /* LiveActivityUpdateSchedulingTests.m */; };
 		67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */; };
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
@@ -97,6 +98,7 @@
 		068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRequestResponseParsingTests.m; sourceTree = "<group>"; };
 		0D7BD679E00A2C57BE7AA5E3 /* Pods-AutomatedUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.release.xcconfig"; sourceTree = "<group>"; };
 		12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakDeviceConfigurationTests.m; sourceTree = "<group>"; };
+		2286E8051950D4EC6E1C79EF /* TeakSessionDeferredCallbackTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakSessionDeferredCallbackTests.m; sourceTree = "<group>"; };
 		2CC8154D37CB560E22904A43 /* Pods-AutomatedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3FFF5A9E3FBB614BDDAF98EC /* Pods-Automated.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.release.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.release.xcconfig"; sourceTree = "<group>"; };
 		433392902654423400B10DE4 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
@@ -261,6 +263,7 @@
 				068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */,
 				F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */,
 				EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */,
+				2286E8051950D4EC6E1C79EF /* TeakSessionDeferredCallbackTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -591,6 +594,7 @@
 				AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */,
 				20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */,
 				01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */,
+				440EB1A255029FAF5B1ACEB9 /* TeakSessionDeferredCallbackTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakSessionDeferredCallbackTests.m
+++ b/Automated/AutomatedTests/TeakSessionDeferredCallbackTests.m
@@ -27,18 +27,20 @@ extern TeakSession* currentSession;
   [super tearDown];
 }
 
-// C-615: the deferred callback must run with the session that was current when
-// it was *enqueued*, not whatever currentSession points at when the async block
-// finally fires. Before the fix the block re-read the currentSession global
-// after the @synchronized(currentSessionMutex) lock had been released, racing
-// with reassignment — an unsynchronized objc_retain of the strong global that
-// over-released the session and crashed a later access.
+// Enforces the capture invariant for the deferred callbacks
+// (whenUserIdIsReadyRun: / whenUserIdIsOrWasReadyRun:): the callback must run
+// with the session that was current when it was *enqueued*, not whatever
+// currentSession points at when the async block later fires. The session has to
+// be captured under @synchronized(currentSessionMutex); reading the
+// currentSession global from inside the async block reads it after the lock is
+// released, racing an unsynchronized retain of the strong global against
+// reassignment (C-615).
 //
-// This loops because it documents capture semantics rather than reproducing the
-// data race: the fixed code passes deterministically every iteration, while the
-// old re-read-the-global pattern almost always loses the race against the swap
-// below and is caught well within the iteration count. A true crash repro needs
-// ThreadSanitizer, which this project's schemes don't enable.
+// The loop documents the invariant rather than reproducing the race: a
+// capturing implementation passes deterministically, while one that re-reads
+// the global fails because the swap below almost always wins the race against
+// the async wakeup. A true race repro needs ThreadSanitizer, which this
+// project's schemes don't enable.
 - (void)assertDeferredCaptureConfiguring:(void (^)(TeakSession*))configureSession
                                  enqueue:(void (^)(UserIdReadyBlock))enqueue {
   for (NSUInteger i = 0; i < 256; i++) {
@@ -55,9 +57,9 @@ extern TeakSession* currentSession;
       [ran fulfill];
     });
 
-    // Swap the global out from under the just-enqueued callback. The fixed code
-    // captured `enqueued` under the lock; the buggy code re-reads the global
-    // here and hands the callback `replacement` instead.
+    // Swap the global out from under the just-enqueued callback. A callback that
+    // captured the session under the lock still sees `enqueued`; one that
+    // re-reads the global here would see `replacement` instead.
     currentSession = replacement;
 
     [self waitForExpectations:@[ ran ] timeout:2.0];

--- a/Automated/AutomatedTests/TeakSessionDeferredCallbackTests.m
+++ b/Automated/AutomatedTests/TeakSessionDeferredCallbackTests.m
@@ -12,6 +12,11 @@
 // standing up a real session (which performs network I/O at init).
 extern TeakSession* currentSession;
 
+// previousState is internal; re-expose it so the OrWas Expiring gate can be stubbed.
+@interface TeakSession (Testing)
+@property (strong, nonatomic) TeakState* previousState;
+@end
+
 @interface TeakSessionDeferredCallbackTests : XCTestCase
 @end
 
@@ -34,10 +39,11 @@ extern TeakSession* currentSession;
 // old re-read-the-global pattern almost always loses the race against the swap
 // below and is caught well within the iteration count. A true crash repro needs
 // ThreadSanitizer, which this project's schemes don't enable.
-- (void)assertDeferredCaptureFor:(void (^)(UserIdReadyBlock))enqueue {
+- (void)assertDeferredCaptureConfiguring:(void (^)(TeakSession*))configureSession
+                                 enqueue:(void (^)(UserIdReadyBlock))enqueue {
   for (NSUInteger i = 0; i < 256; i++) {
     TeakSession* enqueued = mock([TeakSession class]);
-    [given([enqueued currentState]) willReturn:[TeakSession UserIdentified]];
+    configureSession(enqueued);
     TeakSession* replacement = mock([TeakSession class]);
 
     currentSession = enqueued;
@@ -62,15 +68,33 @@ extern TeakSession* currentSession;
 }
 
 - (void)testWhenUserIdIsReadyRunCapturesSessionAtEnqueue {
-  [self assertDeferredCaptureFor:^(UserIdReadyBlock block) {
-    [TeakSession whenUserIdIsReadyRun:block];
-  }];
+  [self assertDeferredCaptureConfiguring:^(TeakSession* session) {
+    [given([session currentState]) willReturn:[TeakSession UserIdentified]];
+  }
+      enqueue:^(UserIdReadyBlock block) {
+        [TeakSession whenUserIdIsReadyRun:block];
+      }];
 }
 
 - (void)testWhenUserIdIsOrWasReadyRunCapturesSessionAtEnqueue {
-  [self assertDeferredCaptureFor:^(UserIdReadyBlock block) {
-    [TeakSession whenUserIdIsOrWasReadyRun:block];
-  }];
+  [self assertDeferredCaptureConfiguring:^(TeakSession* session) {
+    [given([session currentState]) willReturn:[TeakSession UserIdentified]];
+  }
+      enqueue:^(UserIdReadyBlock block) {
+        [TeakSession whenUserIdIsOrWasReadyRun:block];
+      }];
+}
+
+// Exercises whenUserIdIsOrWasReadyRun:'s own gate — Expiring with a previous
+// UserIdentified state — which the UserIdentified cases above don't reach.
+- (void)testWhenUserIdIsOrWasReadyRunCapturesSessionWhileExpiring {
+  [self assertDeferredCaptureConfiguring:^(TeakSession* session) {
+    [given([session currentState]) willReturn:[TeakSession Expiring]];
+    [given([session previousState]) willReturn:[TeakSession UserIdentified]];
+  }
+      enqueue:^(UserIdReadyBlock block) {
+        [TeakSession whenUserIdIsOrWasReadyRun:block];
+      }];
 }
 
 @end

--- a/Automated/AutomatedTests/TeakSessionDeferredCallbackTests.m
+++ b/Automated/AutomatedTests/TeakSessionDeferredCallbackTests.m
@@ -1,0 +1,76 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakSession.h"
+#import "TeakState.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// The session pointer that whenUserIdIsReadyRun: / whenUserIdIsOrWasReadyRun:
+// read. It has external linkage, so the test can drive it directly without
+// standing up a real session (which performs network I/O at init).
+extern TeakSession* currentSession;
+
+@interface TeakSessionDeferredCallbackTests : XCTestCase
+@end
+
+@implementation TeakSessionDeferredCallbackTests
+
+- (void)tearDown {
+  currentSession = nil;
+  [super tearDown];
+}
+
+// C-615: the deferred callback must run with the session that was current when
+// it was *enqueued*, not whatever currentSession points at when the async block
+// finally fires. Before the fix the block re-read the currentSession global
+// after the @synchronized(currentSessionMutex) lock had been released, racing
+// with reassignment — an unsynchronized objc_retain of the strong global that
+// over-released the session and crashed a later access.
+//
+// This loops because it documents capture semantics rather than reproducing the
+// data race: the fixed code passes deterministically every iteration, while the
+// old re-read-the-global pattern almost always loses the race against the swap
+// below and is caught well within the iteration count. A true crash repro needs
+// ThreadSanitizer, which this project's schemes don't enable.
+- (void)assertDeferredCaptureFor:(void (^)(UserIdReadyBlock))enqueue {
+  for (NSUInteger i = 0; i < 256; i++) {
+    TeakSession* enqueued = mock([TeakSession class]);
+    [given([enqueued currentState]) willReturn:[TeakSession UserIdentified]];
+    TeakSession* replacement = mock([TeakSession class]);
+
+    currentSession = enqueued;
+
+    XCTestExpectation* ran = [self expectationWithDescription:@"deferred callback ran"];
+    __block TeakSession* received = nil;
+    enqueue(^(TeakSession* session) {
+      received = session;
+      [ran fulfill];
+    });
+
+    // Swap the global out from under the just-enqueued callback. The fixed code
+    // captured `enqueued` under the lock; the buggy code re-reads the global
+    // here and hands the callback `replacement` instead.
+    currentSession = replacement;
+
+    [self waitForExpectations:@[ ran ] timeout:2.0];
+    XCTAssertEqual(received, enqueued,
+                   @"iteration %lu: callback saw a session swapped in after enqueue",
+                   (unsigned long)i);
+  }
+}
+
+- (void)testWhenUserIdIsReadyRunCapturesSessionAtEnqueue {
+  [self assertDeferredCaptureFor:^(UserIdReadyBlock block) {
+    [TeakSession whenUserIdIsReadyRun:block];
+  }];
+}
+
+- (void)testWhenUserIdIsOrWasReadyRunCapturesSessionAtEnqueue {
+  [self assertDeferredCaptureFor:^(UserIdReadyBlock block) {
+    [TeakSession whenUserIdIsOrWasReadyRun:block];
+  }];
+}
+
+@end

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -105,8 +105,12 @@ DefineTeakState(Expired, (@[]));
 + (void)whenUserIdIsReadyRun:(nonnull UserIdReadyBlock)block {
   @synchronized(currentSessionMutex) {
     if (currentSession != nil && currentSession.currentState == [TeakSession UserIdentified]) {
+      // Bind to a local so the async block captures the session that was current
+      // under the lock. Reading the currentSession global from inside the block
+      // would re-read it after the lock is released, racing with reassignment.
+      TeakSession* session = currentSession;
       dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        block(currentSession);
+        block(session);
       });
     } else {
       [[TeakSession whenUserIdIsReadyRunBlocks] addObject:[block copy]];
@@ -119,8 +123,12 @@ DefineTeakState(Expired, (@[]));
     if (currentSession != nil && (currentSession.currentState == [TeakSession UserIdentified] ||
                                   (currentSession.currentState == [TeakSession Expiring] &&
                                    currentSession.previousState == [TeakSession UserIdentified]))) {
+      // Bind to a local so the async block captures the session that was current
+      // under the lock. Reading the currentSession global from inside the block
+      // would re-read it after the lock is released, racing with reassignment.
+      TeakSession* session = currentSession;
       dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        block(currentSession);
+        block(session);
       });
     } else {
       [[TeakSession whenUserIdIsReadyRunBlocks] addObject:[block copy]];

--- a/docs/modules/changelog/versions/4.3.13.yaml
+++ b/docs/modules/changelog/versions/4.3.13.yaml
@@ -1,0 +1,2 @@
+bug:
+  - "Fixed a rare multi-threaded crash (``EXC_BAD_ACCESS`` in ``+[TeakSession whenUserIdIsReadyRun:]``) where a deferred callback could retain a session that was being replaced on another thread. The callback now captures the session that was current when it was queued."


### PR DESCRIPTION
## C-615 — investigate iOS crash

Linear: https://linear.app/teakio/issue/c-615

### Symptom
Kitchen Scramble (com.disney.kitchenscramble 11.2.26/229) reports ~4–6 iOS crashes/day. The Crashlytics report:

```
Crashed: io.teak.sdk.eventProcessingQueue
0  libobjc.A.dylib   objc_retain_x0
1  libobjc.A.dylib   objc_retain
2  +[TeakSession whenUserIdIsReadyRun:]
3  -[TeakCore handleEvent:]
4  __23+[TeakEvent postEvent:]_block_invoke
```

EXC_BAD_ACCESS in `objc_retain` — retaining a freed object reached through `whenUserIdIsReadyRun:`.

### Root cause
`currentSession` is a `__strong` **file-global**. The two deferred callbacks dispatched `^{ block(currentSession); }`. Blocks don't capture globals by value — they reference the global directly, so the retain happened when the block **executed**: on a global concurrent queue, *after* `@synchronized(currentSessionMutex)` had been released.

That unsynchronized `objc_retain` of the strong global races with `currentSession = newSession` (which `objc_release`s the old value) on session reassignment/expiry — a textbook ARC strong-variable data race. It over-releases the session, leaving the global dangling; the next synchronous read in `whenUserIdIsReadyRun:` then crashes in `objc_retain`. The narrow window matches the low, steady crash rate.

### The audit (this is the proof — there's no deterministic repro)
Line numbers below are on this branch's HEAD (after the patch comments).

**Writes to the global — all 3 under `@synchronized(currentSessionMutex)`:**
- `TeakSession.m:533` `logoutReusingCurrentSession:`
- `TeakSession.m:607` `didLaunchWithData:`
- `TeakSession.m:629` `+currentSession`

No setter, no `&currentSession`, no writer outside the file, none using `@synchronized(self)` or no lock. Because every write is under the mutex, copying the global into a strong local under that same lock genuinely closes the race — it doesn't just relocate it.

**Reads from a deferred/async context — only 2, both patched here:**
- `whenUserIdIsReadyRun:` (the async `block(currentSession)` was at :109, now `block(session)` at :113)
- `whenUserIdIsOrWasReadyRun:` (was :123, now :131)

The third async block (`whenDeviceIsAwakeRun:`) calls `block()` and reads no global; the `setState:` drain at :797 passes `block(self)`; every other read of `currentSession` is synchronous and already inside `@synchronized(currentSessionMutex)`.

Confirmed present on `4.3-stable` HEAD (3b0b07a) — a real code change, not regression-only.

### The fix
Bind `TeakSession* session = currentSession;` inside the lock and have the block capture the local. Two sites. Also fixes a latent correctness bug: the callback now runs with the session that was current when it was queued, not whatever is current when the async fires.

Heavier options (serial-queue rewrite, atomic accessor) were ruled out — the mutex already covers every write and synchronous read, so only the two async re-reads are the hole; widening the locking would tangle with the existing nested `@synchronized(self)` / KVO-on-`setState:` and is unjustified risk for a point release.

### Test
`TeakSessionDeferredCallbackTests` drives the `currentSession` global (external linkage) with OCMockito stand-ins, enqueues a callback, swaps the global, and asserts the callback received the session current **at enqueue**. Three cases: `whenUserIdIsReadyRun:`, `whenUserIdIsOrWasReadyRun:`, and the OrWas-specific `Expiring && previousState == UserIdentified` gate. The two `UserIdentified` cases were verified to fail 512/512 on the old code; all three pass on the fix. It documents the capture semantics rather than reproducing the data race itself — a true crash repro needs ThreadSanitizer, which this project's schemes don't enable.

### Follow-up (out of scope, flagged for the lead)
`currentState` is `nonatomic`, written under `@synchronized(self)` in `setState:` but read under `currentSessionMutex` elsewhere — inconsistent locking. Benign today (state values are singletons), but worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
