### PR TITLE
Classify reward attribution when iOSPath absent (align with Android)

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
 		C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */; };
+		DDD903E4475B291CE2D4DD1E /* TeakResolvedLinkClassificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */; };
 		F05085BD353FDBF2763B09C7 /* LiveActivityTokenForwardingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */; };
 		F10455A046CB359057A63D58 /* TeakOperationTestDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 49655D0CF74258D769DEA6F9 /* TeakOperationTestDriver.m */; };
 		F4B9E6A620B8C3BC50CCB7CE /* libPods-Automated.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */; };
@@ -135,6 +136,7 @@
 		58899BE40E40447A87FDF2D8 /* Pods-AutomatedTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.release.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.release.xcconfig"; sourceTree = "<group>"; };
 		58C2AA35CD060472CAC08059 /* Pods-Automated.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.debug.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.debug.xcconfig"; sourceTree = "<group>"; };
 		58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKPaymentObserverTests.m; sourceTree = "<group>"; };
+		5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakResolvedLinkClassificationTests.m; sourceTree = "<group>"; };
 		688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakLiveActivityLaunchDataTests.m; sourceTree = "<group>"; };
 		6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UserDataEventTests.m; sourceTree = "<group>"; };
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */,
 				58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */,
 				C93E5C5C2DBE62981455D4A7 /* TeakSessionLockingTests.m */,
+				5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -607,6 +610,7 @@
 				6D15A01FD0A680A1CD603491 /* TeakRavenTests.m in Sources */,
 				9094BF0120E894EDA3CA1D75 /* SKPaymentObserverTests.m in Sources */,
 				6FF622EDF0E531603BB01BE3 /* TeakSessionLockingTests.m in Sources */,
+				DDD903E4475B291CE2D4DD1E /* TeakResolvedLinkClassificationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakResolvedLinkClassificationTests.m
+++ b/Automated/AutomatedTests/TeakResolvedLinkClassificationTests.m
@@ -1,0 +1,104 @@
+#import <XCTest/XCTest.h>
+
+#import <Teak/Teak.h>
+
+#import "TeakLaunchData.h"
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose the pure classifier so tests can exercise it without the network
+// round-trip in resolveUniversalLink:. resolvedUrl is what the server returned as
+// iOSPath (nil when omitted); shortLink is the original universal/launch link.
+@interface TeakLaunchDataOperation (Testing)
++ (TeakLaunchData*)launchDataFromResolvedUrl:(NSURL*)resolvedUrl shortLink:(NSURL*)shortLink;
+@end
+
+@interface TeakResolvedLinkClassificationTests : XCTestCase
+@end
+
+@implementation TeakResolvedLinkClassificationTests
+
+#pragma mark - iOSPath present (happy path — behavior must be unchanged)
+
+/// Server returned an iOSPath carrying reward params: classify from the resolved
+/// deep link, keep the short link as launchUrl.
+- (void)testResolvedRewardLinkClassifiesFromResolvedUrl {
+  NSURL* resolvedUrl = [NSURL URLWithString:@"teaktest-app://reward?teak_rewardlink_id=abc&teak_reward_id=99"];
+  NSURL* shortLink = [NSURL URLWithString:@"https://test.jckpt.com/x"];
+
+  TeakLaunchData* data = [TeakLaunchDataOperation launchDataFromResolvedUrl:resolvedUrl shortLink:shortLink];
+
+  XCTAssertTrue([data isKindOfClass:[TeakRewardlinkLaunchData class]]);
+  TeakAttributedLaunchData* attributed = (TeakAttributedLaunchData*)data;
+  XCTAssertEqualObjects(attributed.launchUrl.absoluteString, shortLink.absoluteString);
+  XCTAssertEqualObjects(attributed.deepLink.absoluteString, resolvedUrl.absoluteString);
+  XCTAssertEqualObjects(attributed.rewardId, @"99");
+  XCTAssertEqualObjects(attributed.creativeId, @"abc");
+}
+
+/// Server returned an iOSPath carrying a notif id: classify as a notification launch.
+- (void)testResolvedNotifLinkClassifiesFromResolvedUrl {
+  NSURL* resolvedUrl = [NSURL URLWithString:@"teaktest-app://open?teak_notif_id=555"];
+  NSURL* shortLink = [NSURL URLWithString:@"https://test.jckpt.com/x"];
+
+  TeakLaunchData* data = [TeakLaunchDataOperation launchDataFromResolvedUrl:resolvedUrl shortLink:shortLink];
+
+  XCTAssertTrue([data isKindOfClass:[TeakNotificationLaunchData class]]);
+  XCTAssertEqualObjects(((TeakNotificationLaunchData*)data).sourceSendId, @"555");
+}
+
+/// Server resolved to a plain deep link with no teak_* params: unattributed launch,
+/// short link retained as launchUrl.
+- (void)testResolvedPlainLinkIsUnattributed {
+  NSURL* resolvedUrl = [NSURL URLWithString:@"teaktest-app://home"];
+  NSURL* shortLink = [NSURL URLWithString:@"https://test.jckpt.com/x"];
+
+  TeakLaunchData* data = [TeakLaunchDataOperation launchDataFromResolvedUrl:resolvedUrl shortLink:shortLink];
+
+  XCTAssertFalse([data isKindOfClass:[TeakAttributedLaunchData class]]);
+  XCTAssertEqualObjects(data.launchUrl.absoluteString, shortLink.absoluteString);
+}
+
+#pragma mark - iOSPath absent (the C-836 fix — classify from the original launch link)
+
+/// THE regression guard. When the server omits iOSPath, resolvedUrl is nil and the
+/// reward params live on the original launch link. Before the `?: shortLink` fallback
+/// this dropped to a plain TeakLaunchData and lost reward attribution; reverting the
+/// fix makes this assertion fail.
+- (void)testAbsentIOSPathRewardClassifiesFromShortLink {
+  NSURL* shortLink = [NSURL URLWithString:@"https://test.jckpt.com/x?teak_rewardlink_id=abc&teak_reward_id=99"];
+
+  TeakLaunchData* data = [TeakLaunchDataOperation launchDataFromResolvedUrl:nil shortLink:shortLink];
+
+  XCTAssertTrue([data isKindOfClass:[TeakRewardlinkLaunchData class]],
+                @"reward attribution on the launch link must survive an absent iOSPath");
+  TeakAttributedLaunchData* attributed = (TeakAttributedLaunchData*)data;
+  XCTAssertEqualObjects(attributed.launchUrl.absoluteString, shortLink.absoluteString);
+  XCTAssertEqualObjects(attributed.deepLink.absoluteString, shortLink.absoluteString);
+  XCTAssertEqualObjects(attributed.rewardId, @"99");
+  XCTAssertEqualObjects(attributed.creativeId, @"abc");
+}
+
+/// Same fallback for notification links carried on the launch link itself.
+- (void)testAbsentIOSPathNotifClassifiesFromShortLink {
+  NSURL* shortLink = [NSURL URLWithString:@"https://test.jckpt.com/x?teak_notif_id=555"];
+
+  TeakLaunchData* data = [TeakLaunchDataOperation launchDataFromResolvedUrl:nil shortLink:shortLink];
+
+  XCTAssertTrue([data isKindOfClass:[TeakNotificationLaunchData class]]);
+  XCTAssertEqualObjects(((TeakNotificationLaunchData*)data).sourceSendId, @"555");
+}
+
+/// Absent iOSPath with no teak_* params on the launch link is still unattributed —
+/// the fallback must not manufacture attribution out of a plain link.
+- (void)testAbsentIOSPathNoTeakParamsIsUnattributed {
+  NSURL* shortLink = [NSURL URLWithString:@"https://test.jckpt.com/x"];
+
+  TeakLaunchData* data = [TeakLaunchDataOperation launchDataFromResolvedUrl:nil shortLink:shortLink];
+
+  XCTAssertFalse([data isKindOfClass:[TeakAttributedLaunchData class]]);
+  XCTAssertEqualObjects(data.launchUrl.absoluteString, shortLink.absoluteString);
+}
+
+@end

--- a/Automated/AutomatedTests/TeakResolvedLinkClassificationTests.m
+++ b/Automated/AutomatedTests/TeakResolvedLinkClassificationTests.m
@@ -60,7 +60,7 @@
   XCTAssertEqualObjects(data.launchUrl.absoluteString, shortLink.absoluteString);
 }
 
-#pragma mark - iOSPath absent (the C-836 fix — classify from the original launch link)
+#pragma mark - iOSPath absent (the fix — classify from the original launch link)
 
 /// THE regression guard. When the server omits iOSPath, resolvedUrl is nil and the
 /// reward params live on the original launch link. Before the `?: shortLink` fallback

--- a/Teak/Core/TeakLaunchData.m
+++ b/Teak/Core/TeakLaunchData.m
@@ -229,13 +229,14 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
                      }
 
                      TeakLog_i(@"deep_link.request.resolve", self.resolvedLaunchUrl.absoluteString);
-                   } else if ([reply isKindOfClass:NSDictionary.class] && reply.count > 0) {
+                   } else if (reply.count > 0) {
                      // A resolved link is expected to carry an iOSPath; a well-formed
                      // response that omits it (e.g. an Android-only link) is anomalous,
                      // so report it with the URL and body to surface which links omit
                      // the key. Attribution still survives via the original launch link
-                     // in launchDataFromResolvedUrl:shortLink:. Empty/malformed bodies
-                     // (count 0, or not a dictionary) fall through and stay out of the log.
+                     // in launchDataFromResolvedUrl:shortLink:. The count gate skips an
+                     // empty body, mirroring Android's teakData.length() > 0. (A malformed
+                     // body parses to error != nil and is handled in the else below.)
                      TeakLog_e(@"deep_link.no_ios_path", @{
                        @"url" : url.absoluteString,
                        @"response" : [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]

--- a/Teak/Core/TeakLaunchData.m
+++ b/Teak/Core/TeakLaunchData.m
@@ -83,6 +83,27 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
   return [[TeakLaunchData alloc] initWithUrl:url];
 }
 
+// Classify a resolved universal link. When the server omits iOSPath, resolvedUrl is
+// nil and we fall back to the original launch link so reward/notification attribution
+// carried on the link itself isn't lost — mirroring teak-android's launchDataFromUriPair,
+// which classifies the original launch link when AndroidPath is absent. Distinct from
+// launchDataFromUrl:withShortlink: above: that one drops the short link (launchUrl=nil)
+// for reward links, whereas here the short link is retained as launchUrl.
++ (TeakLaunchData*)launchDataFromResolvedUrl:(NSURL*)resolvedUrl shortLink:(NSURL*)shortLink {
+  NSURL* attributionUrl = NewIfNotOld(resolvedUrl, shortLink);
+  NSDictionary* query = TeakGetQueryParameterDictionaryFromUrl(attributionUrl);
+  if (query[@"teak_rewardlink_id"]) {
+    // If it has a 'teak_rewardlink_id' then it's a reward link
+    return [[TeakRewardlinkLaunchData alloc] initWithUrl:attributionUrl andShortLink:shortLink];
+  } else if (query[@"teak_notif_id"]) {
+    // If it has a 'teak_notif_id' then it's a notification
+    return [[TeakNotificationLaunchData alloc] initWithUrl:attributionUrl];
+  }
+
+  // Otherwise this is not a Teak attributed launch
+  return [[TeakLaunchData alloc] initWithUrl:shortLink];
+}
+
 + (TeakLaunchDataOperation*)fromOpenUrl:(NSURL*)url {
   TeakLaunchData* launchData = [TeakLaunchDataOperation launchDataFromUrl:url withShortlink:nil];
   return [[TeakLaunchDataOperation alloc] initWithLaunchData:launchData];
@@ -141,26 +162,15 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
 // This will get run as an NSInvocationOperation
 - (TeakLaunchData*)resolveUniversalLink:(NSURL*)url {
   // Resolve the universal link, wait for the NSURLSession to complete (or timeout)
-  // then run super, which will use the updated contents.
+  // then classify the result.
   dispatch_semaphore_t sema = dispatch_semaphore_create(0);
   [self resolveUniversalLink:url retryCount:0 thenSignal:sema];
   dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
 
-  // NOTE: This is different logic for what goes into the unattributed
-  // launch case from launchDataFromUrl:andShortLink:
-
-  // Process the resolved link
-  NSDictionary* query = TeakGetQueryParameterDictionaryFromUrl(self.resolvedLaunchUrl);
-  if (query[@"teak_rewardlink_id"]) {
-    // If it has a 'teak_rewardlink_id' then it's a reward link
-    return [[TeakRewardlinkLaunchData alloc] initWithUrl:self.resolvedLaunchUrl andShortLink:url];
-  } else if (query[@"teak_notif_id"]) {
-    // If it has a 'teak_notif_id' then it's a notification
-    return [[TeakNotificationLaunchData alloc] initWithUrl:self.resolvedLaunchUrl];
-  }
-
-  // Otherwise this is not a Teak attributed launch
-  return [[TeakLaunchData alloc] initWithUrl:url];
+  // resolvedLaunchUrl is set only when the server returned an iOSPath; when it's
+  // absent (or the request failed) the classifier falls back to the original launch
+  // link so reward/notification attribution on the link itself isn't lost.
+  return [TeakLaunchDataOperation launchDataFromResolvedUrl:self.resolvedLaunchUrl shortLink:url];
 }
 
 - (void)resolveUniversalLink:(NSURL*)url retryCount:(int)retryCount thenSignal:(dispatch_semaphore_t)sema {
@@ -219,6 +229,17 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
                      }
 
                      TeakLog_i(@"deep_link.request.resolve", self.resolvedLaunchUrl.absoluteString);
+                   } else if ([reply isKindOfClass:NSDictionary.class] && reply.count > 0) {
+                     // A resolved link is expected to carry an iOSPath; a well-formed
+                     // response that omits it (e.g. an Android-only link) is anomalous,
+                     // so report it with the URL and body to surface which links omit
+                     // the key. Attribution still survives via the original launch link
+                     // in launchDataFromResolvedUrl:shortLink:. Empty/malformed bodies
+                     // (count 0, or not a dictionary) fall through and stay out of the log.
+                     TeakLog_e(@"deep_link.no_ios_path", @{
+                       @"url" : url.absoluteString,
+                       @"response" : [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]
+                     });
                    }
                  } else {
                    TeakLog_e(@"deep_link.json.error", @{


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/C-836

## Problem

`resolveUniversalLink:` classified reward/notification launches off `self.resolvedLaunchUrl` only, which is set **only** when the server returns an `iOSPath`. When `iOSPath` was omitted (or the resolution request failed), the query was empty and the launch dropped to a plain `TeakLaunchData` — silently losing reward attribution carried on the link itself. teak-android keeps the original launch link as the classification source in that case (`launchDataFromUriPair`), so iOS was the weaker side (from the C-736 investigation).

## Fix

- Extract a pure, network-free classifier `+launchDataFromResolvedUrl:shortLink:` that falls back to the original launch link when `resolvedUrl` is nil, then classifies reward → notif → plain. Happy path (`resolvedUrl` non-nil) is **byte-for-byte identical**; the fallback restores attribution on the absent-`iOSPath` and request-failure paths, mirroring Android. Kept distinct from the existing `launchDataFromUrl:withShortlink:` because that path deliberately drops the short link for reward links (`launchUrl=nil`) whereas this one retains it.
- Report a `deep_link.no_ios_path` **ERROR** when a well-formed (non-empty dict) resolution response omits `iOSPath`, so the previously-silent drop is observable (C-863). Gated on a non-empty dictionary to keep malformed/empty bodies out — mirrors Android's `teakData.length() > 0` gate. iOS `TeakLog` has no WARN tier, and an `iOSPath`-less resolved link is anomalous, so ERROR is the right level.

## Tests

`TeakResolvedLinkClassificationTests` exercises the classifier directly across resolved (reward/notif/plain) and absent-`iOSPath` (reward/notif/none) cases. The absent-`iOSPath` reward/notif tests fail if the `?: shortLink` fallback is reverted (verified). Full suite green (139 tests).