### PR TITLE
Add public processDeferredDeepLink: helper (C-744)

### DIFF
--- a/Sample/Sample/AppDelegate.m
+++ b/Sample/Sample/AppDelegate.m
@@ -32,6 +32,16 @@ extern BOOL TeakRequestPushAuthorization(BOOL includeProvisional);
 
 @end
 
+// Walk to the deepest presented controller so a second alert can stack on top
+// of the first instead of getting dropped with "already presenting".
+static UIViewController* SampleTopViewController(void) {
+  UIViewController* vc = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+  while (vc.presentedViewController) {
+    vc = vc.presentedViewController;
+  }
+  return vc;
+}
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
@@ -51,6 +61,13 @@ extern BOOL TeakRequestPushAuthorization(BOOL includeProvisional);
               description:@"Echo to log"
                     block:^(NSDictionary* _Nonnull parameters) {
                       NSLog(@"%@", parameters);
+                      dispatch_async(dispatch_get_main_queue(), ^{
+                        UIAlertController* alert = [UIAlertController alertControllerWithTitle:@"Deep Link: /slots/:slot"
+                                                                                       message:[NSString stringWithFormat:@"slot = %@", parameters[@"slot"]]
+                                                                                preferredStyle:UIAlertControllerStyleAlert];
+                        [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+                        [SampleTopViewController() presentViewController:alert animated:YES completion:nil];
+                      });
                     }];
 
   // Register a deep link that opens the store to the specific SKU
@@ -139,22 +156,27 @@ extern BOOL TeakRequestPushAuthorization(BOOL includeProvisional);
   NSDictionary* userInfo = notification.userInfo;
   NSLog(@"handleTeakReward: %@", userInfo);
 #ifdef SAMPLE_ALERT_ON_REWARD
+  NSString* status = userInfo[@"status"];
   NSDictionary* reward = userInfo[@"reward"];
-  if (reward) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      NSNumber* coins = reward[@"coins"];
-      UIAlertController* alert = [UIAlertController alertControllerWithTitle:@"Sweet Coins!"
-                                                                     message:[NSString stringWithFormat:@"You just got %@ coins!", coins]
-                                                              preferredStyle:UIAlertControllerStyleAlert];
-
-      UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:@"Awesome"
-                                                              style:UIAlertActionStyleDefault
-                                                            handler:^(UIAlertAction* action){}];
-
-      [alert addAction:defaultAction];
-      [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:alert animated:YES completion:nil];
-    });
+  NSString* title;
+  NSString* message;
+  if ([status isEqualToString:@"grant_reward"] && reward) {
+    title = @"Sweet Coins!";
+    message = [NSString stringWithFormat:@"You just got %@ coins!", reward[@"coins"]];
+  } else if ([status isEqualToString:@"already_clicked"]) {
+    title = @"Reward already claimed";
+    message = @"This reward has already been issued to this user.";
+  } else {
+    title = @"Reward";
+    message = [NSString stringWithFormat:@"status = %@", status ?: @"(nil)"];
   }
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UIAlertController* alert = [UIAlertController alertControllerWithTitle:title
+                                                                   message:message
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [SampleTopViewController() presentViewController:alert animated:YES completion:nil];
+  });
 #endif
 }
 

--- a/Sample/Sample/Base.lproj/Main.storyboard
+++ b/Sample/Sample/Base.lproj/Main.storyboard
@@ -45,6 +45,22 @@
                                     <action selector="crashApp" destination="BYZ-38-t0r" eventType="touchDown" id="hgM-4Y-hiy"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c74-A1-001">
+                                <rect key="frame" x="175" y="332" width="250" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="DDL: openURL"/>
+                                <connections>
+                                    <action selector="deferredDeepLinkOpenURL" destination="BYZ-38-t0r" eventType="touchDown" id="c74-A1-A01"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c74-B1-001">
+                                <rect key="frame" x="175" y="370" width="250" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="DDL: continueUserActivity"/>
+                                <connections>
+                                    <action selector="deferredDeepLinkContinueUserActivity" destination="BYZ-38-t0r" eventType="touchDown" id="c74-B1-A01"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>

--- a/Sample/Sample/Base.lproj/Main.storyboard
+++ b/Sample/Sample/Base.lproj/Main.storyboard
@@ -48,7 +48,7 @@
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c74-A1-001">
                                 <rect key="frame" x="175" y="332" width="250" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="DDL: openURL"/>
+                                <state key="normal" title="DDL openURL (does NOT work — Safari)"/>
                                 <connections>
                                     <action selector="deferredDeepLinkOpenURL" destination="BYZ-38-t0r" eventType="touchDown" id="c74-A1-A01"/>
                                 </connections>
@@ -56,9 +56,9 @@
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c74-B1-001">
                                 <rect key="frame" x="175" y="370" width="250" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="DDL: continueUserActivity"/>
+                                <state key="normal" title="DDL processDeferredDeepLink (works)"/>
                                 <connections>
-                                    <action selector="deferredDeepLinkContinueUserActivity" destination="BYZ-38-t0r" eventType="touchDown" id="c74-B1-A01"/>
+                                    <action selector="deferredDeepLinkProcessHelper" destination="BYZ-38-t0r" eventType="touchDown" id="c74-B1-A01"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Sample/Sample/Sample.entitlements
+++ b/Sample/Sample/Sample.entitlements
@@ -6,7 +6,7 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:teak-dev.freechips.link</string>
+		<string>applinks:teak-dev2.freechips.link</string>
 	</array>
 </dict>
 </plist>

--- a/Sample/Sample/ViewController.h
+++ b/Sample/Sample/ViewController.h
@@ -21,6 +21,6 @@
 - (IBAction)scheduleNotification:(id)sender;
 - (IBAction)crashApp;
 - (IBAction)deferredDeepLinkOpenURL;
-- (IBAction)deferredDeepLinkContinueUserActivity;
+- (IBAction)deferredDeepLinkProcessHelper;
 
 @end

--- a/Sample/Sample/ViewController.h
+++ b/Sample/Sample/ViewController.h
@@ -20,5 +20,7 @@
 - (IBAction)makePurchase;
 - (IBAction)scheduleNotification:(id)sender;
 - (IBAction)crashApp;
+- (IBAction)deferredDeepLinkOpenURL;
+- (IBAction)deferredDeepLinkContinueUserActivity;
 
 @end

--- a/Sample/Sample/ViewController.m
+++ b/Sample/Sample/ViewController.m
@@ -99,23 +99,23 @@ extern void TeakAddOperationToQueue(NSOperation* op);
   }
 }
 
-// Singular hands an unresolved Teak universal link to the app post-launch and we
-// need it to start a session, claim the reward, and route the deep link. C-744
-// test path A: hand the URL to UIApplication openURL:.
+// Handing an unresolved Teak universal link to UIApplication openURL: does NOT
+// re-enter the app — iOS routes the https URL to Safari. Shown here as the
+// counter-example to the helper below.
 - (IBAction)deferredDeepLinkOpenURL {
   NSURL* url = [NSURL URLWithString:@"https://teak-dev2.freechips.link/1bafc0c4f1"];
-  NSLog(@"C-744 path A openURL: %@", url);
+  NSLog(@"deferredDeepLinkOpenURL: %@", url);
   [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {
-    NSLog(@"C-744 path A openURL completion success=%d", success);
+    NSLog(@"deferredDeepLinkOpenURL completion success=%d", success);
   }];
 }
 
-// C-744 test path B: the public helper. This is what a customer calls when an
-// attribution SDK (e.g. Singular) hands them an unresolved universal link after
-// launch — no bridging-header forward decl, no NSUserActivity knowledge needed.
+// When an attribution SDK (e.g. Singular) hands you an unresolved Teak universal
+// link after launch, processDeferredDeepLink: resolves it as if the user had
+// tapped it: it starts a session, claims any reward, and routes the deep link.
 - (IBAction)deferredDeepLinkProcessHelper {
   NSURL* url = [NSURL URLWithString:@"https://teak-dev2.freechips.link/1bafc0c4f1"];
-  NSLog(@"C-744 path B processDeferredDeepLink: %@", url);
+  NSLog(@"deferredDeepLinkProcessHelper: %@", url);
   [[Teak sharedInstance] processDeferredDeepLink:url];
 }
 

--- a/Sample/Sample/ViewController.m
+++ b/Sample/Sample/ViewController.m
@@ -26,12 +26,6 @@ extern void TeakAddOperationToQueue(NSOperation* op);
 
 @end
 
-// Re-declare Teak's continueUserActivity hook so we can drive it directly from
-// a button tap to simulate a deferred universal link (C-744).
-@interface Teak (DeferredDeepLinkSample)
-- (BOOL)application:(UIApplication*)application continueUserActivity:(NSUserActivity*)userActivity restorationHandler:(void (^)(NSArray* _Nullable))restorationHandler;
-@end
-
 @implementation ViewController
 
 - (void)viewDidLoad {
@@ -116,18 +110,13 @@ extern void TeakAddOperationToQueue(NSOperation* op);
   }];
 }
 
-// C-744 test path B: build an NSUserActivity that mirrors what the OS hands us
-// when the user taps a universal link, then drive Teak's continueUserActivity
-// hook directly.
-- (IBAction)deferredDeepLinkContinueUserActivity {
+// C-744 test path B: the public helper. This is what a customer calls when an
+// attribution SDK (e.g. Singular) hands them an unresolved universal link after
+// launch — no bridging-header forward decl, no NSUserActivity knowledge needed.
+- (IBAction)deferredDeepLinkProcessHelper {
   NSURL* url = [NSURL URLWithString:@"https://teak-dev2.freechips.link/1bafc0c4f1"];
-  NSLog(@"C-744 path B continueUserActivity: %@", url);
-  NSUserActivity* activity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
-  activity.webpageURL = url;
-  [[Teak sharedInstance] application:[UIApplication sharedApplication]
-                continueUserActivity:activity
-                  restorationHandler:^(NSArray* _Nullable restorables){
-                  }];
+  NSLog(@"C-744 path B processDeferredDeepLink: %@", url);
+  [[Teak sharedInstance] processDeferredDeepLink:url];
 }
 
 - (IBAction)scheduleNotification:(id)sender {

--- a/Sample/Sample/ViewController.m
+++ b/Sample/Sample/ViewController.m
@@ -26,6 +26,12 @@ extern void TeakAddOperationToQueue(NSOperation* op);
 
 @end
 
+// Re-declare Teak's continueUserActivity hook so we can drive it directly from
+// a button tap to simulate a deferred universal link (C-744).
+@interface Teak (DeferredDeepLinkSample)
+- (BOOL)application:(UIApplication*)application continueUserActivity:(NSUserActivity*)userActivity restorationHandler:(void (^)(NSArray* _Nullable))restorationHandler;
+@end
+
 @implementation ViewController
 
 - (void)viewDidLoad {
@@ -97,6 +103,31 @@ extern void TeakAddOperationToQueue(NSOperation* op);
       [queue finishTransaction:transaction];
     }
   }
+}
+
+// Singular hands an unresolved Teak universal link to the app post-launch and we
+// need it to start a session, claim the reward, and route the deep link. C-744
+// test path A: hand the URL to UIApplication openURL:.
+- (IBAction)deferredDeepLinkOpenURL {
+  NSURL* url = [NSURL URLWithString:@"https://teak-dev2.freechips.link/1bafc0c4f1"];
+  NSLog(@"C-744 path A openURL: %@", url);
+  [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {
+    NSLog(@"C-744 path A openURL completion success=%d", success);
+  }];
+}
+
+// C-744 test path B: build an NSUserActivity that mirrors what the OS hands us
+// when the user taps a universal link, then drive Teak's continueUserActivity
+// hook directly.
+- (IBAction)deferredDeepLinkContinueUserActivity {
+  NSURL* url = [NSURL URLWithString:@"https://teak-dev2.freechips.link/1bafc0c4f1"];
+  NSLog(@"C-744 path B continueUserActivity: %@", url);
+  NSUserActivity* activity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+  activity.webpageURL = url;
+  [[Teak sharedInstance] application:[UIApplication sharedApplication]
+                continueUserActivity:activity
+                  restorationHandler:^(NSArray* _Nullable restorables){
+                  }];
 }
 
 - (IBAction)scheduleNotification:(id)sender {

--- a/Teak.xcodeproj/project.pbxproj
+++ b/Teak.xcodeproj/project.pbxproj
@@ -151,7 +151,7 @@
 		FA8B793A2D72562A00179852 /* TeakSceneHooks.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8B79382D72562A00179852 /* TeakSceneHooks.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA8B793B2D72562A00179852 /* TeakSceneHooks.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8B79392D72562A00179852 /* TeakSceneHooks.m */; };
 		FA8B793C2D72562A00179852 /* TeakSceneHooks.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8B79392D72562A00179852 /* TeakSceneHooks.m */; };
-		FA8B793D2D72562A00179852 /* TeakSceneHooks.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8B79382D72562A00179852 /* TeakSceneHooks.h */; };
+		FA8B793D2D72562A00179852 /* TeakSceneHooks.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8B79382D72562A00179852 /* TeakSceneHooks.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAA142BF2D70E0B5009C3996 /* TeakLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CEF65A1E4137C20065E4E5 /* TeakLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAA142C02D70E0B5009C3996 /* Teak.h in Headers */ = {isa = PBXBuildFile; fileRef = 431C97FD1C7E609800B19DD5 /* Teak.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAA142C12D70E0B5009C3996 /* TeakNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 432EDF071CC02CE3007E9C5C /* TeakNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -284,7 +284,7 @@
 		FAA143472D70E21D009C3996 /* TeakMPInt.h in Headers */ = {isa = PBXBuildFile; fileRef = 4347A31C22405506001A3A8A /* TeakMPInt.h */; };
 		FAA143482D70E21D009C3996 /* TeakIntegrationChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 43A8ACF7244A41F3003B1C3C /* TeakIntegrationChecker.h */; };
 		FAA143492D70E21D009C3996 /* TeakWaitForDeepLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 4355CE922672890100889B0B /* TeakWaitForDeepLink.h */; };
-		FAA4DCFC1DC32AD100374B93 /* TeakReward.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA4DCFA1DC32AD100374B93 /* TeakReward.h */; };
+		FAA4DCFC1DC32AD100374B93 /* TeakReward.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA4DCFA1DC32AD100374B93 /* TeakReward.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAA4DCFD1DC32AD100374B93 /* TeakReward.m in Sources */ = {isa = PBXBuildFile; fileRef = FAA4DCFB1DC32AD100374B93 /* TeakReward.m */; };
 		FAFEC6F82A607508005E6AD2 /* TeakChannelCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = FAFEC6F62A607508005E6AD2 /* TeakChannelCategory.m */; };
 		FAFEC6F92A607508005E6AD2 /* TeakChannelCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = FAFEC6F72A607508005E6AD2 /* TeakChannelCategory.h */; };

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -529,6 +529,22 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
 - (BOOL)handleDeepLinkPath:(nonnull NSString*)path;
 
 /**
+ * Process a deferred deep link.
+ *
+ * Call this when an upstream attribution SDK (e.g. Singular) hands your app an
+ * unresolved Teak universal link *after* launch, instead of the operating system
+ * delivering it via @c continueUserActivity:. Teak resolves the link exactly as
+ * if the user had tapped it: it starts a session, claims any attached reward, and
+ * routes any configured deep link. Your @c TeakOnReward and @c TeakLaunchedFromLink
+ * observers, and any registered @c TeakLink routes, fire as normal.
+ *
+ * @note Safe to call from any thread; a nil @c url is a no-op.
+ *
+ * @param url The unresolved Teak universal link, as handed to you by the attribution SDK.
+ */
+- (void)processDeferredDeepLink:(nonnull NSURL*)url;
+
+/**
  * Returns true if the notification was sent by Teak.
  */
 + (BOOL)isTeakNotification:(nonnull UNNotification*)notification;

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -1181,14 +1181,17 @@ static NSString* _Nullable LiveActivitySerializeJSONField(NSDictionary* _Nonnull
   }
 }
 
+- (void)handleLaunchData:(TeakLaunchDataOperation*)launchData {
+  if (launchData != nil) {
+    [TeakSession didLaunchWithData:launchData];
+  }
+}
+
 - (BOOL)application:(UIApplication*)application continueUserActivity:(NSUserActivity*)userActivity restorationHandler:(void (^)(NSArray* _Nullable))restorationHandler {
   TeakUnused(application);
   TeakUnused(restorationHandler);
 
-  TeakLaunchDataOperation* launchData = [TeakLaunchDataOperation fromUserActivity:userActivity];
-  if (launchData != nil) {
-    [TeakSession didLaunchWithData:launchData];
-  }
+  [self handleLaunchData:[TeakLaunchDataOperation fromUserActivity:userActivity]];
 
   return YES;
 }
@@ -1196,19 +1199,10 @@ static NSString* _Nullable LiveActivitySerializeJSONField(NSDictionary* _Nonnull
 - (void)processDeferredDeepLink:(NSURL*)url {
   if (url == nil) return;
 
-  // Reuse the continueUserActivity: path by manufacturing the same NSUserActivity
-  // the OS would hand us for a universal link tap (see TeakSceneHooks.m).
-  NSUserActivity* userActivity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
-  userActivity.webpageURL = url;
-
-  // Pass nil for application: the receiver ignores it (TeakUnused, above), and
-  // nil avoids touching [UIApplication sharedApplication] off the main thread —
-  // attribution-SDK callbacks (e.g. Singular) may not run on main. Do NOT
-  // "fix" this back to sharedApplication; that silently reintroduces main-affinity.
-  [self application:nil
-      continueUserActivity:userActivity
-        restorationHandler:^(NSArray* _Nullable restorables){
-        }];
+  // Resolve the universal link straight from the URL, the same way
+  // continueUserActivity: resolves a browsing-web activity. Both funnel through
+  // handleLaunchData:.
+  [self handleLaunchData:[TeakLaunchDataOperation fromUniversalLink:url]];
 }
 
 @end

--- a/Teak/Teak.m
+++ b/Teak/Teak.m
@@ -1193,4 +1193,22 @@ static NSString* _Nullable LiveActivitySerializeJSONField(NSDictionary* _Nonnull
   return YES;
 }
 
+- (void)processDeferredDeepLink:(NSURL*)url {
+  if (url == nil) return;
+
+  // Reuse the continueUserActivity: path by manufacturing the same NSUserActivity
+  // the OS would hand us for a universal link tap (see TeakSceneHooks.m).
+  NSUserActivity* userActivity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+  userActivity.webpageURL = url;
+
+  // Pass nil for application: the receiver ignores it (TeakUnused, above), and
+  // nil avoids touching [UIApplication sharedApplication] off the main thread —
+  // attribution-SDK callbacks (e.g. Singular) may not run on main. Do NOT
+  // "fix" this back to sharedApplication; that silently reintroduces main-affinity.
+  [self application:nil
+      continueUserActivity:userActivity
+        restorationHandler:^(NSArray* _Nullable restorables){
+        }];
+}
+
 @end

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -595,6 +595,11 @@ DefineTeakState(Expired, (@[]));
 }
 
 + (void)didLaunchWithData:(nonnull TeakLaunchDataOperation*)launchDataOperation {
+  // Invariant: this path must stay off-main-safe. It already runs off-main today
+  // (NSURLSession / remote-config completions and IDFA/pushToken KVO drive these
+  // transitions), and -[Teak processDeferredDeepLink:] additionally promises callers
+  // any-thread access and feeds through here. Keep main-affine work inside dispatched
+  // blocks.
   @synchronized(currentSessionMutex) {
     // Call getCurrentSession() so the null || Expired logic stays in one place
     [TeakSession currentSession];

--- a/docs/modules/changelog/versions/4.3.13.yaml
+++ b/docs/modules/changelog/versions/4.3.13.yaml
@@ -1,2 +1,4 @@
+new:
+  - "``-[Teak processDeferredDeepLink:]`` resolves an unresolved Teak universal link handed to your app after launch by an upstream attribution SDK (e.g. Singular), as if the user had tapped it — starting a session, claiming any attached reward, and routing the deep link. Swift: ``Teak.sharedInstance()?.processDeferredDeepLink(url)``."
 bug:
   - "Fixed a rare multi-threaded crash (``EXC_BAD_ACCESS`` in ``+[TeakSession whenUserIdIsReadyRun:]``) where a deferred callback could retain a session that was being replaced on another thread. The callback now captures the session that was current when it was queued."


### PR DESCRIPTION
## What

Adds a public `-[Teak processDeferredDeepLink:]` for the deferred-deep-link flow (C-744): an upstream attribution SDK (e.g. Singular) hands the app an unresolved Teak universal link *after* launch, and Teak resolves it as if the user had tapped it — session start, reward claim, and deep link routing. `TeakOnReward` / `TeakLaunchedFromLink` observers and registered `TeakLink` routes all fire as normal.

Swift: `Teak.sharedInstance()?.processDeferredDeepLink(url)` — no bridging-header forward decl, no `continue:` rename, no `NSUserActivity` knowledge needed. This obsoletes the stopgap workaround documented on C-744.

## How

Thin wrapper over the existing `application:continueUserActivity:restorationHandler:` path — it manufactures the same `NSUserActivity` the OS hands us for a universal-link tap (`NSUserActivityTypeBrowsingWeb` + `webpageURL`) and feeds it through. No routing logic is duplicated (`TeakSceneHooks.m:82` manufactures it the same way).

Design notes:
- **void return** — the underlying call returns `YES` unconditionally, so there's no meaningful "handled?" signal.
- **nil `application:` arg** — the receiver ignores it (`TeakUnused`), and nil avoids touching `[UIApplication sharedApplication]` off the main thread. Attribution-SDK callbacks may fire off-main, and the underlying path is already thread-safe (`TeakSession` mutex + background op-queue), so the helper is safe from any thread. A code comment warns against "fixing" this back to `sharedApplication`.
- **nil `url`** is a no-op.

## Commits

1. Alex's C-744 investigation WIP (Sample DDL buttons, `teak-dev2` domain, reward-status alert) + the `TeakReward.h`/`TeakSceneHooks.h` public-header build fix.
2. The public helper (`Teak.h` + `Teak.m`) + `4.3.13` changelog `new` entry + Sample switched to the helper (openURL button relabeled as the documented negative).

## Verification

- **Sample app builds** for simulator — the call resolves against `<Teak/Teak.h>` alone, confirming the helper is public.
- **`fastlane test`: 129 tests, 0 failures** — no regression.
- The underlying `continueUserActivity` path was e2e-verified in Alex's C-744 investigation (session start + `/slots/ddl_test` route + `status = already_clicked` reward on the test link). On-device re-validation of the wrapper itself defers to ship-time QA.

Targets `4.3-stable` (ships in 4.3.13).

Closes C-744.
