### PR TITLE
Add MIN_VERSIONS.yml for iOS docs version attributes

### DIFF
--- a/MIN_VERSIONS.yml
+++ b/MIN_VERSIONS.yml
@@ -1,0 +1,5 @@
+# Minimum version requirements for the Teak iOS SDK.
+# Read by antora-ui-teak/script/extract-sdk-versions at docs build time.
+# Update this file when minimum versions change.
+min-ios: "11.0"
+min-xcode: "14"


### PR DESCRIPTION
Ports `MIN_VERSIONS.yml` (present on `develop`, absent on `4.3-stable`) so antora-ui-teak's `extract-sdk-versions` script can inject `{min-ios}`/`{min-xcode}` attributes when building 4.3-stable docs, instead of rendering literal placeholders — affects `docs/modules/ROOT/pages/quickstart/index.adoc`.

Values (iOS 11.0, Xcode 14) verified against 4.3-stable's own `Teak.podspec` platform and CircleCI `xcode-version` default rather than copied from develop — they happen to match because the minimums haven't moved for this line.

Linear: https://linear.app/teakio/issue/C-931