### PR TITLE
Serialize TeakUserProfile attribute-dict access on the operationQueue (C-955)

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */; };
 		0F9BB099DE5CFEDF8A8B30F9 /* Pods_AutomatedUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */; };
+		137B2D87B7DFDBCC7B5DC85A /* TeakUserProfileAttributeQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */; };
 		20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */; };
 		24E918A8B1343E0E4D8092AE /* Teak.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2CC95EAD6283AE3D2A4AB872 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
@@ -149,6 +150,7 @@
 		90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DebugConfigurationTests.m; sourceTree = "<group>"; };
 		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
+		A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakUserProfileAttributeQueueTests.m; sourceTree = "<group>"; };
 		AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityTokenForwardingTests.m; sourceTree = "<group>"; };
 		B165DB88E09CABE8CFB776BA /* TeakWaitForDeepLinkTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakWaitForDeepLinkTests.m; sourceTree = "<group>"; };
 		C1ECFF9E3A6CB54927A8A327 /* TeakRavenTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRavenTests.m; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */,
 				DC251E1F09B0739648086440 /* TeakRequestSocketErrorTests.m */,
 				B165DB88E09CABE8CFB776BA /* TeakWaitForDeepLinkTests.m */,
+				A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -619,6 +622,7 @@
 				DDD903E4475B291CE2D4DD1E /* TeakResolvedLinkClassificationTests.m in Sources */,
 				CF22EC2983C75A4444F429C6 /* TeakRequestSocketErrorTests.m in Sources */,
 				5E6B9B4295CBD9D24A0CF31D /* TeakWaitForDeepLinkTests.m in Sources */,
+				137B2D87B7DFDBCC7B5DC85A /* TeakUserProfileAttributeQueueTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakUserProfileAttributeQueueTests.m
+++ b/Automated/AutomatedTests/TeakUserProfileAttributeQueueTests.m
@@ -1,0 +1,75 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakUserProfile.h"
+#import <Teak/Teak.h>
+
+// setAttribute:forKey:inDictionary: must touch the attribute dictionary + firstSetTime
+// only on the serial operationQueue. The pre-fix code read the dict and stamped
+// firstSetTime synchronously on the caller's default-qos queue while the write ran on
+// the serial queue — a concurrent read/write of the NSMutableDictionary (use-after-free).
+//
+// A behavioral race repro isn't feasible without ThreadSanitizer, so — following
+// TeakSessionDeferredCallbackTests — these tests document the invariant instead: block
+// the serial queue, invoke the real setter, and assert firstSetTime hasn't been stamped
+// yet. The fixed code defers the stamp behind the gate (nil); the pre-fix code stamps it
+// synchronously on the caller's queue, so this fails deterministically when reverted.
+@interface Teak (Testing)
++ (dispatch_queue_t)operationQueue;
+@end
+
+@interface TeakUserProfile (Testing)
+@property (strong, nonatomic) NSMutableDictionary* stringAttributes;
+@property (strong, nonatomic) NSMutableDictionary* numberAttributes;
+@property (strong, nonatomic) NSDate* firstSetTime;
+@end
+
+@interface TeakUserProfileAttributeQueueTests : XCTestCase
+@end
+
+@implementation TeakUserProfileAttributeQueueTests
+
+// Occupies the serial operationQueue with a semaphore-gated block, invokes the setter,
+// and asserts firstSetTime is still nil — proving the stamp (and the guard-read above it)
+// were deferred onto the serial queue rather than run synchronously on the caller. Then
+// releases the gate, drains the queue, and confirms the deferred stamp actually lands.
+// The setter re-sets the existing value so safeNotEquals is false and no send is scheduled.
+- (void)assertFirstSetTimeDeferredForProfile:(TeakUserProfile*)profile setter:(void (^)(void))invokeSetter {
+  dispatch_semaphore_t gate = dispatch_semaphore_create(0);
+  dispatch_async([Teak operationQueue], ^{
+    dispatch_semaphore_wait(gate, DISPATCH_TIME_FOREVER);
+  });
+
+  invokeSetter();
+
+  XCTAssertNil(profile.firstSetTime,
+               @"firstSetTime must be stamped on the serial operationQueue, not synchronously on the caller's queue");
+
+  dispatch_semaphore_signal(gate);
+  dispatch_sync([Teak operationQueue], ^{
+  });
+
+  XCTAssertNotNil(profile.firstSetTime,
+                  @"firstSetTime should be stamped once the queued block runs");
+}
+
+- (void)testStringAttributeDefersDictAccessToSerialQueue {
+  TeakUserProfile* profile = [[TeakUserProfile alloc] init];
+  profile.stringAttributes = [@{@"key" : @"value"} mutableCopy];
+
+  [self assertFirstSetTimeDeferredForProfile:profile
+                                      setter:^{
+                                        [profile setStringAttribute:@"value" forKey:@"key"];
+                                      }];
+}
+
+- (void)testNumericAttributeDefersDictAccessToSerialQueue {
+  TeakUserProfile* profile = [[TeakUserProfile alloc] init];
+  profile.numberAttributes = [@{@"key" : [NSNumber numberWithDouble:1.0]} mutableCopy];
+
+  [self assertFirstSetTimeDeferredForProfile:profile
+                                      setter:^{
+                                        [profile setNumericAttribute:1.0 forKey:@"key"];
+                                      }];
+}
+
+@end

--- a/Teak/Core/TeakUserProfile.m
+++ b/Teak/Core/TeakUserProfile.m
@@ -32,35 +32,40 @@
 }
 
 - (void)setAttribute:(id)value forKey:(NSString*)key inDictionary:(NSMutableDictionary*)dictionary {
-  // Future-Pat: *only* check vs nil here, not NSNull. NSNull is fine.
-  if (dictionary[key] != nil) {
+  // The nil-guard, firstSetTime stamp, equality test, and write all run on the serial
+  // operationQueue so the dictionary is only ever touched from one queue. Reading the
+  // dict on the caller's queue while the writer mutates it here is a use-after-free.
+  dispatch_async([Teak operationQueue], ^{
+    // Future-Pat: *only* check vs nil here, not NSNull. NSNull is fine.
+    if (dictionary[key] == nil) {
+      return;
+    }
+
     if (self.firstSetTime == nil) {
       self.firstSetTime = [NSDate date];
     }
 
-    dispatch_async([Teak operationQueue], ^{
-      BOOL safeNotEquals = YES;
-      @try {
-        safeNotEquals = dictionary[key] == [NSNull null] || ![dictionary[key] isEqual:value];
-      } @finally {
+    BOOL safeNotEquals = YES;
+    @try {
+      safeNotEquals = dictionary[key] == [NSNull null] || ![dictionary[key] isEqual:value];
+    } @finally {
+    }
+
+    if (safeNotEquals) {
+      if (self.scheduledBlock != nil) {
+        dispatch_block_cancel(self.scheduledBlock);
       }
 
-      if (safeNotEquals) {
-        if (self.scheduledBlock != nil) {
-          dispatch_block_cancel(self.scheduledBlock);
-        }
+      dictionary[key] = value;
 
-        dictionary[key] = value;
+      self.scheduledBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
+        [self send];
+      });
 
-        self.scheduledBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
-          [self send];
-        });
-
-        dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, self.batch.time * NSEC_PER_SEC);
-        dispatch_after(delayTime, [Teak operationQueue], self.scheduledBlock);
-      }
-    });
-  }
+      dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, self.batch.time * NSEC_PER_SEC);
+      dispatch_after(delayTime, [Teak operationQueue], self.scheduledBlock);
+    }
+  });
 }
 
 - (void)send {

--- a/Teak/Core/TeakUserProfile.m
+++ b/Teak/Core/TeakUserProfile.m
@@ -45,11 +45,7 @@
       self.firstSetTime = [NSDate date];
     }
 
-    BOOL safeNotEquals = YES;
-    @try {
-      safeNotEquals = dictionary[key] == [NSNull null] || ![dictionary[key] isEqual:value];
-    } @finally {
-    }
+    BOOL safeNotEquals = dictionary[key] == [NSNull null] || ![dictionary[key] isEqual:value];
 
     if (safeNotEquals) {
       if (self.scheduledBlock != nil) {


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/C-955

`TeakUserProfile setAttribute:forKey:inDictionary:` read the attribute dict (nil-guard) and stamped `firstSetTime` on the caller's default-qos queue while the write ran on the serial `io.teak.sdk.operationQueue`. Concurrent read/write of the same `NSMutableDictionary` — the serial writer rehashing/freeing an evicted value while a caller-queue reader retains it — is the use-after-free behind Crash Family 2 (~2.4K prod crashes across Quick Hit / Jackpot Party / 88 Fortunes / Hot Shot).

**Fix:** move the nil-guard, `firstSetTime` stamp, equality test, and write all inside the existing `dispatch_async([Teak operationQueue], …)` block, finishing what 47b97dd started. Once the guard-read and the write both run on the serial queue they're atomic w.r.t. each other — no reader observes the dict mid-mutation. `firstSetTime` stays right after the nil-guard and before the equality check, so `ms_since_first_event` semantics are unchanged.

**Test:** `TeakUserProfileAttributeQueueTests` follows the `TeakSessionDeferredCallbackTests` precedent — a deterministic invariant proof, not a flaky TSan repro. Blocks the serial queue behind a semaphore, calls the real setters, and asserts `firstSetTime` is still nil (deferred behind the gate). Verified it fails on both string + numeric paths when the fix is reverted.
