### PR TITLE
Retry requests when the OS closes a socket without reopening it

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
 		C4FC8AA560BCA9293B0508AA /* DebugConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */; };
+		CF22EC2983C75A4444F429C6 /* TeakRequestSocketErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DC251E1F09B0739648086440 /* TeakRequestSocketErrorTests.m */; };
 		DDD903E4475B291CE2D4DD1E /* TeakResolvedLinkClassificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */; };
 		F05085BD353FDBF2763B09C7 /* LiveActivityTokenForwardingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */; };
 		F10455A046CB359057A63D58 /* TeakOperationTestDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 49655D0CF74258D769DEA6F9 /* TeakOperationTestDriver.m */; };
@@ -151,6 +152,7 @@
 		C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRavenTests.m; sourceTree = "<group>"; };
 		C93E5C5C2DBE62981455D4A7 /* TeakSessionLockingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakSessionLockingTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC251E1F09B0739648086440 /* TeakRequestSocketErrorTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRequestSocketErrorTests.m; sourceTree = "<group>"; };
 		E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateCancellationTests.m; sourceTree = "<group>"; };
 		EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Automated.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakCExternLiveActivityTests.m; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */,
 				C93E5C5C2DBE62981455D4A7 /* TeakSessionLockingTests.m */,
 				5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */,
+				DC251E1F09B0739648086440 /* TeakRequestSocketErrorTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -611,6 +614,7 @@
 				9094BF0120E894EDA3CA1D75 /* SKPaymentObserverTests.m in Sources */,
 				6FF622EDF0E531603BB01BE3 /* TeakSessionLockingTests.m in Sources */,
 				DDD903E4475B291CE2D4DD1E /* TeakResolvedLinkClassificationTests.m in Sources */,
+				CF22EC2983C75A4444F429C6 /* TeakRequestSocketErrorTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakRequestSocketErrorTests.m
+++ b/Automated/AutomatedTests/TeakRequestSocketErrorTests.m
@@ -1,0 +1,77 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakRequest.h"
+#import <Teak/Teak.h>
+
+#include <sys/errno.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Re-expose the internal predicate so tests can exercise it without driving
+// a full NSURLSession round-trip. See CLAUDE.md "Header imports in tests".
+@interface TeakRequest (SocketErrorTests)
++ (BOOL)isRetryableSocketError:(NSError* _Nullable)error;
+@end
+
+@interface TeakRequestSocketErrorTests : XCTestCase
+@end
+
+@implementation TeakRequestSocketErrorTests
+
+#pragma mark - nil
+
+- (void)testNilErrorIsNotRetryable {
+  XCTAssertFalse([TeakRequest isRetryableSocketError:nil]);
+}
+
+#pragma mark - The verified production shape: top-level NSPOSIXErrorDomain/ECONNABORTED
+
+// This is the exact error TeakLog's analogous retry was built from
+// production telemetry to handle, and matches Apple's own documented
+// "NSURLSessionTask receives error 53 when app is relaunched from
+// background" failure mode.
+- (void)testTopLevelPOSIXConnectionAbortedIsRetryable {
+  NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
+  XCTAssertTrue([TeakRequest isRetryableSocketError:error]);
+}
+
+- (void)testTopLevelPOSIXOtherCodeIsNotRetryable {
+  NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ENOTCONN userInfo:nil];
+  XCTAssertFalse([TeakRequest isRetryableSocketError:error]);
+}
+
+#pragma mark - Boundary: a same-shaped error in a different domain does not match
+
+- (void)testSameCodeInDifferentDomainIsNotRetryable {
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:ECONNABORTED userInfo:nil];
+  XCTAssertFalse([TeakRequest isRetryableSocketError:error]);
+}
+
+// NSURLErrorNetworkConnectionLost is a distinct failure (connection severed
+// mid-load, often server-side) with its own nested CFNetwork stream codes —
+// not the OS-background-socket case this predicate targets.
+- (void)testNetworkConnectionLostIsNotRetryable {
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
+  XCTAssertFalse([TeakRequest isRetryableSocketError:error]);
+}
+
+#pragma mark - Nested under NSUnderlyingErrorKey
+
+- (void)testNestedUnderlyingPOSIXConnectionAbortedIsRetryable {
+  NSError* underlying = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain
+                                        code:NSURLErrorUnknown
+                                    userInfo:@{NSUnderlyingErrorKey : underlying}];
+  XCTAssertTrue([TeakRequest isRetryableSocketError:error]);
+}
+
+- (void)testNestedUnderlyingPOSIXOtherCodeIsNotRetryable {
+  NSError* underlying = [NSError errorWithDomain:NSPOSIXErrorDomain code:ENOTCONN userInfo:nil];
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain
+                                        code:NSURLErrorUnknown
+                                    userInfo:@{NSUnderlyingErrorKey : underlying}];
+  XCTAssertFalse([TeakRequest isRetryableSocketError:error]);
+}
+
+@end

--- a/Automated/AutomatedTests/TeakRequestSocketErrorTests.m
+++ b/Automated/AutomatedTests/TeakRequestSocketErrorTests.m
@@ -13,7 +13,7 @@
 // tests".
 @interface TeakRequest (SocketErrorTests)
 + (BOOL)isRetryableSocketError:(NSError* _Nullable)error;
-+ (BOOL)shouldRetrySocketError:(NSError* _Nullable)error alreadyRetried:(BOOL)alreadyRetried;
++ (BOOL)shouldRetrySocketError:(NSError* _Nullable)error retryCount:(NSUInteger)retryCount;
 @end
 
 @interface TeakRequestSocketErrorTests : XCTestCase
@@ -79,33 +79,38 @@
 @end
 
 ///// The retry gate: response:payload:withError: calls
-///// +shouldRetrySocketError:alreadyRetried: to decide whether to fire the
-///// one-shot retry. These pin the full truth table so the gate can't loop or
-///// silently stop retrying a fresh socket error.
+///// +shouldRetrySocketError:retryCount: to decide whether to fire another
+///// retry. These pin the count boundary so the gate can't loop past the stop
+///// policy or silently stop retrying a fresh socket error.
 
 @interface TeakRequestRetryGateTests : XCTestCase
 @end
 
 @implementation TeakRequestRetryGateTests
 
-- (void)testRetriesAFreshSocketError {
+- (void)testRetriesASocketErrorBelowTheLimit {
   NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
-  XCTAssertTrue([TeakRequest shouldRetrySocketError:error alreadyRetried:NO]);
+  XCTAssertTrue([TeakRequest shouldRetrySocketError:error retryCount:0]);
 }
 
-- (void)testDoesNotRetryASocketErrorTwice {
+- (void)testDoesNotRetryASocketErrorAtTheLimit {
   NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
-  XCTAssertFalse([TeakRequest shouldRetrySocketError:error alreadyRetried:YES]);
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:1]);
 }
 
-- (void)testDoesNotRetryANonSocketErrorWhenFresh {
-  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
-  XCTAssertFalse([TeakRequest shouldRetrySocketError:error alreadyRetried:NO]);
+- (void)testDoesNotRetryASocketErrorPastTheLimit {
+  NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:2]);
 }
 
-- (void)testDoesNotRetryANonSocketErrorAlreadyRetried {
+- (void)testDoesNotRetryANonSocketErrorBelowTheLimit {
   NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
-  XCTAssertFalse([TeakRequest shouldRetrySocketError:error alreadyRetried:YES]);
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:0]);
+}
+
+- (void)testDoesNotRetryANonSocketErrorAtTheLimit {
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:1]);
 }
 
 @end

--- a/Automated/AutomatedTests/TeakRequestSocketErrorTests.m
+++ b/Automated/AutomatedTests/TeakRequestSocketErrorTests.m
@@ -8,10 +8,12 @@
 @import OCHamcrest;
 @import OCMockito;
 
-// Re-expose the internal predicate so tests can exercise it without driving
-// a full NSURLSession round-trip. See CLAUDE.md "Header imports in tests".
+// Re-expose the internal predicates so tests can exercise them without
+// driving a full NSURLSession round-trip. See CLAUDE.md "Header imports in
+// tests".
 @interface TeakRequest (SocketErrorTests)
 + (BOOL)isRetryableSocketError:(NSError* _Nullable)error;
++ (BOOL)shouldRetrySocketError:(NSError* _Nullable)error alreadyRetried:(BOOL)alreadyRetried;
 @end
 
 @interface TeakRequestSocketErrorTests : XCTestCase
@@ -72,6 +74,38 @@
                                         code:NSURLErrorUnknown
                                     userInfo:@{NSUnderlyingErrorKey : underlying}];
   XCTAssertFalse([TeakRequest isRetryableSocketError:error]);
+}
+
+@end
+
+///// The retry gate: response:payload:withError: calls
+///// +shouldRetrySocketError:alreadyRetried: to decide whether to fire the
+///// one-shot retry. These pin the full truth table so the gate can't loop or
+///// silently stop retrying a fresh socket error.
+
+@interface TeakRequestRetryGateTests : XCTestCase
+@end
+
+@implementation TeakRequestRetryGateTests
+
+- (void)testRetriesAFreshSocketError {
+  NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
+  XCTAssertTrue([TeakRequest shouldRetrySocketError:error alreadyRetried:NO]);
+}
+
+- (void)testDoesNotRetryASocketErrorTwice {
+  NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error alreadyRetried:YES]);
+}
+
+- (void)testDoesNotRetryANonSocketErrorWhenFresh {
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error alreadyRetried:NO]);
+}
+
+- (void)testDoesNotRetryANonSocketErrorAlreadyRetried {
+  NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error alreadyRetried:YES]);
 }
 
 @end

--- a/Automated/AutomatedTests/TeakRequestSocketErrorTests.m
+++ b/Automated/AutomatedTests/TeakRequestSocketErrorTests.m
@@ -8,9 +8,11 @@
 @import OCHamcrest;
 @import OCMockito;
 
-// Re-expose the internal predicates so tests can exercise them without
-// driving a full NSURLSession round-trip. See CLAUDE.md "Header imports in
-// tests".
+// Re-expose the internal predicates and stop-policy constant so tests can
+// exercise them without driving a full NSURLSession round-trip. See
+// CLAUDE.md "Header imports in tests".
+extern const NSUInteger TeakRequestMaxSocketRetries;
+
 @interface TeakRequest (SocketErrorTests)
 + (BOOL)isRetryableSocketError:(NSError* _Nullable)error;
 + (BOOL)shouldRetrySocketError:(NSError* _Nullable)error retryCount:(NSUInteger)retryCount;
@@ -90,27 +92,27 @@
 
 - (void)testRetriesASocketErrorBelowTheLimit {
   NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
-  XCTAssertTrue([TeakRequest shouldRetrySocketError:error retryCount:0]);
+  XCTAssertTrue([TeakRequest shouldRetrySocketError:error retryCount:TeakRequestMaxSocketRetries - 1]);
 }
 
 - (void)testDoesNotRetryASocketErrorAtTheLimit {
   NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
-  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:1]);
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:TeakRequestMaxSocketRetries]);
 }
 
 - (void)testDoesNotRetryASocketErrorPastTheLimit {
   NSError* error = [NSError errorWithDomain:NSPOSIXErrorDomain code:ECONNABORTED userInfo:nil];
-  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:2]);
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:TeakRequestMaxSocketRetries + 1]);
 }
 
 - (void)testDoesNotRetryANonSocketErrorBelowTheLimit {
   NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
-  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:0]);
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:TeakRequestMaxSocketRetries - 1]);
 }
 
 - (void)testDoesNotRetryANonSocketErrorAtTheLimit {
   NSError* error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNetworkConnectionLost userInfo:nil];
-  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:1]);
+  XCTAssertFalse([TeakRequest shouldRetrySocketError:error retryCount:TeakRequestMaxSocketRetries]);
 }
 
 @end

--- a/Teak/TeakLog.m
+++ b/Teak/TeakLog.m
@@ -246,6 +246,9 @@ __attribute__((overloadable)) void TeakLog_i(NSString* eventType, NSString* mess
         completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
           // When there is an error with the NSPOSIXErrorDomain domain, and the code is 53
           // this is iOS 12 coming back from the background and failing network requests.
+          // TeakRequest.m's response:payload:withError: retries the same failure on its
+          // own NSURLSession with the same delay (TeakRequestSocketErrorRetryDelay) — the
+          // sessions are separate so this isn't shared, but tune both together.
           if (error && error.domain == NSPOSIXErrorDomain && error.code == 53 && reason == nil) {
             __weak typeof(self) weakSelf = self;
             double delayInSeconds = 1.5;

--- a/Teak/TeakRequest+Internal.h
+++ b/Teak/TeakRequest+Internal.h
@@ -39,4 +39,8 @@
 // socket without reopening it. Checks both the top-level domain/code and,
 // for robustness against API surfaces that nest it, NSUnderlyingErrorKey.
 + (BOOL)isRetryableSocketError:(NSError* _Nullable)error;
+
+// Returns YES when `error` is a retryable socket error (see
+// isRetryableSocketError:) and the one-shot retry hasn't already happened.
++ (BOOL)shouldRetrySocketError:(NSError* _Nullable)error alreadyRetried:(BOOL)alreadyRetried;
 @end

--- a/Teak/TeakRequest+Internal.h
+++ b/Teak/TeakRequest+Internal.h
@@ -12,7 +12,7 @@
 @property (strong, nonatomic, readwrite) TeakBatchConfiguration* _Nonnull batch;
 @property (strong, nonatomic, readwrite) TeakRetryConfiguration* _Nonnull retry;
 @property (nonatomic, readwrite) BOOL blackhole;
-@property (nonatomic) BOOL retriedAfterSocketError;
+@property (nonatomic) NSUInteger socketErrorRetryCount;
 
 @property (strong, nonatomic, readwrite) NSString* _Nonnull method;
 
@@ -41,6 +41,7 @@
 + (BOOL)isRetryableSocketError:(NSError* _Nullable)error;
 
 // Returns YES when `error` is a retryable socket error (see
-// isRetryableSocketError:) and the one-shot retry hasn't already happened.
-+ (BOOL)shouldRetrySocketError:(NSError* _Nullable)error alreadyRetried:(BOOL)alreadyRetried;
+// isRetryableSocketError:) and `retryCount` hasn't reached the stop policy
+// (TeakRequestMaxSocketRetries) yet.
++ (BOOL)shouldRetrySocketError:(NSError* _Nullable)error retryCount:(NSUInteger)retryCount;
 @end

--- a/Teak/TeakRequest+Internal.h
+++ b/Teak/TeakRequest+Internal.h
@@ -12,6 +12,7 @@
 @property (strong, nonatomic, readwrite) TeakBatchConfiguration* _Nonnull batch;
 @property (strong, nonatomic, readwrite) TeakRetryConfiguration* _Nonnull retry;
 @property (nonatomic, readwrite) BOOL blackhole;
+@property (nonatomic) BOOL retriedAfterSocketError;
 
 @property (strong, nonatomic, readwrite) NSString* _Nonnull method;
 
@@ -31,4 +32,11 @@
 // "Configuration Error". Never nil — the result is used as a key into the
 // integration checker's error dictionary.
 + (NSString* _Nonnull)titleForClientError:(NSDictionary* _Nullable)clientError;
+
+// Returns YES when `error` is the OS-closed-socket transport failure
+// (ECONNABORTED) that occurs when a pooled connection is reused after the
+// app returns from background and the OS has torn down the underlying
+// socket without reopening it. Checks both the top-level domain/code and,
+// for robustness against API surfaces that nest it, NSUnderlyingErrorKey.
++ (BOOL)isRetryableSocketError:(NSError* _Nullable)error;
 @end

--- a/Teak/TeakRequest+Internal.h
+++ b/Teak/TeakRequest+Internal.h
@@ -1,5 +1,8 @@
 #import "TeakRequest.h"
 
+// Stop policy for isRetryableSocketError: retries — see shouldRetrySocketError:retryCount:.
+extern const NSUInteger TeakRequestMaxSocketRetries;
+
 @interface TeakRequest ()
 @property (strong, nonatomic, readwrite) NSString* _Nonnull endpoint;
 @property (strong, nonatomic, readwrite) NSDictionary* _Nonnull payload;

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -21,7 +21,7 @@ static const NSTimeInterval TeakRequestSocketErrorRetryDelay = 1.5;
 // How many times a socket-closed transport error gets retried. The stop
 // policy lives here so the call site doesn't need to know the limit —
 // raising it later is a one-line change.
-static const NSUInteger TeakRequestMaxSocketRetries = 1;
+const NSUInteger TeakRequestMaxSocketRetries = 1;
 
 #define _(_id) TeakValueOrNSNull(_id)
 

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -18,6 +18,11 @@
 // same underlying OS behavior on its own NSURLSession — tune both together.
 static const NSTimeInterval TeakRequestSocketErrorRetryDelay = 1.5;
 
+// How many times a socket-closed transport error gets retried. The stop
+// policy lives here so the call site doesn't need to know the limit —
+// raising it later is a one-line change.
+static const NSUInteger TeakRequestMaxSocketRetries = 1;
+
 #define _(_id) TeakValueOrNSNull(_id)
 
 NSString* _Nonnull const TeakRequest_POST = @"POST";
@@ -186,8 +191,8 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
   return NO;
 }
 
-+ (BOOL)shouldRetrySocketError:(NSError*)error alreadyRetried:(BOOL)alreadyRetried {
-  return [TeakRequest isRetryableSocketError:error] && !alreadyRetried;
++ (BOOL)shouldRetrySocketError:(NSError*)error retryCount:(NSUInteger)retryCount {
+  return [TeakRequest isRetryableSocketError:error] && retryCount < TeakRequestMaxSocketRetries;
 }
 
 + (NSMutableDictionary*)requestsInFlight {
@@ -232,7 +237,7 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
     self.batch = [[TeakBatchConfiguration alloc] init];
     self.blackhole = NO;
     self.method = method;
-    self.retriedAfterSocketError = NO;
+    self.socketErrorRetryCount = 0;
 
     @try {
       // Assign configuration
@@ -374,14 +379,14 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
       teak_try {
         BOOL isSocketError = [TeakRequest isRetryableSocketError:error];
 
-        if ([TeakRequest shouldRetrySocketError:error alreadyRetried:self.retriedAfterSocketError]) {
+        if ([TeakRequest shouldRetrySocketError:error retryCount:self.socketErrorRetryCount]) {
           // The OS can close a pooled connection's socket while the app is
           // backgrounded and fail to reopen it on the next request; retry
           // once after a short delay rather than surfacing an empty reply.
           // Checked ahead of the server-configured retry ladder below since
           // it's a distinct failure class (transport, not HTTP) — a request
           // with configured retry times still gets this one stacked on top.
-          self.retriedAfterSocketError = YES;
+          self.socketErrorRetryCount++;
           TeakLog_i(@"request.retry.socket_error", [self to_h]);
 
           dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, TeakRequestSocketErrorRetryDelay * NSEC_PER_SEC);

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -14,8 +14,8 @@
 #include <sys/errno.h>
 
 // Delay before retrying a request that failed with a socket-closed transport
-// error. Matches the delay TeakLog's analogous retry uses for the same
-// underlying OS behavior.
+// error. Matches TeakLog.m's TeakLogSender delayInSeconds, which retries the
+// same underlying OS behavior on its own NSURLSession — tune both together.
 static const NSTimeInterval TeakRequestSocketErrorRetryDelay = 1.5;
 
 #define _(_id) TeakValueOrNSNull(_id)
@@ -184,6 +184,10 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
   }
 
   return NO;
+}
+
++ (BOOL)shouldRetrySocketError:(NSError*)error alreadyRetried:(BOOL)alreadyRetried {
+  return [TeakRequest isRetryableSocketError:error] && !alreadyRetried;
 }
 
 + (NSMutableDictionary*)requestsInFlight {
@@ -370,10 +374,13 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
       teak_try {
         BOOL isSocketError = [TeakRequest isRetryableSocketError:error];
 
-        if (isSocketError && !self.retriedAfterSocketError) {
+        if ([TeakRequest shouldRetrySocketError:error alreadyRetried:self.retriedAfterSocketError]) {
           // The OS can close a pooled connection's socket while the app is
           // backgrounded and fail to reopen it on the next request; retry
           // once after a short delay rather than surfacing an empty reply.
+          // Checked ahead of the server-configured retry ladder below since
+          // it's a distinct failure class (transport, not HTTP) — a request
+          // with configured retry times still gets this one stacked on top.
           self.retriedAfterSocketError = YES;
           TeakLog_i(@"request.retry.socket_error", [self to_h]);
 

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -11,6 +11,12 @@
 #import "TeakKVOHelpers.h"
 
 #include <CommonCrypto/CommonHMAC.h>
+#include <sys/errno.h>
+
+// Delay before retrying a request that failed with a socket-closed transport
+// error. Matches the delay TeakLog's analogous retry uses for the same
+// underlying OS behavior.
+static const NSTimeInterval TeakRequestSocketErrorRetryDelay = 1.5;
 
 #define _(_id) TeakValueOrNSNull(_id)
 
@@ -167,6 +173,19 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
   return @"Configuration Error";
 }
 
++ (BOOL)isRetryableSocketError:(NSError*)error {
+  if (error == nil) return NO;
+  if ([error.domain isEqualToString:NSPOSIXErrorDomain] && error.code == ECONNABORTED) return YES;
+
+  NSError* underlying = error.userInfo[NSUnderlyingErrorKey];
+  if ([underlying isKindOfClass:[NSError class]] &&
+      [underlying.domain isEqualToString:NSPOSIXErrorDomain] && underlying.code == ECONNABORTED) {
+    return YES;
+  }
+
+  return NO;
+}
+
 + (NSMutableDictionary*)requestsInFlight {
   static NSMutableDictionary* dict = nil;
   static dispatch_once_t onceToken;
@@ -209,6 +228,7 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
     self.batch = [[TeakBatchConfiguration alloc] init];
     self.blackhole = NO;
     self.method = method;
+    self.retriedAfterSocketError = NO;
 
     @try {
       // Assign configuration
@@ -322,8 +342,6 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
 }
 
 - (void)response:(NSHTTPURLResponse*)response payload:(NSDictionary*)payload withError:(NSError*)error {
-  TeakUnused(error);
-
   teak_try {
     NSMutableDictionary* h = [NSMutableDictionary dictionaryWithDictionary:[self to_h]];
 
@@ -350,7 +368,20 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
       teak_try {
-        if ((response == nil || response.statusCode >= 500) && self.retry.retryIndex < [self.retry.times count]) {
+        BOOL isSocketError = [TeakRequest isRetryableSocketError:error];
+
+        if (isSocketError && !self.retriedAfterSocketError) {
+          // The OS can close a pooled connection's socket while the app is
+          // backgrounded and fail to reopen it on the next request; retry
+          // once after a short delay rather than surfacing an empty reply.
+          self.retriedAfterSocketError = YES;
+          TeakLog_i(@"request.retry.socket_error", [self to_h]);
+
+          dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, TeakRequestSocketErrorRetryDelay * NSEC_PER_SEC);
+          dispatch_after(delayTime, dispatch_get_main_queue(), ^{
+            [self send];
+          });
+        } else if ((response == nil || response.statusCode >= 500) && self.retry.retryIndex < [self.retry.times count]) {
           // Retry with delay + jitter
           float jitter = (drand48() * 2.0 - 1.0) * self.retry.jitter;
           float delay = [self.retry.times[self.retry.retryIndex] floatValue] + jitter;
@@ -363,6 +394,10 @@ NSString* TeakRequestsInFlightMutex = @"io.teak.sdk.requestsInFlightMutex";
             [self send];
           });
         } else {
+          if (isSocketError) {
+            TeakLog_e(@"request.retry.socket_error.exhausted", [self to_h]);
+          }
+
           // Check to see if the response has a 'report_client_error' key
           if (payload[@"report_client_error"] != nil &&
               payload[@"report_client_error"] != [NSNull null]) {


### PR DESCRIPTION
Closes #85
Linear: https://linear.app/teakio/issue/C-386

`TeakRequest`'s `response:payload:withError:` discarded the NSError entirely (`TeakUnused(error)`) — a transport-level failure (no HTTP response) just fired the callback with an empty payload, no retry. The known cause is the OS closing a pooled connection's socket while backgrounded and failing to reopen it, surfacing `NSPOSIXErrorDomain`/`ECONNABORTED` (53) at the top level of the task error. `TeakLog.m` already retries this exact failure on its log-sending path; this ports the same fix onto the main request path (purchases, rewards, identify, `/me/events`, etc).

- `+[TeakRequest isRetryableSocketError:]` — pure predicate, checks top-level domain/code and `NSUnderlyingErrorKey` for a nested POSIX/53.
- Scoped to 53 only (not `NSURLErrorNetworkConnectionLost`/-1005): 53 fires before the request body is sent (stale connection abort), so retry can't double-submit; -1005 is a mid-load severance that may have already reached the server.
- One-shot retry via the existing `[self send]` path, 1.5s delay (matches TeakLog's), guarded by a new `retriedAfterSocketError` flag.
- New logs close the observability gap the swallowed error left: `request.retry.socket_error` (retry fires) / `request.retry.socket_error.exhausted` (gives up — only on the true give-up path, not when a server-configured 5xx retry picks it up instead).

## Test plan
- [x] `bundle exec fastlane test` — 146/146 green
- [x] New `TeakRequestSocketErrorTests.m` exercises the predicate directly (nil, top-level match/mismatch, cross-domain same-code boundary, -1005 boundary, nested match/mismatch)
