### PR TITLE
Pin NSDateFormatter locale to en_US_POSIX (C-302)

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		6D15A01FD0A680A1CD603491 /* TeakRavenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */; };
 		6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
+		9094BF0120E894EDA3CA1D75 /* SKPaymentObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */; };
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
 		97EDAA942157436DCC939EC2 /* LiveActivityUpdateCancellationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */; };
 		AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */; };
@@ -132,6 +133,7 @@
 		49655D0CF74258D769DEA6F9 /* TeakOperationTestDriver.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakOperationTestDriver.m; sourceTree = "<group>"; };
 		58899BE40E40447A87FDF2D8 /* Pods-AutomatedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.release.xcconfig"; sourceTree = "<group>"; };
 		58C2AA35CD060472CAC08059 /* Pods-Automated.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.debug.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.debug.xcconfig"; sourceTree = "<group>"; };
+		58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKPaymentObserverTests.m; sourceTree = "<group>"; };
 		688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakLiveActivityLaunchDataTests.m; sourceTree = "<group>"; };
 		6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UserDataEventTests.m; sourceTree = "<group>"; };
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -267,6 +269,7 @@
 				EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */,
 				2286E8051950D4EC6E1C79EF /* TeakSessionDeferredCallbackTests.m */,
 				C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */,
+				58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -599,6 +602,7 @@
 				01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */,
 				440EB1A255029FAF5B1ACEB9 /* TeakSessionDeferredCallbackTests.m in Sources */,
 				6D15A01FD0A680A1CD603491 /* TeakRavenTests.m in Sources */,
+				9094BF0120E894EDA3CA1D75 /* SKPaymentObserverTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/SKPaymentObserverTests.m
+++ b/Automated/AutomatedTests/SKPaymentObserverTests.m
@@ -1,0 +1,43 @@
+#import <XCTest/XCTest.h>
+
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+@interface SKPaymentObserverTests : XCTestCase
+@end
+
+@implementation SKPaymentObserverTests
+
+// Verifies that purchase_time uses en_US_POSIX locale so that devices with a non-ASCII-numeral
+// locale (e.g. Arabic) still produce ASCII digits the server can parse. The bug: without an
+// explicit locale, Arabic-locale devices produced Eastern-Arabic numerals → server ArgumentError.
+- (void)testPurchaseTimeDateFormatterProducesLocaleIndependentOutput {
+  // Fixed timestamp for deterministic output: 2024-01-15T11:50:45 UTC
+  NSDate* date = [NSDate dateWithTimeIntervalSince1970:1705319445];
+
+  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+  [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+  [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
+  [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
+
+  XCTAssertEqualObjects([formatter stringFromDate:date], @"2024-01-15T11:50:45+0000",
+                        @"purchase_time must use ASCII digits regardless of device locale");
+}
+
+// Verifies the Sentry timestamp formatter (TeakRaven) has the same en_US_POSIX fix applied.
+// en_US_POSIX pins digits to ASCII without changing the ISO8601 format Sentry expects.
+- (void)testRavenDateFormatterProducesLocaleIndependentOutput {
+  NSDate* date = [NSDate dateWithTimeIntervalSince1970:1705319445];
+
+  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+  [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+  [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
+  [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
+
+  XCTAssertEqualObjects([formatter stringFromDate:date], @"2024-01-15T11:50:45",
+                        @"Sentry timestamp must use ASCII digits regardless of device locale");
+}
+
+@end

--- a/Automated/AutomatedTests/SKPaymentObserverTests.m
+++ b/Automated/AutomatedTests/SKPaymentObserverTests.m
@@ -1,42 +1,38 @@
 #import <XCTest/XCTest.h>
 
-#import <Teak/Teak.h>
+#import "SKPaymentObserver.h"
+#import "TeakRaven.h"
 
-@import OCHamcrest;
-@import OCMockito;
+// SKPaymentObserver.transactionDateFormatter is private — re-declare for test access.
+@interface SKPaymentObserver (Testing)
++ (NSDateFormatter*)transactionDateFormatter;
+@end
+
+// TeakRavenReport is defined in TeakRaven.m; dateFormatter is its only method we need.
+@interface TeakRavenReport : NSObject
++ (NSDateFormatter*)dateFormatter;
+@end
 
 @interface SKPaymentObserverTests : XCTestCase
 @end
 
 @implementation SKPaymentObserverTests
 
-// Verifies that purchase_time uses en_US_POSIX locale so that devices with a non-ASCII-numeral
-// locale (e.g. Arabic) still produce ASCII digits the server can parse. The bug: without an
-// explicit locale, Arabic-locale devices produced Eastern-Arabic numerals → server ArgumentError.
+// Verifies purchase_time uses en_US_POSIX so Arabic-locale devices don't produce
+// Eastern-Arabic numerals the server can't parse (C-302 / ArgumentError: mon out of range).
 - (void)testPurchaseTimeDateFormatterProducesLocaleIndependentOutput {
-  // Fixed timestamp for deterministic output: 2024-01-15T11:50:45 UTC
-  NSDate* date = [NSDate dateWithTimeIntervalSince1970:1705319445];
-
-  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-  [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
-  [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
-  [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
-
-  XCTAssertEqualObjects([formatter stringFromDate:date], @"2024-01-15T11:50:45+0000",
+  NSDate* date = [NSDate dateWithTimeIntervalSince1970:1705319445]; // 2024-01-15T11:50:45 UTC
+  NSString* formatted = [[SKPaymentObserver transactionDateFormatter] stringFromDate:date];
+  XCTAssertEqualObjects(formatted, @"2024-01-15T11:50:45+0000",
                         @"purchase_time must use ASCII digits regardless of device locale");
 }
 
 // Verifies the Sentry timestamp formatter (TeakRaven) has the same en_US_POSIX fix applied.
 // en_US_POSIX pins digits to ASCII without changing the ISO8601 format Sentry expects.
 - (void)testRavenDateFormatterProducesLocaleIndependentOutput {
-  NSDate* date = [NSDate dateWithTimeIntervalSince1970:1705319445];
-
-  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-  [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
-  [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
-  [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
-
-  XCTAssertEqualObjects([formatter stringFromDate:date], @"2024-01-15T11:50:45",
+  NSDate* date = [NSDate dateWithTimeIntervalSince1970:1705319445]; // 2024-01-15T11:50:45 UTC
+  NSString* formatted = [[TeakRavenReport dateFormatter] stringFromDate:date];
+  XCTAssertEqualObjects(formatted, @"2024-01-15T11:50:45",
                         @"Sentry timestamp must use ASCII digits regardless of device locale");
 }
 

--- a/Teak/Store/SKPaymentObserver.m
+++ b/Teak/Store/SKPaymentObserver.m
@@ -43,6 +43,7 @@
 
     teak_log_breadcrumb(@"Building date formatter");
     NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+    [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
     [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
 

--- a/Teak/Store/SKPaymentObserver.m
+++ b/Teak/Store/SKPaymentObserver.m
@@ -17,6 +17,15 @@
 @end
 
 @implementation SKPaymentObserver
+
++ (NSDateFormatter*)transactionDateFormatter {
+  NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+  [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+  [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
+  [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
+  return formatter;
+}
+
 - (id)init {
   self = [super init];
   if (self) {
@@ -42,10 +51,7 @@
     TeakLog_i(@"transaction.purchased", @{@"purchase_duration" : _(purchaseDuration)});
 
     teak_log_breadcrumb(@"Building date formatter");
-    NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-    [formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
-    [formatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
-    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
+    NSDateFormatter* formatter = [SKPaymentObserver transactionDateFormatter];
 
     teak_log_breadcrumb(@"Getting info from App Store receipt");
     NSURL* receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -530,6 +530,7 @@ void TeakSignalHandler(int signal) {
   dispatch_once(&onceToken, ^{
     NSTimeZone* timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
     dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormatter setTimeZone:timeZone];
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
   });


### PR DESCRIPTION
https://linear.app/teakio/issue/C-302/purchase-time-is-being-localized-and-it-should-not-be

NSDateFormatter defaults to [NSLocale currentLocale], so Arabic-locale devices produced Eastern-Arabic numerals in date strings sent to the server → ArgumentError: mon out of range.

Fix: add `[formatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]]` to each formatter that sends timestamps to an external system. Also caught the same bug in TeakRaven.m (Sentry timestamps) during a sibling audit — same one-line fix. TeakLog.m was already clean.

New `SKPaymentObserverTests.m` has two regression tests verifying both formatter configurations produce ASCII ISO 8601 output.

[sdks-teak-ios-worker-c-302]