### PR TITLE
4.3.13 changelog

### DIFF
--- a/docs/modules/changelog/versions/4.3.13.yaml
+++ b/docs/modules/changelog/versions/4.3.13.yaml
@@ -2,6 +2,5 @@ new:
   - "``-[Teak processDeferredDeepLink:]`` resolves an unresolved Teak universal link handed to your app after launch by an upstream attribution SDK (e.g. Singular), as if the user had tapped it — starting a session, claiming any attached reward, and routing the deep link. Swift: ``Teak.sharedInstance()?.processDeferredDeepLink(url)``."
 bug:
   - "Fixed a rare multi-threaded crash (``EXC_BAD_ACCESS`` in ``+[TeakSession whenUserIdIsReadyRun:]``) where a deferred callback could retain a session that was being replaced on another thread. The callback now captures the session that was current when it was queued."
-  - "Added ``TeakRegisterPushToStartToken`` C extern for Unity, enabling Unity developers to register push-to-start tokens — matching the existing Live Activity C extern surface."
 enhancement:
   - "Improved internal error reporting."

--- a/docs/modules/changelog/versions/4.3.13.yaml
+++ b/docs/modules/changelog/versions/4.3.13.yaml
@@ -2,3 +2,6 @@ new:
   - "``-[Teak processDeferredDeepLink:]`` resolves an unresolved Teak universal link handed to your app after launch by an upstream attribution SDK (e.g. Singular), as if the user had tapped it — starting a session, claiming any attached reward, and routing the deep link. Swift: ``Teak.sharedInstance()?.processDeferredDeepLink(url)``."
 bug:
   - "Fixed a rare multi-threaded crash (``EXC_BAD_ACCESS`` in ``+[TeakSession whenUserIdIsReadyRun:]``) where a deferred callback could retain a session that was being replaced on another thread. The callback now captures the session that was current when it was queued."
+  - "Added ``TeakRegisterPushToStartToken`` C extern for Unity, enabling Unity developers to register push-to-start tokens — matching the existing Live Activity C extern surface."
+enhancement:
+  - "Improved internal error reporting."


### PR DESCRIPTION
## Summary
- Audited `git log 4.3.12..origin/4.3-stable` and reconciled against `docs/modules/changelog/versions/4.3.13.yaml`
- Existing entries (processDeferredDeepLink: new feature, C-615 crash fix) were already correct
- Added collapsed "Improved internal error reporting." enhancement for C-681/C-683/C-843 (Sentry run_id tags, breadcrumbs, caught-exception log parity)

## Key decisions
- C-746 (TeakRegisterPushToStartToken C extern) is Unity-bridge plumbing, not a CocoaPods iOS API — dropped; belongs in the Unity SDK changelog
- C-681/C-683/C-843 are internal observability, collapsed per issue spec

## Test plan
- Review the diff: only `docs/modules/changelog/versions/4.3.13.yaml` changes
- Verify entries match commits in `git log 4.3.12..origin/4.3-stable`

Closes C-875