### PR TITLE
Emit observable "exception" log event on caught exception (C-843)

### DIFF
--- a/Automated/AutomatedTests/TeakRavenTests.m
+++ b/Automated/AutomatedTests/TeakRavenTests.m
@@ -14,7 +14,14 @@
 @interface Teak ()
 @property (strong, nonatomic) TeakConfiguration* _Nonnull configuration;
 @property (strong, nonatomic) TeakLog* _Nonnull log;
+@property (strong, nonatomic) TeakRaven* _Nonnull sdkRaven;
+@property (strong, nonatomic, readwrite) NSString* _Nonnull sdkVersion;
+- (void)reportTestException;
 @end
+
+// The shared instance is a plain global with external linkage, so a test can
+// install a real Teak to exercise the singleton-routed exception path.
+extern Teak* _Nullable _teakSharedInstance;
 
 // Re-expose payloadTemplate for inspection
 @interface TeakRaven ()
@@ -72,6 +79,62 @@
   // nil log must degrade gracefully: tag absent, raven still created
   XCTAssertNotNil(raven);
   XCTAssertNil(raven.payloadTemplate[@"tags"][@"run_id"]);
+}
+
+// A caught exception (teak_catch_report → reportWithHelper) must surface an
+// observable "exception" TeakLog event whose event_data matches Android's
+// throwableToMap shape: type ← NSException.name, value ← NSException.reason.
+// reportTestException is the exact path the C-739 cleanroom test drives.
+- (void)testReportTestExceptionEmitsObservableExceptionEvent {
+  Teak* teak = [[Teak alloc] init];
+  teak.sdkVersion = @"4.3.13-test";
+  teak.log = [[TeakLog alloc] initForTeak:teak withAppId:@"test"];
+
+  __block NSString* capturedEventType = nil;
+  __block NSDictionary* capturedEventData = nil;
+  teak.logListener = ^(NSString* event, NSString* level, NSDictionary* payload) {
+    if ([event isEqualToString:@"exception"]) {
+      capturedEventType = payload[@"event_type"];
+      capturedEventData = payload[@"event_data"];
+    }
+  };
+
+  // Raven built from the fully-stubbed mock so payloadTemplate construction
+  // doesn't bail; its endpoint stays nil so nothing hits the network.
+  teak.sdkRaven = [TeakRaven ravenForTeak:self.teakMock];
+
+  Teak* previousShared = _teakSharedInstance;
+  _teakSharedInstance = teak;
+  @try {
+    [teak reportTestException];
+  } @finally {
+    _teakSharedInstance = previousShared;
+  }
+
+  assertThat(capturedEventType, is(@"exception"));
+  assertThat(capturedEventData[@"type"], is(@"ReportTestException"));
+  assertThat(capturedEventData[@"value"], is(@"Version: 4.3.13-test"));
+}
+
+- (void)testExceptionLogEventDataMapsNameToTypeAndReasonToValue {
+  NSException* exception = [NSException exceptionWithName:@"ReportTestException"
+                                                  reason:@"Version: 4.3.13"
+                                                userInfo:nil];
+
+  NSDictionary* eventData = [TeakRaven exceptionLogEventDataForException:exception];
+
+  assertThat(eventData[@"type"], is(@"ReportTestException"));
+  assertThat(eventData[@"value"], is(@"Version: 4.3.13"));
+}
+
+- (void)testExceptionLogEventDataIsNilSafeForMissingReason {
+  NSException* exception = [NSException exceptionWithName:@"NoReason" reason:nil userInfo:nil];
+
+  NSDictionary* eventData = [TeakRaven exceptionLogEventDataForException:exception];
+
+  // A nil reason is omitted rather than crashing the dictionary build.
+  assertThat(eventData[@"type"], is(@"NoReason"));
+  XCTAssertNil(eventData[@"value"]);
 }
 
 @end

--- a/Teak/TeakRaven.h
+++ b/Teak/TeakRaven.h
@@ -33,6 +33,11 @@ extern NSString* _Nonnull const TeakRavenLevelFatal;
 
 + (nonnull NSArray*)stacktraceSkippingFrames:(int)skipFrames;
 + (nonnull NSArray*)reverseStacktraceSkippingFrames:(int)skipFrames;
+
+// event_data for the observable "exception" TeakLog event, keyed to match
+// Android's throwableToMap: type ← NSException.name, value ← NSException.reason.
+// nil-safe — a nil name or reason is omitted rather than crashing.
++ (nonnull NSDictionary*)exceptionLogEventDataForException:(nonnull NSException*)exception;
 @end
 
 #define teak_try                                                                                   \

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -182,6 +182,11 @@ void TeakSignalHandler(int signal) {
   });
   if (breadcrumbSnapshot.count > 0) additions[@"breadcrumbs"] = breadcrumbSnapshot;
 
+  // Surface an observable "exception" log event (Unity OnLogEvent, remote TeakLog
+  // consumers) on parity with Android's log.exception(). Built from a fresh dict so
+  // the Sentry report payload is untouched.
+  TeakLog_e(@"exception", [TeakRaven exceptionLogEventDataForException:helper.exception]);
+
   TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:self
                                                             level:TeakRavenLevelError
                                                           message:[NSString stringWithFormat:@"%@: %@", helper.exception.name, helper.exception.reason]
@@ -204,6 +209,8 @@ void TeakSignalHandler(int signal) {
 
 - (void)reportUncaughtException:(nonnull NSException*)exception {
   [self unsetAsUncaughtExceptionHandler];
+
+  TeakLog_e(@"exception", [TeakRaven exceptionLogEventDataForException:exception]);
 
   NSDictionary* additions = @{
     @"exception" : @[
@@ -412,6 +419,13 @@ void TeakSignalHandler(int signal) {
   return stacktrace;
 }
 
++ (NSDictionary*)exceptionLogEventDataForException:(NSException*)exception {
+  NSMutableDictionary* eventData = [NSMutableDictionary dictionary];
+  [eventData setValue:exception.name forKey:@"type"];
+  [eventData setValue:exception.reason forKey:@"value"];
+  return eventData;
+}
+
 + (NSArray*)reverseStacktraceSkippingFrames:(int)skipFrames {
   void* callstack[128];
   int frames = backtrace(callstack, 128);
@@ -484,10 +498,6 @@ void TeakSignalHandler(int signal) {
 }
 
 - (void)send {
-  if ([Teak sharedInstance].log != nil) {
-    TeakLog_e(@"exception", self.payload);
-  }
-
   if (self.raven.endpoint == nil) return;
 
   NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:self.raven.endpoint];

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -210,8 +210,6 @@ void TeakSignalHandler(int signal) {
 - (void)reportUncaughtException:(nonnull NSException*)exception {
   [self unsetAsUncaughtExceptionHandler];
 
-  TeakLog_e(@"exception", [TeakRaven exceptionLogEventDataForException:exception]);
-
   NSDictionary* additions = @{
     @"exception" : @[
       @{


### PR DESCRIPTION
## Summary
- On a caught SDK exception (`teak_catch_report` → `reportWithHelper`), iOS now emits an observable `"exception"` TeakLog event, so exceptions are visible to game code (Unity `OnLogEvent`) and remote TeakLog consumers — parity with Android's `log.exception()`.
- `event_data` matches Android's `Raven.throwableToMap`: `type` ← `NSException.name`, `value` ← `NSException.reason`.

## Key decisions
- Emit from `reportWithHelper` (+ `reportUncaughtException`) using a fresh dict, so the Sentry report payload is byte-for-byte unchanged.
- Dropped `send()`'s old `TeakLog_e(@"exception", self.payload)` — it shipped the raw Sentry blob (no top-level `type`/`value`, so C-739 couldn't match) and would otherwise double-emit. Confirmed no backend consumer depends on the old shape.
- `{type, value}` only — `module` has no faithful iOS analog and the iOS stacktrace frame shape diverges from Android's (and the full stacktrace already goes to Sentry).

## Test plan
- `bundle exec fastlane test` — green.
- `testReportTestExceptionEmitsObservableExceptionEvent` drives the real `reportTestException` path through a real `Teak` + capturing `logListener` (no network) and asserts `event_type == "exception"`, `type == "ReportTestException"`, `value == "Version: 4.3.13-test"`.
- `testExceptionLogEventDataMapsNameToTypeAndReasonToValue` / `…IsNilSafeForMissingReason` cover the shaping helper, including a nil reason.

Linear: https://linear.app/teakio/issue/C-843/teak-ios-emit-an-observable-log-event-on-caught-exception-parity-with
