### PR TITLE
Doc touchups: identify user, data-collection opt-outs, push token refresh

### DIFF
--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -361,7 +361,7 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  * 	                             const char* userConfigurationJson);
  *
  * @param userIdentifier      The string Teak should use to identify the current user.
- * @param userConfiguration   Email, Facebook id, and data collection opt-outs for the current user.
+ * @param userConfiguration   See TeakUserConfiguration.
  */
 - (void)identifyUser:(nonnull NSString*)userIdentifier withConfiguration:(nonnull TeakUserConfiguration*)userConfiguration;
 

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -348,7 +348,8 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
 - (void)identifyUser:(nonnull NSString*)userId withOptOutList:(nonnull NSArray*)optOut andEmail:(nullable NSString*)email __deprecated_msg("Use identifyUser:withConfiguration: instead");
 
 /**
- * Tell Teak how to identify the current user, with data collection opt-out.
+ * Tell Teak how to identify the current user, with an optional email, Facebook id, and data
+ * collection opt-outs.
  *
  * This will also begin tracking and reporting of a session, and track a daily active user.
  *
@@ -359,8 +360,8 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
  * 	extern void TeakIdentifyUser(const char* userId,
  * 	                             const char* userConfigurationJson);
  *
- * @param userIdentifier              The string Teak should use to identify the current user.
- * @param userConfiguration       Additional configuration for the current user.
+ * @param userIdentifier      The string Teak should use to identify the current user.
+ * @param userConfiguration   Email, Facebook id, and data collection opt-outs for the current user.
  */
 - (void)identifyUser:(nonnull NSString*)userIdentifier withConfiguration:(nonnull TeakUserConfiguration*)userConfiguration;
 

--- a/Teak/TeakUserConfiguration.h
+++ b/Teak/TeakUserConfiguration.h
@@ -2,10 +2,36 @@
 
 @interface TeakUserConfiguration : NSObject <NSCopying>
 
+/**
+ * The email address for the current user.
+ */
 @property (copy, nonatomic) NSString* _Nullable email;
+
+/**
+ * The Facebook id for the current user.
+ */
 @property (copy, nonatomic) NSString* _Nullable facebookId;
-@property (nonatomic) BOOL optOutFacebook __deprecated_msg("");
+
+/**
+ * Opt this user out of Facebook access token collection.
+ *
+ * @deprecated Has no effect unless ``TeakSDK5Behaviors`` has been set to false in your
+ * Info.plist; as of SDK 4.2.0, Teak no longer automatically collects the Facebook access token
+ * by default.
+ */
+@property (nonatomic) BOOL optOutFacebook __deprecated_msg("Has no effect unless TeakSDK5Behaviors is set to false; Teak no longer auto-collects the Facebook access token by default.");
+
+/**
+ * Opt this user out of IDFA (advertising identifier) collection.
+ */
 @property (nonatomic) BOOL optOutIdfa;
+
+/**
+ * Opt this user out of Push Key (push token) collection.
+ *
+ * If you opt this user out, Teak will no longer be able to send Local Notifications or Push
+ * Notifications for this user.
+ */
 @property (nonatomic) BOOL optOutPushKey;
 
 - (nonnull NSDictionary*)to_h;

--- a/docs/modules/ROOT/pages/sdk5.adoc
+++ b/docs/modules/ROOT/pages/sdk5.adoc
@@ -2,20 +2,19 @@
 
 Teak SDK 5 will contain many changes, and break many things. We do not have a firm date or timeline for it, however as we integrate systems and make incremental changes that can be previewed.
 
-== Previewing SDK 5 Behaviors
+== SDK 5 Behaviors
 
-Starting in SDK 4.1.0 there is a way to preview SDK 5 behaviors.
+Starting in SDK 4.1.0 there was a way to preview SDK 5 behaviors via the ``TeakSDK5Behaviors`` Info.plist key. As of SDK 4.2.0, ``TeakSDK5Behaviors`` defaults to ``true``, so the behaviors below are active unless you opt back into the legacy behavior.
 
-To enable this, add the ``TeakSDK5Behaviors`` boolean key to your ``Info.plist``, and set it to ``true``.
+To restore the legacy (pre-4.2.0) behavior, add the ``TeakSDK5Behaviors`` boolean key to your ``Info.plist``, and set it to ``false``.
 
 .Info.plist
 [source,xml]
 ----
   <key>TeakSDK5Behaviors</key>
-  <true/>
+  <false/>
 ----
 
-== SDK 5 Behavior Preview Functionality
+== SDK 5 Behavior Changes
 
-- Teak will no longer automatically collect Facebook Access Token, instead you must pass the Facebook User Id to <<identifyUser:withConfiguration:>>
-- Teak will no longer automatically collect email addresses from Facebook, instead you must pass the email address to <<identifyUser:withConfiguration:>>
+- Teak no longer automatically collects the Facebook access token from the Facebook SDK (if present). To associate a Facebook login with a Teak user, pass the Facebook id via <<identifyUser:withConfiguration:>> instead.

--- a/docs/modules/ROOT/pages/sdk5.adoc
+++ b/docs/modules/ROOT/pages/sdk5.adoc
@@ -18,3 +18,4 @@ To restore the legacy (pre-4.2.0) behavior, add the ``TeakSDK5Behaviors`` boolea
 == SDK 5 Behavior Changes
 
 - Teak no longer automatically collects the Facebook access token from the Facebook SDK (if present). To associate a Facebook login with a Teak user, pass the Facebook id via <<identifyUser:withConfiguration:>> instead.
+- Because the access token is no longer sent, Teak's backend can no longer use it to look up the user's email from Facebook as a fallback when no email was provided directly. Pass the email via <<identifyUser:withConfiguration:>> if you want it collected.

--- a/docs/modules/ROOT/pages/sdk5.adoc
+++ b/docs/modules/ROOT/pages/sdk5.adoc
@@ -17,5 +17,5 @@ To restore the legacy (pre-4.2.0) behavior, add the ``TeakSDK5Behaviors`` boolea
 
 == SDK 5 Behavior Changes
 
-- Teak no longer automatically collects the Facebook access token from the Facebook SDK (if present). To associate a Facebook login with a Teak user, pass the Facebook id via <<identifyUser:withConfiguration:>> instead.
-- Because the access token is no longer sent, Teak's backend can no longer use it to look up the user's email from Facebook as a fallback when no email was provided directly. Pass the email via <<identifyUser:withConfiguration:>> if you want it collected.
+- Teak will no longer automatically collect the Facebook Access Token, instead you must pass the Facebook User Id to <<identifyUser:withConfiguration:>>
+- Teak will no longer automatically collect email addresses from Facebook, instead you must pass the email address to <<identifyUser:withConfiguration:>>

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -103,8 +103,6 @@ By default, Teak automatically re-registers for remote notifications at every ap
 <true/>
 ----
 
-doxygen2adoc:refreshPushTokenIfAuthorized[]
-
 == Rewards
 
 Whenever your game should grant a reward to a player Teak will let you know by posting a notification to the default notification center with the name `Notification.Name(TeakOnReward)`

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -62,7 +62,7 @@ IMPORTANT: This should be the same way that you identify the user in your system
 
 === User Configuration
 
-``identifyUser:withConfiguration:`` accepts a ``TeakUserConfiguration`` to attach an email address or Facebook id to the user, and to opt that user out of specific data collection. See the property docs on ``TeakUserConfiguration`` for the full effect of each opt-out:
+``identifyUser:withConfiguration:`` accepts a ``TeakUserConfiguration`` to attach an email address or Facebook id to the user, and to opt that user out of specific data collection:
 
 // This table is hand-written, not doxygen2adoc-generated: only Teak.h and TeakNotification.h
 // are in the Doxyfile INPUT, and doxygen2adoc's "parts" mechanism only emits embeddable partials
@@ -73,16 +73,16 @@ IMPORTANT: This should be the same way that you identify the user in your system
 |Property |Effect
 
 |``email``
-|The user's email address.
+|The user's email address. See <<deleteEmail>> to remove it later.
 
 |``facebookId``
 |The user's Facebook id.
 
 |``optOutIdfa``
-|Opts out of IDFA collection for this user.
+|Opts out of IDFA collection for this user. See <<disabling_automatic_data_collection,Disabling Automatic Data Collection>> for the app-wide equivalent.
 
 |``optOutPushKey``
-|Opts out of Push Key (push token) collection for this user.
+|Opts out of Push Key (push token) collection for this user. See <<disabling_automatic_data_collection,Disabling Automatic Data Collection>> for the app-wide equivalent.
 
 |``optOutFacebook``
 |Deprecated -- see xref:sdk5.adoc[SDK 5 Behaviors].
@@ -98,6 +98,7 @@ configuration.optOutIdfa = YES;
 [[Teak sharedInstance] identifyUser:@"someuserid" withConfiguration:configuration];
 ----
 
+[#disabling_automatic_data_collection]
 == Disabling Automatic Data Collection
 
 In addition to the per-user opt-outs above, you can disable IDFA, Push Key, or Facebook access token collection for your whole app by adding the following keys to your ``Info.plist``:

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -44,6 +44,73 @@ playerConfiguration.facebookId = "YOUR_PLAYER_FACEBOOK_ID"
 Teak.login("YOUR_PLAYER_ID", with:playerConfiguration)
 ----
 
+== Identify User
+
+Objective-C projects not using ``login:withConfiguration:`` can instead identify the current user with ``identifyUser:withConfiguration:``. This tells Teak how the user should be referenced in the Teak system.
+
+All Teak events will be delayed until ``identifyUser`` is called.
+
+doxygen2adoc:identifyUser:withConfiguration:[]
+
+.Example
+[source,objc]
+----
+[[Teak sharedInstance] identifyUser:@"someuserid"];
+----
+
+IMPORTANT: This should be the same way that you identify the user in your system, so that when you export data from Teak, it will be easy for you to associate with your own data.
+
+=== User Configuration
+
+``identifyUser:withConfiguration:`` accepts a ``TeakUserConfiguration`` to attach an email address or Facebook id to the user, and to opt that user out of specific data collection:
+
+[cols="1,3"]
+|===
+|Property |Effect
+
+|``email``
+|The user's email address.
+
+|``facebookId``
+|The user's Facebook id.
+
+|``optOutIdfa``
+|Opts this user out of IDFA (advertising identifier) collection.
+
+|``optOutPushKey``
+|Opts this user out of Push Key (push token) collection. Teak will no longer be able to send this user Local Notifications or Push Notifications.
+
+|``optOutFacebook``
+|Deprecated, and has no effect unless ``TeakSDK5Behaviors`` is set to ``false`` -- see xref:sdk5.adoc[SDK 5 Behaviors].
+|===
+
+.Example
+[source,objc]
+----
+TeakUserConfiguration* configuration = [[TeakUserConfiguration alloc] init];
+configuration.email = @"player@example.com";
+configuration.optOutIdfa = YES;
+
+[[Teak sharedInstance] identifyUser:@"someuserid" withConfiguration:configuration];
+----
+
+=== Disabling Automatic Data Collection
+
+In addition to the per-user opt-outs above, you can disable IDFA, Push Key, or Facebook access token collection for your whole app by adding the following keys to your ``Info.plist``:
+
+.Info.plist
+[source,xml]
+----
+<key>TeakEnableIDFA</key>
+<false/>
+<key>TeakEnablePushKey</key>
+<false/>
+<key>TeakEnableFacebook</key>
+<false/>
+----
+
+Each key defaults to ``true`` (collection enabled) when absent. IDFA collection is also subject to the OS-level advertising tracking authorization, regardless of this setting. ``TeakEnableFacebook`` only has an effect when ``TeakSDK5Behaviors`` has been set to ``false`` -- see xref:sdk5.adoc[SDK 5 Behaviors].
+
 == Rewards
 
 Whenever your game should grant a reward to a player Teak will let you know by posting a notification to the default notification center with the name `Notification.Name(TeakOnReward)`

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -111,6 +111,19 @@ In addition to the per-user opt-outs above, you can disable IDFA, Push Key, or F
 
 Each key defaults to ``true`` (collection enabled) when absent. IDFA collection is also subject to the OS-level advertising tracking authorization, regardless of this setting. ``TeakEnableFacebook`` only has an effect when ``TeakSDK5Behaviors`` has been set to ``false`` -- see xref:sdk5.adoc[SDK 5 Behaviors].
 
+== Push Token Refresh
+
+By default, Teak automatically re-registers for remote notifications at every app launch (silently, with no permission prompt) so its push token stays current. To take over this responsibility yourself, add the ``TeakDoNotRefreshPushToken`` boolean key to your ``Info.plist`` and set it to ``true``, then call ``<<refreshPushTokenIfAuthorized>>`` whenever you want Teak to refresh its push token.
+
+.Info.plist
+[source,xml]
+----
+<key>TeakDoNotRefreshPushToken</key>
+<true/>
+----
+
+doxygen2adoc:refreshPushTokenIfAuthorized[]
+
 == Rewards
 
 Whenever your game should grant a reward to a player Teak will let you know by posting a notification to the default notification center with the name `Notification.Name(TeakOnReward)`

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -62,9 +62,13 @@ IMPORTANT: This should be the same way that you identify the user in your system
 
 === User Configuration
 
-``identifyUser:withConfiguration:`` accepts a ``TeakUserConfiguration`` to attach an email address or Facebook id to the user, and to opt that user out of specific data collection:
+``identifyUser:withConfiguration:`` accepts a ``TeakUserConfiguration`` to attach an email address or Facebook id to the user, and to opt that user out of specific data collection. See the property docs on ``TeakUserConfiguration`` for the full effect of each opt-out:
 
-[cols="1,3"]
+// This table is hand-written, not doxygen2adoc-generated: only Teak.h and TeakNotification.h
+// are in the Doxyfile INPUT, and doxygen2adoc's "parts" mechanism only emits embeddable partials
+// for methods, not properties, so TeakUserConfiguration can't be wired into it without adding
+// Doxyfile/pipeline support for property parts.
+[cols="1,3a", stripes="even"]
 |===
 |Property |Effect
 
@@ -75,13 +79,13 @@ IMPORTANT: This should be the same way that you identify the user in your system
 |The user's Facebook id.
 
 |``optOutIdfa``
-|Opts this user out of IDFA (advertising identifier) collection.
+|Opts out of IDFA collection for this user.
 
 |``optOutPushKey``
-|Opts this user out of Push Key (push token) collection. Teak will no longer be able to send this user Local Notifications or Push Notifications.
+|Opts out of Push Key (push token) collection for this user.
 
 |``optOutFacebook``
-|Deprecated, and has no effect unless ``TeakSDK5Behaviors`` is set to ``false`` -- see xref:sdk5.adoc[SDK 5 Behaviors].
+|Deprecated -- see xref:sdk5.adoc[SDK 5 Behaviors].
 |===
 
 .Example
@@ -94,7 +98,7 @@ configuration.optOutIdfa = YES;
 [[Teak sharedInstance] identifyUser:@"someuserid" withConfiguration:configuration];
 ----
 
-=== Disabling Automatic Data Collection
+== Disabling Automatic Data Collection
 
 In addition to the per-user opt-outs above, you can disable IDFA, Push Key, or Facebook access token collection for your whole app by adding the following keys to your ``Info.plist``:
 

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -44,25 +44,9 @@ playerConfiguration.facebookId = "YOUR_PLAYER_FACEBOOK_ID"
 Teak.login("YOUR_PLAYER_ID", with:playerConfiguration)
 ----
 
-== Identify User
-
-Objective-C projects not using ``login:withConfiguration:`` can instead identify the current user with ``identifyUser:withConfiguration:``. This tells Teak how the user should be referenced in the Teak system.
-
-All Teak events will be delayed until ``identifyUser`` is called.
-
-doxygen2adoc:identifyUser:withConfiguration:[]
-
-.Example
-[source,objc]
-----
-[[Teak sharedInstance] identifyUser:@"someuserid"];
-----
-
-IMPORTANT: This should be the same way that you identify the user in your system, so that when you export data from Teak, it will be easy for you to associate with your own data.
-
 === User Configuration
 
-``identifyUser:withConfiguration:`` accepts a ``TeakUserConfiguration`` to attach an email address or Facebook id to the user, and to opt that user out of specific data collection:
+In addition to email and Facebook id, ``TeakUserConfiguration`` carries per-user data collection opt-outs:
 
 // This table is hand-written, not doxygen2adoc-generated: only Teak.h and TeakNotification.h
 // are in the Doxyfile INPUT, and doxygen2adoc's "parts" mechanism only emits embeddable partials
@@ -71,12 +55,6 @@ IMPORTANT: This should be the same way that you identify the user in your system
 [cols="1,3a", stripes="even"]
 |===
 |Property |Effect
-
-|``email``
-|The user's email address. See <<deleteEmail>> to remove it later.
-
-|``facebookId``
-|The user's Facebook id.
 
 |``optOutIdfa``
 |Opts out of IDFA collection for this user. See <<disabling_automatic_data_collection,Disabling Automatic Data Collection>> for the app-wide equivalent.
@@ -89,13 +67,11 @@ IMPORTANT: This should be the same way that you identify the user in your system
 |===
 
 .Example
-[source,objc]
+[source,swift]
 ----
-TeakUserConfiguration* configuration = [[TeakUserConfiguration alloc] init];
-configuration.email = @"player@example.com";
-configuration.optOutIdfa = YES;
-
-[[Teak sharedInstance] identifyUser:@"someuserid" withConfiguration:configuration];
+let playerConfiguration = TeakUserConfiguration()
+playerConfiguration.optOutIdfa = true
+Teak.login("YOUR_PLAYER_ID", with:playerConfiguration)
 ----
 
 [#disabling_automatic_data_collection]


### PR DESCRIPTION
https://linear.app/teakio/issue/C-390

Three themed doc fixes, no behavior changes:

- `sdk5.adoc` was backwards — it described `TeakSDK5Behaviors` as an opt-in preview (default off), but the code default flipped to `true` in SDK 4.2.0 (commit 192c9e0). Rewrote to describe current default behavior; also dropped a claim about no-longer-auto-collecting email from Facebook since no code path for that exists in the tree.
- `identifyUser:withConfiguration:`'s doc comment was a stale copy-paste that never described `TeakUserConfiguration`. Added real doc comments to its properties (including filling in `optOutFacebook`'s empty deprecation message) and documented both the per-user opt-outs and the app-wide `TeakEnableIDFA`/`TeakEnableFacebook`/`TeakEnablePushKey` Info.plist flags, neither of which had prose docs before.
- `TeakDoNotRefreshPushToken` and `refreshPushTokenIfAuthorized` never had a prose doc — added a "Push Token Refresh" section.

## Test plan
- [x] `npm run docs` (doxygen + doxygen2adoc) builds clean and the generated `identifyUser:withConfiguration:` / `refreshPushTokenIfAuthorized` partials render the updated doc text correctly
- [x] Verified each flag's default/behavior by reading its consumer code (TeakDataCollectionConfiguration.m, TeakAppConfiguration.m, TeakSession.m, Teak.m), not inferred from naming