### PR TITLE
Remove orphaned .oclint rule-config

### DIFF
--- a/.oclint
+++ b/.oclint
@@ -1,5 +1,0 @@
-rule-configurations:
-  - key: LONG_LINE
-    value: 200
-  - key: LONG_VARIABLE_NAME
-    value: 51


### PR DESCRIPTION
## What

Removes the orphaned `.oclint` rule-config — the last surviving OCLint artifact in the repo.

## Why

C-389 asked "why is OCLint not reporting issues correctly anymore?" Investigation: it isn't broken, it was deliberately retired. There's no toolchain/compile-DB regression — the OCLint invocation no longer exists.

- **Dec 2017** (`3e254e4`) — introduced, advisory-only. The build-fail `exit 1` was commented out from day one; it only ever wrote an HTML report, never gated a build.
- **Dec 16 2019** (`165ebbb`) — disabled on CI via an `if [[ -z "${CI}" ]]` HAX guard. Ran only in local dev after this.
- **Feb 2026** — the invoking `compile` script (`3b6576d`), the `subl-oclint` dev helper and the setup cask install (`852b847`) were all deleted.

That cleanup missed exactly one file: the tracked `.oclint` rule-config, now dead config with no readers. This PR removes it to close the book.

A tree-wide grep (tracked / untracked / hidden, git hooks, CI yml, Rakefile, Gemfile, Fastfile, setup, format-code) confirms zero remaining references to `oclint`, so the removal is safe.

Re-introducing static analysis (xcodebuild analyze / clang-tidy) is a separate discretionary decision, out of scope here.

Closes #65

Linear: https://linear.app/teakio/issue/C-389
