### PR TITLE
expose TeakRegisterPushToStartToken as C extern (C-746)

### DIFF
--- a/Automated/AutomatedTests/TeakCExternLiveActivityTests.m
+++ b/Automated/AutomatedTests/TeakCExternLiveActivityTests.m
@@ -1,10 +1,17 @@
 #import <XCTest/XCTest.h>
 
+#import "PushRegistrationEvent.h"
+#import "TeakEvent.h"
 #import "TeakOperationTestDriver.h"
 #import <Teak/Teak.h>
 
 @import OCHamcrest;
 @import OCMockito;
+
+// Expose the internal serial event processing queue so tests can flush pending events.
+@interface TeakEvent (PushToStartTesting)
++ (dispatch_queue_t)eventProcessingQueue;
+@end
 
 // Forward declarations for the TeakCExtern Live Activity wrappers. They are
 // defined in TeakCExtern.m (compiled into Teak.framework) and consumed from
@@ -18,6 +25,7 @@ extern TeakOperation* TeakScheduleLiveActivityUpdate(const char* activityId,
                                                     const char* customDataJson,
                                                     const char* systemDataJson);
 extern TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId);
+extern void TeakRegisterPushToStartToken(const void* pushTokenBytes, int pushTokenLength);
 
 @interface TeakCExternLiveActivityTests : XCTestCase
 @property (nonatomic) TeakOperationTestDriver* driver;
@@ -180,6 +188,63 @@ extern TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId);
   XCTAssertTrue(result.error);
   XCTAssertEqualObjects(result.status, @"error");
   XCTAssertNotNil(result.errors[@"activityId"]);
+}
+
+@end
+
+#pragma mark - TeakCExternPushToStartTokenTests
+
+@interface TeakCExternPushToStartTokenTests : XCTestCase
+@property (strong, nonatomic) NSMutableArray<PushRegistrationEvent*>* capturedEvents;
+@property (strong, nonatomic) TeakEventBlockHandler* handler;
+@end
+
+@implementation TeakCExternPushToStartTokenTests
+
+- (void)setUp {
+  self.capturedEvents = [[NSMutableArray alloc] init];
+  NSMutableArray* events = self.capturedEvents;
+  self.handler = [TeakEventBlockHandler handlerWithBlock:^(TeakEvent* event) {
+    if (event.type == LiveActivityPushToStartRegistered) {
+      @synchronized(events) {
+        [events addObject:(PushRegistrationEvent*)event];
+      }
+    }
+  }];
+  [TeakEvent addEventHandler:self.handler];
+}
+
+- (void)tearDown {
+  [TeakEvent removeEventHandler:self.handler];
+  self.handler = nil;
+  self.capturedEvents = nil;
+}
+
+- (NSArray<PushRegistrationEvent*>*)drainCapturedEvents {
+  dispatch_sync([TeakEvent eventProcessingQueue], ^{});
+  @synchronized(self.capturedEvents) {
+    return [self.capturedEvents copy];
+  }
+}
+
+- (void)testRegisterPushToStartToken_ValidBytesPostEventWithHexToken {
+  unsigned char bytes[] = {0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x01, 0x23};
+  TeakRegisterPushToStartToken(bytes, (int)sizeof(bytes));
+
+  NSArray<PushRegistrationEvent*>* events = [self drainCapturedEvents];
+  assertThat(events, hasCountOf(1));
+  assertThat(events[0].token, is(@"deadbeefcafe0123"));
+}
+
+- (void)testRegisterPushToStartToken_NullBytesDoesNotPostEvent {
+  TeakRegisterPushToStartToken(NULL, 0);
+  assertThat([self drainCapturedEvents], hasCountOf(0));
+}
+
+- (void)testRegisterPushToStartToken_ZeroLengthDoesNotPostEvent {
+  unsigned char bytes[] = {0xde, 0xad};
+  TeakRegisterPushToStartToken(bytes, 0);
+  assertThat([self drainCapturedEvents], hasCountOf(0));
 }
 
 @end

--- a/Teak/TeakCExtern.m
+++ b/Teak/TeakCExtern.m
@@ -279,10 +279,14 @@ static NSDictionary* TeakParseJSONDictionaryOrNil(const char* jsonCStr) {
   return parsed;
 }
 
+static NSData* TeakDataFromBytesOrNil(const void* bytes, int length) {
+  return (bytes == NULL || length <= 0) ? nil : [NSData dataWithBytes:bytes length:length];
+}
+
 TeakOperation* TeakStartedLiveActivity(const char* activityId, const void* pushTokenBytes, int pushTokenLength, const char* systemActivityId) {
   NSString* activityIdString = activityId == NULL ? nil : [NSString stringWithUTF8String:activityId];
   NSString* systemActivityIdString = systemActivityId == NULL ? nil : [NSString stringWithUTF8String:systemActivityId];
-  NSData* tokenData = (pushTokenBytes == NULL || pushTokenLength <= 0) ? nil : [NSData dataWithBytes:pushTokenBytes length:pushTokenLength];
+  NSData* tokenData = TeakDataFromBytesOrNil(pushTokenBytes, pushTokenLength);
   return [Teak startedLiveActivity:activityIdString withToken:tokenData systemActivityId:systemActivityIdString];
 }
 
@@ -302,8 +306,7 @@ TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId) {
 }
 
 void TeakRegisterPushToStartToken(const void* pushTokenBytes, int pushTokenLength) {
-  NSData* tokenData = (pushTokenBytes == NULL || pushTokenLength <= 0) ? nil : [NSData dataWithBytes:pushTokenBytes length:pushTokenLength];
-  [Teak registerPushToStartToken:tokenData];
+  [Teak registerPushToStartToken:TeakDataFromBytesOrNil(pushTokenBytes, pushTokenLength)];
 }
 
 TeakOperation* TeakSetStateForChannel(const char* stateCstr, const char* channelCstr) {

--- a/Teak/TeakCExtern.m
+++ b/Teak/TeakCExtern.m
@@ -301,6 +301,11 @@ TeakOperation* TeakCancelLiveActivityUpdates(const char* activityId) {
   return [Teak cancelLiveActivityUpdates:activityIdString];
 }
 
+void TeakRegisterPushToStartToken(const void* pushTokenBytes, int pushTokenLength) {
+  NSData* tokenData = (pushTokenBytes == NULL || pushTokenLength <= 0) ? nil : [NSData dataWithBytes:pushTokenBytes length:pushTokenLength];
+  [Teak registerPushToStartToken:tokenData];
+}
+
 TeakOperation* TeakSetStateForChannel(const char* stateCstr, const char* channelCstr) {
   NSString* state = [NSString stringWithUTF8String:stateCstr];
   NSString* channel = [NSString stringWithUTF8String:channelCstr];


### PR DESCRIPTION
Adds `TeakRegisterPushToStartToken` to `TeakCExtern.m` alongside its three Live Activity siblings, so the Unity SDK can bind it via DllImport.

The function marshals `(bytes, length)` to `NSData` using the same NULL/zero-length guard as `TeakStartedLiveActivity`, then calls `[Teak registerPushToStartToken:]`. No new behavior — the ObjC method already existed in 4.3.12; this just exposes a C surface for cross-language callers.

Three tests added to `TeakCExternLiveActivityTests.m` covering the marshaling layer (valid bytes → correct hex event, NULL → no event, zero length → no event). All 125 tests pass.

https://linear.app/teakio/issue/C-746