### PR TITLE
Fix TeakSession reportDurationBlock background-queue use-after-free

### DIFF
--- a/Automated/AutomatedTests/TeakSessionLockingTests.m
+++ b/Automated/AutomatedTests/TeakSessionLockingTests.m
@@ -9,7 +9,7 @@
 //     methods) but written under @synchronized(self), so atomic keeps a cross-domain read from
 //     tearing.
 //   - reportDurationBlock is created and freed (reset) under @synchronized(self), but its
-//     background-queue body reads it lock-free to test its own cancellation. atomic keeps that
+//     background-queue body reads it lock-free to check for cancellation. atomic keeps that
 //     read from retaining a pointer the setter is releasing out from under it (a use-after-free
 //     seen in production as an EXC_BAD_ACCESS in dispatch_block_testcancel).
 //

--- a/Automated/AutomatedTests/TeakSessionLockingTests.m
+++ b/Automated/AutomatedTests/TeakSessionLockingTests.m
@@ -3,12 +3,19 @@
 #import "TeakSession.h"
 #import <objc/runtime.h>
 
-// TeakSession.currentState and previousState are read in the currentSessionMutex lock
-// domain (the class methods) but written under @synchronized(self), so they must be
-// declared `atomic` to keep a cross-domain read from tearing. A behavioral race test
-// isn't feasible — on ARM64 aligned pointer reads don't actually tear, so the race is
-// formal (UB / TSan-detectable) rather than observable. These tests instead pin the
-// property declarations to atomic via the Objective-C runtime, and fail if either reverts.
+// Several TeakSession properties are accessed across lock boundaries and must stay `atomic`:
+//
+//   - currentState / previousState are read in the currentSessionMutex lock domain (the class
+//     methods) but written under @synchronized(self), so atomic keeps a cross-domain read from
+//     tearing.
+//   - reportDurationBlock is created and freed (reset) under @synchronized(self), but its
+//     background-queue body reads it lock-free to test its own cancellation. atomic keeps that
+//     read from retaining a pointer the setter is releasing out from under it (a use-after-free
+//     seen in production as an EXC_BAD_ACCESS in dispatch_block_testcancel).
+//
+// A behavioral race test isn't feasible — on ARM64 aligned pointer reads don't actually tear, so
+// the race is formal (UB / TSan-detectable) rather than observable. These tests instead pin the
+// property declarations to atomic via the Objective-C runtime, and fail if any reverts.
 @interface TeakSessionLockingTests : XCTestCase
 @end
 
@@ -32,6 +39,11 @@
 - (void)testPreviousStateIsAtomic {
   XCTAssertFalse([self isNonatomicProperty:"previousState"],
                  @"TeakSession.previousState must stay atomic — same cross-lock-domain access as currentState");
+}
+
+- (void)testReportDurationBlockIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"reportDurationBlock"],
+                 @"TeakSession.reportDurationBlock must stay atomic — its background-queue body reads it outside @synchronized(self) while resetReportDurationBlock cancels and frees it under the lock");
 }
 
 @end

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -61,9 +61,9 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 
 @property (nonatomic) BOOL userIdentificationSent;
 // reportDurationBlock is created and stored under @synchronized(self) in the currentState
-// handler, but its background-queue body reads it lock-free to test its own cancellation
-// while resetReportDurationBlock cancels and frees it under the lock. atomic accessors keep
-// that lock-free read from retaining a pointer the setter is releasing out from under it.
+// handler, but its background-queue body reads it lock-free to check for cancellation while
+// resetReportDurationBlock cancels and frees it under the lock. atomic accessors keep that
+// lock-free read from retaining a pointer the setter is releasing out from under it.
 @property (strong, atomic) dispatch_block_t reportDurationBlock;
 @property (nonatomic) BOOL reportDurationSent;
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundUpdateTask;
@@ -863,7 +863,9 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
           __strong typeof(self) blockSelf = weakSelf;
           [blockSelf beginBackgroundUpdateTask];
 
-          // Make sure we're not canceled.
+          // Make sure the current reportDurationBlock hasn't been canceled. This body captures
+          // weakSelf (it can't reference itself), so it tests whatever reportDurationBlock holds
+          // now — under a rapid Expiring re-transition that may be a newer block than this one.
           // This body runs outside @synchronized(self), so a concurrent resetReportDurationBlock
           // can cancel and nil reportDurationBlock at any moment. Reading it once into a strong
           // local is load-bearing: it retains the block across dispatch_block_testcancel so the

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -60,7 +60,11 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 @property (strong, nonatomic, readwrite) TeakUserProfile* userProfile;
 
 @property (nonatomic) BOOL userIdentificationSent;
-@property (strong, nonatomic) dispatch_block_t reportDurationBlock;
+// reportDurationBlock is created and stored under @synchronized(self) in the currentState
+// handler, but its background-queue body reads it lock-free to test its own cancellation
+// while resetReportDurationBlock cancels and frees it under the lock. atomic accessors keep
+// that lock-free read from retaining a pointer the setter is releasing out from under it.
+@property (strong, atomic) dispatch_block_t reportDurationBlock;
 @property (nonatomic) BOOL reportDurationSent;
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundUpdateTask;
 @property (strong, nonatomic) NSString* serverSessionId;
@@ -855,13 +859,19 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
       if(self.serverSessionId != nil) {
         [self resetReportDurationBlock];
         __weak typeof(self) weakSelf = self;
-        self.reportDurationBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
+        dispatch_block_t reportDurationBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
           __strong typeof(self) blockSelf = weakSelf;
           [blockSelf beginBackgroundUpdateTask];
 
-          // Make sure we're not canceled
+          // Make sure we're not canceled.
+          // This body runs outside @synchronized(self), so a concurrent resetReportDurationBlock
+          // can cancel and nil reportDurationBlock at any moment. Reading it once into a strong
+          // local is load-bearing: it retains the block across dispatch_block_testcancel so the
+          // testcancel can't race the setter's release, and it removes the nil-window a second
+          // read would open (testcancel(nil) crashes). Do not re-read the property here.
           // In testing we encountered an issue where serverSessionId was nil here, but not nil earlier.
-          if (blockSelf.reportDurationBlock != nil && !dispatch_block_testcancel(blockSelf.reportDurationBlock) && blockSelf.serverSessionId != nil) {
+          dispatch_block_t canceledCheckBlock = blockSelf.reportDurationBlock;
+          if (canceledCheckBlock != nil && !dispatch_block_testcancel(canceledCheckBlock) && blockSelf.serverSessionId != nil) {
             blockSelf.reportDurationSent = YES;
             blockSelf.sessionVectorClock++;
 
@@ -883,7 +893,8 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
 
           [blockSelf endBackgroundUpdateTask];
         });
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), self.reportDurationBlock);
+        self.reportDurationBlock = reportDurationBlock;
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), reportDurationBlock);
       }
     } else if (newValue == [TeakSession Expired]) {
     }


### PR DESCRIPTION
[sdks-worker-c-956]

Linear: https://linear.app/teakio/issue/C-956

## What

`reportDurationBlock` (a `dispatch_block_t` on TeakSession) is created + freed under `@synchronized(self)` in the currentState KVO handler, but its background-queue body reads it lock-free to test its own cancellation. A `nonatomic` getter racing `resetReportDurationBlock`s cancel+nil release retains a pointer being freed underneath it → objc retain/release UAF, seen in production as EXC_BAD_ACCESS in `dispatch_block_testcancel` (Crash Family 3).

## Fix

- Make `reportDurationBlock` **atomic** — the getter safely retains across the concurrent release. Mirrors the C-837 fix for currentState/previousState. This closes the primary UAF.
- Read the property **once into a strong local** before the cancel check. Atomic alone isnt enough: the old code read it twice (`!= nil`, then `testcancel`), so reset could nil it between reads → `testcancel(nil)` crash. Load-bearing; commented as such.
- Capture the created block in a local and dispatch that local (consistency, not a race fix — both sites are already under the lock).
- Regression test pins the property to atomic via the ObjC runtime, alongside the existing currentState/previousState guards. A behavioral race test isnt feasible (aligned pointer reads dont tear on ARM64).

Heartbeat/heartbeatQueue audited (issue asked): only touched under the lock, `sendHeartbeat` doesnt deref them → clear. Unlocked scalar mutations in the same body (reportDurationSent, sessionVectorClock) are a separate non-UAF data race, tracked as C-957.

Tests: 157 passing, 0 failures.