### PR TITLE
feat(C-681): attach run_id to Sentry payload tags

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		55AAEB0EF3B9E90616642C8E /* LiveActivityUpdateSchedulingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 741732706353CEBB41D0AE37 /* LiveActivityUpdateSchedulingTests.m */; };
 		67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */; };
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
+		6D15A01FD0A680A1CD603491 /* TeakRavenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */; };
 		6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
@@ -140,6 +141,7 @@
 		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
+		C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRavenTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateCancellationTests.m; sourceTree = "<group>"; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -261,6 +263,7 @@
 				068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */,
 				F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */,
 				EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */,
+				C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -591,6 +594,7 @@
 				AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */,
 				20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */,
 				01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */,
+				6D15A01FD0A680A1CD603491 /* TeakRavenTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakRavenTests.m
+++ b/Automated/AutomatedTests/TeakRavenTests.m
@@ -50,7 +50,6 @@
   self.teakMock = mock([Teak class]);
   [given([self.teakMock sdkVersion]) willReturn:@"4.3.13-test"];
   [given([self.teakMock configuration]) willReturn:config];
-  [given([self.teakMock enableRemoteLogging]) willReturn:@NO];
 
   self.log = [[TeakLog alloc] initForTeak:self.teakMock withAppId:@"test"];
   [given([self.teakMock log]) willReturn:self.log];

--- a/Automated/AutomatedTests/TeakRavenTests.m
+++ b/Automated/AutomatedTests/TeakRavenTests.m
@@ -64,4 +64,14 @@
   assertThat(raven.payloadTemplate[@"tags"][@"run_id"], is(knownRunId));
 }
 
+- (void)testPayloadTemplateTagsOmitRunIdWhenLogIsNil {
+  [given([self.teakMock log]) willReturn:nil];
+
+  TeakRaven* raven = [TeakRaven ravenForTeak:self.teakMock];
+
+  // nil log must degrade gracefully: tag absent, raven still created
+  XCTAssertNotNil(raven);
+  XCTAssertNil(raven.payloadTemplate[@"tags"][@"run_id"]);
+}
+
 @end

--- a/Automated/AutomatedTests/TeakRavenTests.m
+++ b/Automated/AutomatedTests/TeakRavenTests.m
@@ -1,0 +1,68 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakAppConfiguration.h"
+#import "TeakConfiguration.h"
+#import "TeakDeviceConfiguration.h"
+#import "TeakLog.h"
+#import "TeakRaven.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose internal Teak properties needed to build a TeakRaven
+@interface Teak ()
+@property (strong, nonatomic) TeakConfiguration* _Nonnull configuration;
+@property (strong, nonatomic) TeakLog* _Nonnull log;
+@end
+
+// Re-expose payloadTemplate for inspection
+@interface TeakRaven ()
+@property (strong, nonatomic) NSMutableDictionary* payloadTemplate;
+@end
+
+// Re-expose runId as read-write so tests can inject a known value
+@interface TeakLog ()
+@property (strong, nonatomic) NSString* runId;
+@end
+
+@interface TeakRavenTests : XCTestCase
+@property (strong, nonatomic) TeakLog* log;
+@property (strong, nonatomic) Teak* teakMock;
+@end
+
+@implementation TeakRavenTests
+
+- (void)setUp {
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:@"test-device-id"];
+
+  TeakAppConfiguration* appConfig = mock([TeakAppConfiguration class]);
+  [given([appConfig appId]) willReturn:@"test-app-id"];
+  [given([appConfig appVersion]) willReturn:@"1"];
+  [given([appConfig appVersionName]) willReturn:@"1.0.0"];
+  [given([appConfig isProduction]) willReturn:@NO];
+
+  TeakConfiguration* config = mock([TeakConfiguration class]);
+  [given([config deviceConfiguration]) willReturn:deviceConfig];
+  [given([config appConfiguration]) willReturn:appConfig];
+
+  self.teakMock = mock([Teak class]);
+  [given([self.teakMock sdkVersion]) willReturn:@"4.3.13-test"];
+  [given([self.teakMock configuration]) willReturn:config];
+  [given([self.teakMock enableRemoteLogging]) willReturn:@NO];
+
+  self.log = [[TeakLog alloc] initForTeak:self.teakMock withAppId:@"test"];
+  [given([self.teakMock log]) willReturn:self.log];
+}
+
+- (void)testPayloadTemplateTagsContainRunId {
+  NSString* knownRunId = @"deadbeefcafe0123456789abcdef0042";
+  self.log.runId = knownRunId;
+
+  TeakRaven* raven = [TeakRaven ravenForTeak:self.teakMock];
+
+  assertThat(raven.payloadTemplate[@"tags"][@"run_id"], is(knownRunId));
+}
+
+@end

--- a/Teak/TeakLog.h
+++ b/Teak/TeakLog.h
@@ -7,6 +7,8 @@
 @class Teak;
 
 @interface TeakLog : NSObject
+@property (readonly, strong, nonatomic) NSString* _Nonnull runId;
+
 - (void)useSdk:(nonnull NSDictionary*)sdkVersion andXcode:(nonnull NSDictionary*)xcodeVersion;
 - (void)useDeviceConfiguration:(nonnull TeakDeviceConfiguration*)deviceConfiguration;
 - (void)useAppConfiguration:(nonnull TeakAppConfiguration*)appConfiguration;

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -254,13 +254,16 @@ void TeakSignalHandler(int signal) {
 
       self.isSdkRaven = YES;
       self.appId = @"sdk";
-      // teak.log must be initialized before this point (Teak.m:644 precedes :678);
-      // nil log causes @{run_id:nil} to throw → raven init fails → crash reporting silently off.
+      NSMutableDictionary* tags = [NSMutableDictionary dictionary];
+      NSString* runId = teak.log.runId;
+      if (runId != nil) {
+        tags[@"run_id"] = runId;
+      }
       self.payloadTemplate = [NSMutableDictionary dictionaryWithDictionary:@{
         @"logger" : @"teak",
         @"platform" : @"objc",
         @"release" : teak.sdkVersion,
-        @"tags" : @{@"run_id" : teak.log.runId},
+        @"tags" : tags,
         @"sdk" : @{
           @"name" : @"teak",
           @"version" : TeakSentryVersion

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -258,7 +258,7 @@ void TeakSignalHandler(int signal) {
         @"logger" : @"teak",
         @"platform" : @"objc",
         @"release" : teak.sdkVersion,
-        @"tags" : @{},
+        @"tags" : @{@"run_id" : teak.log.runId},
         @"sdk" : @{
           @"name" : @"teak",
           @"version" : TeakSentryVersion

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -254,6 +254,8 @@ void TeakSignalHandler(int signal) {
 
       self.isSdkRaven = YES;
       self.appId = @"sdk";
+      // teak.log must be initialized before this point (Teak.m:644 precedes :678);
+      // nil log causes @{run_id:nil} to throw → raven init fails → crash reporting silently off.
       self.payloadTemplate = [NSMutableDictionary dictionaryWithDictionary:@{
         @"logger" : @"teak",
         @"platform" : @"objc",


### PR DESCRIPTION
Adds `run_id` to the `tags` dict in `TeakRaven`'s Sentry payload template so every Sentry event can be joined to the TeakLog run that produced it.

https://linear.app/teakio/issue/C-681

## Changes

- `TeakLog.h`: expose `runId` as a public `readonly` property
- `TeakRaven.m`: set `tags.run_id = teak.log.runId` in `initForTeak:` payload template
- `TeakRavenTests.m`: new test verifying the tag equals a known injected value (non-vacuous assertion)

`run_id` is in `tags` (not `contexts`) because Sentry indexes tags for search. Tag key matches the Android SDK (C-685).

🤖 Generated with [Claude Code](https://claude.com/claude-code)