### PR TITLE
Add regression tests for deep-link-gated remote configuration

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		43B4619D22A20FE4004AC636 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B4617F22A1EB05004AC636 /* StoreKit.framework */; };
 		440EB1A255029FAF5B1ACEB9 /* TeakSessionDeferredCallbackTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2286E8051950D4EC6E1C79EF /* TeakSessionDeferredCallbackTests.m */; };
 		55AAEB0EF3B9E90616642C8E /* LiveActivityUpdateSchedulingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 741732706353CEBB41D0AE37 /* LiveActivityUpdateSchedulingTests.m */; };
+		5E6B9B4295CBD9D24A0CF31D /* TeakWaitForDeepLinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B165DB88E09CABE8CFB776BA /* TeakWaitForDeepLinkTests.m */; };
 		67ED924AB1318D0336E94BE6 /* TeakAttributedLaunchDataEnrichmentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */; };
 		6CCAAEB7E63F06EEC9B8512E /* RemoteConfigurationEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */; };
 		6D15A01FD0A680A1CD603491 /* TeakRavenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */; };
@@ -149,6 +150,7 @@
 		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
+		B165DB88E09CABE8CFB776BA /* TeakWaitForDeepLinkTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakWaitForDeepLinkTests.m; sourceTree = "<group>"; };
 		C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRavenTests.m; sourceTree = "<group>"; };
 		C93E5C5C2DBE62981455D4A7 /* TeakSessionLockingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakSessionLockingTests.m; sourceTree = "<group>"; };
 		C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AutomatedTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -279,6 +281,7 @@
 				C93E5C5C2DBE62981455D4A7 /* TeakSessionLockingTests.m */,
 				5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */,
 				DC251E1F09B0739648086440 /* TeakRequestSocketErrorTests.m */,
+				B165DB88E09CABE8CFB776BA /* TeakWaitForDeepLinkTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				6FF622EDF0E531603BB01BE3 /* TeakSessionLockingTests.m in Sources */,
 				DDD903E4475B291CE2D4DD1E /* TeakResolvedLinkClassificationTests.m in Sources */,
 				CF22EC2983C75A4444F429C6 /* TeakRequestSocketErrorTests.m in Sources */,
+				5E6B9B4295CBD9D24A0CF31D /* TeakWaitForDeepLinkTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakWaitForDeepLinkTests.m
+++ b/Automated/AutomatedTests/TeakWaitForDeepLinkTests.m
@@ -5,7 +5,6 @@
 #import "TeakWaitForDeepLink.h"
 #import <Teak/Teak.h>
 
-@import OCHamcrest;
 @import OCMockito;
 
 // Set by Teak_Plant in production; we drive it directly so configureForSession:
@@ -58,9 +57,8 @@ extern Teak* _teakSharedInstance;
   [queue addOperation:gatedOp];
 
   // Barrier not yet released: the op has an unsatisfied dependency, so it is
-  // neither ready nor run.
+  // not ready to run.
   XCTAssertFalse(gatedOp.ready, @"gated op must not be ready until the deep-link barrier is released");
-  XCTAssertFalse(gatedOp.finished, @"gated op must not run until the deep-link barrier is released");
 
   [wait addToQueue:queue];
 
@@ -79,7 +77,7 @@ extern Teak* _teakSharedInstance;
 
 #pragma mark - Behavior: remote config blocks until deep links are ready
 
-// The C-384 guard: configureForSession: must gate the settings.json request on
+// Regression guard: configureForSession: must gate the settings.json request on
 // the deep-link barrier. Red if whenFinishedRun:configOp is removed. The barrier
 // is deliberately left unreleased, so the configOp block never runs and no
 // TeakRequest is sent.
@@ -94,16 +92,16 @@ extern Teak* _teakSharedInstance;
   TeakRemoteConfiguration* remoteConfig = [[TeakRemoteConfiguration alloc] init];
   [remoteConfig configureForSession:session];
 
-  NSOperation* barrierOp = _teakSharedInstance.waitForDeepLink.operation;
-  BOOL gated = NO;
-  for (NSOperation* op in _teakSharedInstance.operationQueue.operations) {
-    if ([op.dependencies containsObject:barrierOp]) {
-      gated = YES;
-      break;
-    }
-  }
+  // configureForSession: enqueues exactly the settings.json op, and it must
+  // depend on the barrier. Asserting on that one op (rather than "some op is
+  // gated") keeps the guard honest if a second op is ever enqueued here.
+  NSArray<NSOperation*>* operations = _teakSharedInstance.operationQueue.operations;
+  XCTAssertEqual(operations.count, (NSUInteger)1, @"configureForSession: should enqueue exactly the settings.json op");
 
-  XCTAssertTrue(gated, @"configureForSession: must gate the settings.json request on the deep-link barrier");
+  NSOperation* configOp = operations.firstObject;
+  NSOperation* barrierOp = _teakSharedInstance.waitForDeepLink.operation;
+  XCTAssertTrue([configOp.dependencies containsObject:barrierOp],
+                @"the settings.json op must depend on the deep-link barrier");
 }
 
 @end

--- a/Automated/AutomatedTests/TeakWaitForDeepLinkTests.m
+++ b/Automated/AutomatedTests/TeakWaitForDeepLinkTests.m
@@ -1,0 +1,109 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakRemoteConfiguration.h"
+#import "TeakSession.h"
+#import "TeakWaitForDeepLink.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Set by Teak_Plant in production; we drive it directly so configureForSession:
+// resolves the barrier and queue it reaches through [Teak sharedInstance].
+extern Teak* _teakSharedInstance;
+
+// Re-expose internals for testing rather than importing Teak+Internal.h.
+@interface Teak ()
+@property (strong, nonatomic) NSOperationQueue* _Nonnull operationQueue;
+@property (strong, nonatomic) TeakWaitForDeepLink* _Nonnull waitForDeepLink;
+@end
+
+@interface TeakWaitForDeepLink ()
+@property (strong, nonatomic) NSOperation* operation;
+@end
+
+@interface TeakRemoteConfiguration (Testing)
+- (void)configureForSession:(nonnull TeakSession*)session;
+@end
+
+@interface TeakWaitForDeepLinkTests : XCTestCase
+@end
+
+@implementation TeakWaitForDeepLinkTests {
+  Teak* _savedSharedInstance;
+}
+
+- (void)setUp {
+  _savedSharedInstance = _teakSharedInstance;
+}
+
+- (void)tearDown {
+  _teakSharedInstance = _savedSharedInstance;
+}
+
+#pragma mark - Primitive: the barrier gates dependent operations
+
+// Guards the dependency wiring in -whenFinishedRun:. If it stops adding the
+// barrier as a dependency, the gated op is ready immediately and this fails.
+- (void)testWhenFinishedRunBlocksOperationUntilBarrierReleased {
+  TeakWaitForDeepLink* wait = [[TeakWaitForDeepLink alloc] init];
+  NSOperationQueue* queue = [[NSOperationQueue alloc] init];
+
+  XCTestExpectation* ran = [self expectationWithDescription:@"gated op runs after the barrier is released"];
+  NSOperation* gatedOp = [NSBlockOperation blockOperationWithBlock:^{
+    [ran fulfill];
+  }];
+
+  [wait whenFinishedRun:gatedOp];
+  [queue addOperation:gatedOp];
+
+  // Barrier not yet released: the op has an unsatisfied dependency, so it is
+  // neither ready nor run.
+  XCTAssertFalse(gatedOp.ready, @"gated op must not be ready until the deep-link barrier is released");
+  XCTAssertFalse(gatedOp.finished, @"gated op must not run until the deep-link barrier is released");
+
+  [wait addToQueue:queue];
+
+  [self waitForExpectations:@[ran] timeout:2.0];
+}
+
+// Guards the hasBeenAdded race fix: the barrier op must enqueue at most once
+// (adding the same NSOperation to a queue twice throws).
+- (void)testAddToQueueIsIdempotent {
+  TeakWaitForDeepLink* wait = [[TeakWaitForDeepLink alloc] init];
+  NSOperationQueue* queue = [[NSOperationQueue alloc] init];
+
+  XCTAssertTrue([wait addToQueue:queue], @"first addToQueue: releases the barrier");
+  XCTAssertFalse([wait addToQueue:queue], @"subsequent addToQueue: calls are no-ops");
+}
+
+#pragma mark - Behavior: remote config blocks until deep links are ready
+
+// The C-384 guard: configureForSession: must gate the settings.json request on
+// the deep-link barrier. Red if whenFinishedRun:configOp is removed. The barrier
+// is deliberately left unreleased, so the configOp block never runs and no
+// TeakRequest is sent.
+- (void)testConfigureForSessionGatesSettingsRequestOnDeepLinkBarrier {
+  _teakSharedInstance = [[Teak alloc] init];
+  _teakSharedInstance.operationQueue = [[NSOperationQueue alloc] init];
+  _teakSharedInstance.waitForDeepLink = [[TeakWaitForDeepLink alloc] init];
+
+  // Captured by the configOp block but never messaged, since the block never runs.
+  TeakSession* session = mock([TeakSession class]);
+
+  TeakRemoteConfiguration* remoteConfig = [[TeakRemoteConfiguration alloc] init];
+  [remoteConfig configureForSession:session];
+
+  NSOperation* barrierOp = _teakSharedInstance.waitForDeepLink.operation;
+  BOOL gated = NO;
+  for (NSOperation* op in _teakSharedInstance.operationQueue.operations) {
+    if ([op.dependencies containsObject:barrierOp]) {
+      gated = YES;
+      break;
+    }
+  }
+
+  XCTAssertTrue(gated, @"configureForSession: must gate the settings.json request on the deep-link barrier");
+}
+
+@end


### PR DESCRIPTION
[sdks-teak-ios-worker-c-384]

Closes #88

Linear: https://linear.app/teakio/issue/C-384

C-384 asks that remote configuration block until deep links are ready. That behavior already ships: `TeakRemoteConfiguration`'s settings.json request (the one reporting `deep_link_routes`) is built as `configOp` and gated on the `TeakWaitForDeepLink` barrier, released via `processDeepLinks()` — called by `identifyUser` and Unity's `TeakProcessDeepLinks`.

Verified across the edge paths, not just the happy one:
- **Bypass** — one settings.json build site, always wrapped in the barrier; warm-start sessions depend on the same (already-released) barrier op.
- **Never-ready** — no timeout, but no `waitUntilFinished` / `semaphore_wait FOREVER` in the tree sits on `configOp`, so a never-released barrier *defers* the request, it does not hang a thread. A timeout would be wrong here (could send an incomplete route set if it raced a slow host).
- **Failure** — release is a no-op block op, unconditional, and runs before `identifyUser`'s early-return.

So this PR locks the sequencing in with regression tests rather than changing behavior.

Three tests in `TeakWaitForDeepLinkTests.m`:
- `whenFinishedRun:` gates an operation until `addToQueue:` releases the barrier — guards the primitive's dependency wiring.
- `addToQueue:` is idempotent — guards the once-only enqueue race fix.
- `configureForSession:` gates the settings.json op on the barrier — drives the shared instance directly with a fresh barrier + queue, leaves the barrier **unreleased** so the `configOp` block never runs (no `TeakRequest` sent), and scans the operation graph for the dependency edge. Confirmed red when `whenFinishedRun:configOp` is removed from `configureForSession` while the two primitive tests stay green (C-302 bar).

Suite green.
