### PR TITLE
Mark short quickstart intros as [discrete] headings (clear last 2 warnings)

### DIFF
--- a/docs/modules/ROOT/pages/quickstart/add-teak-code.adoc
+++ b/docs/modules/ROOT/pages/quickstart/add-teak-code.adoc
@@ -57,6 +57,7 @@ Your game probably has a player ID to store progress, coin balances, and other u
 Having a consistent ID between your game makes customer support easier, and makes life easier for your analytics team.
 ====
 
+[discrete]
 === Build Your Game
 
 At this point, Teak is ready to to be tested on device or in the simulator.
@@ -64,6 +65,7 @@ At this point, Teak is ready to to be tested on device or in the simulator.
 * Build your game and get it running on a device or in the simulator.
 * Approve the system prompt asking for push notification permissions.
 
+[discrete]
 === See Your Active User
 
 * Open the https://app.teak.io/login[Teak Dashboard] and navigate to your game.


### PR DESCRIPTION
"Build Your Game" and "See Your Active User" on the *Initializing Teak* page were `=== ` (level 2) sections sitting directly under the `= ` page title, skipping level 1 — Asciidoctor warned `section title out of sequence` for each.

They're short closing intros, not real page sections. Promoting them to `==` would give them full heading weight + a section divider and surface them in the page TOC — too heavy for a one-line intro. Marking them `[discrete]` keeps the exact lightweight `<h3>` rendering (and the anchor), but takes them out of the section hierarchy.

```diff
+[discrete]
 === Build Your Game
```

### No reader-visible change
- Same light h3 rendering.
- Page TOC unchanged — it was already empty (Antora's default page TOC only lists `==` sections, and this page has none).

Clears the **last 2** iOS docs build warnings. With teak-ios#145 (xref errors) and teak-ios#146 (list-index warnings), the iOS docs build reaches **0 errors / 0 warnings**.

Context: "Fix Compile Errors" cleanup on the Teak Docs master checklist (Linear C-579). Third of three small, independent PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)