### PR TITLE
Make TeakSession state-machine fields atomic for consistent locking

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
 		6D15A01FD0A680A1CD603491 /* TeakRavenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */; };
 		6D792A77134D055F66346BC3 /* PushToStartTokenRegistrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */; };
+		6FF622EDF0E531603BB01BE3 /* TeakSessionLockingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C93E5C5C2DBE62981455D4A7 /* TeakSessionLockingTests.m */; };
 		7FEB52BB31B7C9926174546D /* NotificationSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */; };
 		9094BF0120E894EDA3CA1D75 /* SKPaymentObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */; };
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
@@ -146,6 +147,7 @@
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
 		C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRavenTests.m; sourceTree = "<group>"; };
+		C93E5C5C2DBE62981455D4A7 /* TeakSessionLockingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakSessionLockingTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateCancellationTests.m; sourceTree = "<group>"; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -270,6 +272,7 @@
 				2286E8051950D4EC6E1C79EF /* TeakSessionDeferredCallbackTests.m */,
 				C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */,
 				58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */,
+				C93E5C5C2DBE62981455D4A7 /* TeakSessionLockingTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -603,6 +606,7 @@
 				440EB1A255029FAF5B1ACEB9 /* TeakSessionDeferredCallbackTests.m in Sources */,
 				6D15A01FD0A680A1CD603491 /* TeakRavenTests.m in Sources */,
 				9094BF0120E894EDA3CA1D75 /* SKPaymentObserverTests.m in Sources */,
+				6FF622EDF0E531603BB01BE3 /* TeakSessionLockingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakSessionLockingTests.m
+++ b/Automated/AutomatedTests/TeakSessionLockingTests.m
@@ -3,19 +3,19 @@
 #import "TeakSession.h"
 #import <objc/runtime.h>
 
-// C-837: TeakSession.currentState and previousState are read in the currentSessionMutex
-// lock domain (the class methods) but written under @synchronized(self). They must be
-// declared `atomic` so a cross-domain read can't tear. A behavioral race test isn't
-// feasible — on ARM64 aligned pointer reads don't actually tear, so the race is formal
-// (UB / TSan-detectable) rather than observable. These tests instead pin the property
-// declarations to atomic via the Objective-C runtime, and fail if either is reverted.
+// TeakSession.currentState and previousState are read in the currentSessionMutex lock
+// domain (the class methods) but written under @synchronized(self), so they must be
+// declared `atomic` to keep a cross-domain read from tearing. A behavioral race test
+// isn't feasible — on ARM64 aligned pointer reads don't actually tear, so the race is
+// formal (UB / TSan-detectable) rather than observable. These tests instead pin the
+// property declarations to atomic via the Objective-C runtime, and fail if either reverts.
 @interface TeakSessionLockingTests : XCTestCase
 @end
 
 @implementation TeakSessionLockingTests
 
 // YES if the named property carries the nonatomic flag (the "N" token in its runtime
-// attribute string), which would reintroduce the C-837 torn-read race.
+// attribute string), which would reintroduce the torn-read race.
 - (BOOL)isNonatomicProperty:(const char*)name {
   objc_property_t property = class_getProperty([TeakSession class], name);
   XCTAssertTrue(property != NULL, @"TeakSession has no property named %s", name);
@@ -26,12 +26,12 @@
 
 - (void)testCurrentStateIsAtomic {
   XCTAssertFalse([self isNonatomicProperty:"currentState"],
-                 @"TeakSession.currentState must stay atomic — read under currentSessionMutex, written under @synchronized(self) (C-837)");
+                 @"TeakSession.currentState must stay atomic — read under currentSessionMutex, written under @synchronized(self)");
 }
 
 - (void)testPreviousStateIsAtomic {
   XCTAssertFalse([self isNonatomicProperty:"previousState"],
-                 @"TeakSession.previousState must stay atomic — same cross-lock-domain access as currentState (C-837)");
+                 @"TeakSession.previousState must stay atomic — same cross-lock-domain access as currentState");
 }
 
 @end

--- a/Automated/AutomatedTests/TeakSessionLockingTests.m
+++ b/Automated/AutomatedTests/TeakSessionLockingTests.m
@@ -1,0 +1,37 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakSession.h"
+#import <objc/runtime.h>
+
+// C-837: TeakSession.currentState and previousState are read in the currentSessionMutex
+// lock domain (the class methods) but written under @synchronized(self). They must be
+// declared `atomic` so a cross-domain read can't tear. A behavioral race test isn't
+// feasible — on ARM64 aligned pointer reads don't actually tear, so the race is formal
+// (UB / TSan-detectable) rather than observable. These tests instead pin the property
+// declarations to atomic via the Objective-C runtime, and fail if either is reverted.
+@interface TeakSessionLockingTests : XCTestCase
+@end
+
+@implementation TeakSessionLockingTests
+
+// YES if the named property carries the nonatomic flag (the "N" token in its runtime
+// attribute string), which would reintroduce the C-837 torn-read race.
+- (BOOL)isNonatomicProperty:(const char*)name {
+  objc_property_t property = class_getProperty([TeakSession class], name);
+  XCTAssertTrue(property != NULL, @"TeakSession has no property named %s", name);
+  if (property == NULL) return YES;
+  NSString* attributes = @(property_getAttributes(property));
+  return [[attributes componentsSeparatedByString:@","] containsObject:@"N"];
+}
+
+- (void)testCurrentStateIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"currentState"],
+                 @"TeakSession.currentState must stay atomic — read under currentSessionMutex, written under @synchronized(self) (C-837)");
+}
+
+- (void)testPreviousStateIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"previousState"],
+                 @"TeakSession.previousState must stay atomic — same cross-lock-domain access as currentState (C-837)");
+}
+
+@end

--- a/Teak/TeakSession.h
+++ b/Teak/TeakSession.h
@@ -25,7 +25,7 @@ typedef void (^UserIdReadyBlock)(TeakSession* _Nonnull);
 @property (strong, nonatomic, readwrite) NSString* _Nullable email;
 @property (strong, nonatomic, readonly) NSString* _Nullable facebookId;
 @property (strong, nonatomic, readonly) NSString* _Nonnull sessionId;
-@property (strong, nonatomic, readonly) TeakState* _Nonnull currentState;
+@property (strong, atomic, readonly) TeakState* _Nonnull currentState;
 @property (strong, nonatomic, readonly) TeakUserProfile* _Nonnull userProfile;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull emailStatus;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull pushStatus;

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -29,8 +29,10 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 
 @interface TeakSession ()
 // currentState/previousState are atomic: these state-machine fields are read in the
-// currentSessionMutex lock domain (the class methods) but written under @synchronized(self),
-// so atomic accessors prevent a torn read across that lock boundary (C-837).
+// currentSessionMutex lock domain (the class methods) but written under @synchronized(self)
+// in -setState:. previousState is additionally written lock-free in the -sendUserIdentifier
+// request callback, so that read is otherwise wholly unsynchronized. atomic accessors
+// prevent a torn read across all of those boundaries (C-837).
 @property (strong, atomic, readwrite) TeakState* currentState;
 @property (strong, atomic) TeakState* previousState;
 @property (strong, nonatomic) NSDate* startDate;

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -28,8 +28,11 @@ extern BOOL TeakLink_HandleDeepLink(NSURL* deepLink);
 extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 
 @interface TeakSession ()
-@property (strong, nonatomic, readwrite) TeakState* currentState;
-@property (strong, nonatomic) TeakState* previousState;
+// currentState/previousState are atomic: these state-machine fields are read in the
+// currentSessionMutex lock domain (the class methods) but written under @synchronized(self),
+// so atomic accessors prevent a torn read across that lock boundary (C-837).
+@property (strong, atomic, readwrite) TeakState* currentState;
+@property (strong, atomic) TeakState* previousState;
 @property (strong, nonatomic) NSDate* startDate;
 @property (strong, nonatomic) NSDate* endDate;
 @property (strong, nonatomic) NSString* countryCode;

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -32,7 +32,7 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 // currentSessionMutex lock domain (the class methods) but written under @synchronized(self)
 // in -setState:. previousState is additionally written lock-free in the -sendUserIdentifier
 // request callback, so that read is otherwise wholly unsynchronized. atomic accessors
-// prevent a torn read across all of those boundaries (C-837).
+// prevent a torn read across those boundaries.
 @property (strong, atomic, readwrite) TeakState* currentState;
 @property (strong, atomic) TeakState* previousState;
 @property (strong, nonatomic) NSDate* startDate;


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/C-837

## Problem
`TeakSession.currentState` was `nonatomic` but read in the `currentSessionMutex` lock domain (the `+` class methods) while written under `@synchronized(self)` in `setState:`. That's a formal data race across two lock domains — benign today only because the state values are singletons and ARM64 aligned pointer reads don't tear, but a latent torn-read waiting for a non-singleton value or a tearing compiler. Surfaced by the C-615 write+read audit. `previousState` shares the same defect, and is actually worse — it's written with no lock at all in the `sendUserIdentifier` callback.

## Fix
Declare `currentState` and `previousState` `atomic`. This closes the torn-read race on every access path with **zero lock-topology change** — no `@synchronized` block is added, removed, or reordered, so no new deadlock surface. The existing locks keep guarding the compound check-then-act invariants; atomic is purely additive on the word access. Chosen over consolidating on one lock, which would mean nesting `@synchronized(currentSession)` inside `currentSessionMutex` at every read site and widening an existing lock-order inversion — too much blast radius for a 4.3.x maintenance release.

## Test
`TeakSessionLockingTests` pins both properties to atomic via the Obj-C runtime attribute string and **fails if either is reverted to nonatomic** (verified). A behavioral race test isn't feasible — the race is formal/TSan-detectable, not observable (ARM64 reads don't tear), and the default test scheme doesn't run TSan.

Full unit bundle (132 tests) green.

## Out of scope (flagged for follow-up)
A real lock-order inversion exists independent of this fix: the transition-to-`UserIdentified` KVO observer grabs `currentSessionMutex` while holding `@synchronized(self)`, whereas `setUserId`/`logout` take `currentSessionMutex` then `self` — a latent cross-thread deadlock. Not touched here.
