### PR TITLE
Emit observable exception log event on the uncaught path

### DIFF
--- a/Automated/AutomatedTests/TeakRavenTests.m
+++ b/Automated/AutomatedTests/TeakRavenTests.m
@@ -7,6 +7,8 @@
 #import "TeakRaven.h"
 #import <Teak/Teak.h>
 
+#import <signal.h>
+
 @import OCHamcrest;
 @import OCMockito;
 
@@ -23,9 +25,11 @@
 // install a real Teak to exercise the singleton-routed exception path.
 extern Teak* _Nullable _teakSharedInstance;
 
-// Re-expose payloadTemplate for inspection
+// Re-expose payloadTemplate for inspection, and the uncaught-path entry point so a
+// test can drive it directly (it's declared in a TeakRaven.m class extension).
 @interface TeakRaven ()
 @property (strong, nonatomic) NSMutableDictionary* payloadTemplate;
+- (void)reportUncaughtException:(nonnull NSException*)exception;
 @end
 
 // Re-expose runId as read-write so tests can inject a known value
@@ -114,6 +118,60 @@ extern Teak* _Nullable _teakSharedInstance;
   assertThat(capturedEventType, is(@"exception"));
   assertThat(capturedEventData[@"type"], is(@"ReportTestException"));
   assertThat(capturedEventData[@"value"], is(@"Version: 4.3.13-test"));
+}
+
+// The uncaught path (TeakUncaughtExceptionHandler → reportUncaughtException:) must
+// surface the same observable "exception" event as the caught path, with the same
+// {type ← NSException.name, value ← NSException.reason} shape. Guards the uncaught
+// emit against being dropped again.
+- (void)testReportUncaughtExceptionEmitsObservableExceptionEvent {
+  Teak* teak = [[Teak alloc] init];
+  teak.sdkVersion = @"4.3.13-test";
+  teak.log = [[TeakLog alloc] initForTeak:teak withAppId:@"test"];
+
+  __block NSString* capturedEventType = nil;
+  __block NSDictionary* capturedEventData = nil;
+  teak.logListener = ^(NSString* event, NSString* level, NSDictionary* payload) {
+    if ([event isEqualToString:@"exception"]) {
+      capturedEventType = payload[@"event_type"];
+      capturedEventData = payload[@"event_data"];
+    }
+  };
+
+  // Raven from the fully-stubbed mock so payloadTemplate construction doesn't bail;
+  // its endpoint stays nil so the report send is a no-op (no network).
+  TeakRaven* raven = [TeakRaven ravenForTeak:self.teakMock];
+
+  NSException* exception = [NSException exceptionWithName:@"UncaughtTestException"
+                                                  reason:@"boom"
+                                                userInfo:nil];
+
+  // reportUncaughtException: unsets the process uncaught + signal handlers as its
+  // first step; snapshot and restore them so the test doesn't leak SIG_DFL into the
+  // XCTest harness.
+  NSUncaughtExceptionHandler* savedUncaught = NSGetUncaughtExceptionHandler();
+  int signals[] = {SIGABRT, SIGILL, SIGSEGV, SIGFPE, SIGBUS, SIGPIPE};
+  const int signalCount = sizeof(signals) / sizeof(signals[0]);
+  struct sigaction savedActions[signalCount];
+  for (int i = 0; i < signalCount; i++) {
+    sigaction(signals[i], NULL, &savedActions[i]);
+  }
+
+  Teak* previousShared = _teakSharedInstance;
+  _teakSharedInstance = teak;
+  @try {
+    [raven reportUncaughtException:exception];
+  } @finally {
+    _teakSharedInstance = previousShared;
+    NSSetUncaughtExceptionHandler(savedUncaught);
+    for (int i = 0; i < signalCount; i++) {
+      sigaction(signals[i], &savedActions[i], NULL);
+    }
+  }
+
+  assertThat(capturedEventType, is(@"exception"));
+  assertThat(capturedEventData[@"type"], is(@"UncaughtTestException"));
+  assertThat(capturedEventData[@"value"], is(@"boom"));
 }
 
 - (void)testExceptionLogEventDataMapsNameToTypeAndReasonToValue {

--- a/Automated/AutomatedTests/TeakRavenTests.m
+++ b/Automated/AutomatedTests/TeakRavenTests.m
@@ -148,7 +148,8 @@ extern Teak* _Nullable _teakSharedInstance;
 
   // reportUncaughtException: unsets the process uncaught + signal handlers as its
   // first step; snapshot and restore them so the test doesn't leak SIG_DFL into the
-  // XCTest harness.
+  // XCTest harness. The signal set mirrors the one production manages in
+  // setAsUncaughtExceptionHandler.
   NSUncaughtExceptionHandler* savedUncaught = NSGetUncaughtExceptionHandler();
   int signals[] = {SIGABRT, SIGILL, SIGSEGV, SIGFPE, SIGBUS, SIGPIPE};
   const int signalCount = sizeof(signals) / sizeof(signals[0]);
@@ -172,6 +173,44 @@ extern Teak* _Nullable _teakSharedInstance;
   assertThat(capturedEventType, is(@"exception"));
   assertThat(capturedEventData[@"type"], is(@"UncaughtTestException"));
   assertThat(capturedEventData[@"value"], is(@"boom"));
+}
+
+// On the fatal uncaught path the synchronous host logListener is the only host code
+// that runs before the Sentry crash report is sent. A listener that throws must not
+// escape reportUncaughtException: and suppress that report — the emit is guarded so
+// the throw is swallowed and the report below still sends.
+- (void)testReportUncaughtExceptionSwallowsThrowingLogListener {
+  Teak* teak = [[Teak alloc] init];
+  teak.sdkVersion = @"4.3.13-test";
+  teak.log = [[TeakLog alloc] initForTeak:teak withAppId:@"test"];
+  teak.logListener = ^(NSString* event, NSString* level, NSDictionary* payload) {
+    [NSException raise:@"ListenerBoom" format:@"host listener threw"];
+  };
+
+  TeakRaven* raven = [TeakRaven ravenForTeak:self.teakMock];
+  NSException* exception = [NSException exceptionWithName:@"UncaughtTestException"
+                                                  reason:@"boom"
+                                                userInfo:nil];
+
+  NSUncaughtExceptionHandler* savedUncaught = NSGetUncaughtExceptionHandler();
+  int signals[] = {SIGABRT, SIGILL, SIGSEGV, SIGFPE, SIGBUS, SIGPIPE};
+  const int signalCount = sizeof(signals) / sizeof(signals[0]);
+  struct sigaction savedActions[signalCount];
+  for (int i = 0; i < signalCount; i++) {
+    sigaction(signals[i], NULL, &savedActions[i]);
+  }
+
+  Teak* previousShared = _teakSharedInstance;
+  _teakSharedInstance = teak;
+  @try {
+    XCTAssertNoThrow([raven reportUncaughtException:exception]);
+  } @finally {
+    _teakSharedInstance = previousShared;
+    NSSetUncaughtExceptionHandler(savedUncaught);
+    for (int i = 0; i < signalCount; i++) {
+      sigaction(signals[i], &savedActions[i], NULL);
+    }
+  }
 }
 
 - (void)testExceptionLogEventDataMapsNameToTypeAndReasonToValue {

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -212,8 +212,14 @@ void TeakSignalHandler(int signal) {
 
   // Surface an observable "exception" log event on the uncaught path, matching the
   // caught path's {type, value} shape. Built from a fresh dict so the Sentry report
-  // payload below is untouched.
-  TeakLog_e(@"exception", [TeakRaven exceptionLogEventDataForException:exception]);
+  // payload below is untouched. Guarded because this is the last-resort handler: the
+  // synchronous host logListener is the only host code on this path, so a listener
+  // that throws would escape and suppress the Sentry crash report below. Swallow it —
+  // don't re-log, the log system is what just threw.
+  @try {
+    TeakLog_e(@"exception", [TeakRaven exceptionLogEventDataForException:exception]);
+  } @catch (NSException* ignored) {
+  }
 
   NSDictionary* additions = @{
     @"exception" : @[

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -210,6 +210,11 @@ void TeakSignalHandler(int signal) {
 - (void)reportUncaughtException:(nonnull NSException*)exception {
   [self unsetAsUncaughtExceptionHandler];
 
+  // Surface an observable "exception" log event on the uncaught path, matching the
+  // caught path's {type, value} shape. Built from a fresh dict so the Sentry report
+  // payload below is untouched.
+  TeakLog_e(@"exception", [TeakRaven exceptionLogEventDataForException:exception]);
+
   NSDictionary* additions = @{
     @"exception" : @[
       @{


### PR DESCRIPTION
Restores the observable `exception` log event on the uncaught path, dropped in 3ba30dd under the original "uncaught → Sentry-only" parity call. The cross-platform policy is now: each platform emits its own caught-path shape on the uncaught path, with the `{type, value}` intersection as the guaranteed contract (the C-739 e2e asserts type+value only).

**Behavior:** an uncaught `NSException` now emits `TeakLog_e("exception", {type ← name, value ← reason})` — the same `{type, value}` shape and helper as the caught path (C-843). Observable during the crash because the uncaught handler spins the run loop ~3s (`pumpRunLoops`) before the process terminates, so the synchronous `logListener` and the async remote send both ride that window.

**Scope held:** NSException uncaught path only. POSIX signal handlers stay Sentry-only (a signal isn't an NSException; Android's `Thread.UncaughtExceptionHandler` handles Java throwables only and suppresses "signal"-prefixed throwables from the log event). The iOS event is **not** widened with `module`/`stacktrace` — those stay in the Sentry report only, matching the accepted caught-path asymmetry.

**Test:** a regression test drives `reportUncaughtException:` and asserts the listener fires with `{type, value}`; verified it goes red when the emit line is reverted. It snapshots/restores the process uncaught + signal handlers (the method unsets them as its first step) so it doesn't leak `SIG_DFL` into the XCTest harness. Full unit target green: 154 tests, 0 failures.

Android twin: GoCarrot/teak-android#166.

Resolves C-844 — https://linear.app/teakio/issue/C-844
