### PR TITLE
Add ThreadSanitizer race guard and race-testing methodology doc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,35 @@ jobs:
           command: bundle exec fastlane test
       - store_test_results:
           path: test_output/automated
+  test_race:
+    parameters:
+      xcode-version:
+        type: string
+        default: "14.3.1"
+    macos:
+      xcode: << parameters.xcode-version >>
+    resource_class: m4pro.medium
+    shell: /bin/bash --login -eo pipefail
+    steps:
+      - ios_setup
+      - run:
+          name: Run Race Tripwires (ThreadSanitizer)
+          command: |
+            mkdir -p test_output/race
+            # The lane runs every tripwire and exits nonzero if any is red; swallow that here so the
+            # results are always stored, then re-surface it as a job failure in a later step.
+            bundle exec fastlane test_race || touch test_output/race/.failed
+      - store_test_results:
+          path: test_output/race
+      - store_artifacts:
+          path: test_output/race
+      - run:
+          name: Surface race tripwire result
+          command: |
+            if [ -f test_output/race/.failed ]; then
+              echo "Race tripwires reported failures — a guarded defect is still open (see stored results)."
+              exit 1
+            fi
   build:
     parameters:
       xcode-version:
@@ -176,6 +205,19 @@ workflows:
           context:
             - iOS-Build
       - build:
+          context:
+            - iOS-Build
+
+  nightly-race:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 1-5"
+          filters:
+            branches:
+              only:
+                - 4.3-stable
+    jobs:
+      - test_race:
           context:
             - iOS-Build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,24 +33,17 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - ios_setup
+      # A red run means a guarded defect is still open: the lane exits nonzero and fails the job.
+      # store_* run `when: always` so the results and artifacts still upload on that red.
       - run:
           name: Run Race Tripwires (ThreadSanitizer)
-          command: |
-            mkdir -p test_output/race
-            # The lane runs every tripwire and exits nonzero if any is red; swallow that here so the
-            # results are always stored, then re-surface it as a job failure in a later step.
-            bundle exec fastlane test_race || touch test_output/race/.failed
+          command: bundle exec fastlane test_race
       - store_test_results:
           path: test_output/race
+          when: always
       - store_artifacts:
           path: test_output/race
-      - run:
-          name: Surface race tripwire result
-          command: |
-            if [ -f test_output/race/.failed ]; then
-              echo "Race tripwires reported failures — a guarded defect is still open (see stored results)."
-              exit 1
-            fi
+          when: always
   build:
     parameters:
       xcode-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,10 +209,9 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      # Runs the race tripwires under TSan on every commit, for visibility. Expected red while a
-      # guarded defect is open — some tripwires assert an as-yet-unfixed invariant and fail by
-      # design, and that red is the tracking signal, not a regression. Non-gating here (not a
-      # dependency of tag_build), so a known red doesn't block promote-tag creation; the release
+      # Runs the race regression guard under TSan on every commit. Green in normal operation; a red
+      # means a real regression — the fix it guards was reverted, or a new race landed. Non-gating
+      # here (not a dependency of tag_build), so it doesn't block promote-tag creation; the release
       # gate lives in the tagged-build workflow below, where a red run blocks the deploy.
       - test_race:
           context:
@@ -252,10 +251,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
-      # Release gate: the tripwires must be green before a version deploys. The commitment is that
-      # every red is fixed before cutting a release; this enforces it — a red tripwire run blocks
-      # deploy_versioned (and the whole deploy chain below), so a version can't ship while a guarded
-      # defect is open.
+      # Release gate: the race guard must be green before a version deploys. A red run — a reverted
+      # fix or a new race — blocks deploy_versioned (and the whole deploy chain below), so a version
+      # can't ship while a guarded race is open.
       - test_race:
           context:
             - iOS-Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,22 +208,19 @@ workflows:
           context:
             - iOS-Build
 
-  nightly-race:
-    triggers:
-      - schedule:
-          cron: "0 0 * * 1-5"
-          filters:
-            branches:
-              only:
-                - 4.3-stable
-    jobs:
-      - test_race:
-          context:
-            - iOS-Build
-
   un-tagged-build:
     jobs:
       - test:
+          context:
+            - iOS-Build
+          filters:
+            tags:
+              ignore: /.*/
+      # Runs the race tripwires under TSan on every commit. Expected red while U1/U2 are open
+      # (they assert an as-yet-unfixed invariant) — that red is the tracking signal, not a
+      # regression. Intentionally not a dependency of tag_build, so the known reds don't freeze
+      # the release/tag-promote flow.
+      - test_race:
           context:
             - iOS-Build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,10 +216,10 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      # Runs the race tripwires under TSan on every commit. Expected red while U1/U2 are open
-      # (they assert an as-yet-unfixed invariant) — that red is the tracking signal, not a
-      # regression. Intentionally not a dependency of tag_build, so the known reds don't freeze
-      # the release/tag-promote flow.
+      # Runs the race tripwires under TSan on every commit. Expected red while the guarded defects
+      # are open — two tripwires assert an as-yet-unfixed invariant and fail by design, and that red
+      # is the tracking signal, not a regression. Intentionally not a dependency of tag_build, so
+      # the known reds don't freeze the release/tag-promote flow.
       - test_race:
           context:
             - iOS-Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,10 +209,11 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      # Runs the race tripwires under TSan on every commit. Expected red while the guarded defects
-      # are open — two tripwires assert an as-yet-unfixed invariant and fail by design, and that red
-      # is the tracking signal, not a regression. Intentionally not a dependency of tag_build, so
-      # the known reds don't freeze the release/tag-promote flow.
+      # Runs the race tripwires under TSan on every commit, for visibility. Expected red while a
+      # guarded defect is open — some tripwires assert an as-yet-unfixed invariant and fail by
+      # design, and that red is the tracking signal, not a regression. Non-gating here (not a
+      # dependency of tag_build), so a known red doesn't block promote-tag creation; the release
+      # gate lives in the tagged-build workflow below, where a red run blocks the deploy.
       - test_race:
           context:
             - iOS-Build
@@ -251,12 +252,25 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
+      # Release gate: the tripwires must be green before a version deploys. The commitment is that
+      # every red is fixed before cutting a release; this enforces it — a red tripwire run blocks
+      # deploy_versioned (and the whole deploy chain below), so a version can't ship while a guarded
+      # defect is open.
+      - test_race:
+          context:
+            - iOS-Build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
       - deploy_versioned:
           context:
             - AWS-OIDC-Role
           requires:
             - test
             - build
+            - test_race
           filters:
             branches:
               ignore: /.*/
@@ -267,6 +281,7 @@ workflows:
           requires:
             - test
             - build
+            - test_race
           filters:
             branches:
               ignore: /.*/

--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01DF60A7FDB4617C18BBEAE2 /* RaceTripwireTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F0B163A675BB4810C732B49 /* RaceTripwireTests.m */; };
 		01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */; };
 		0F9BB099DE5CFEDF8A8B30F9 /* Pods_AutomatedUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */; };
 		137B2D87B7DFDBCC7B5DC85A /* TeakUserProfileAttributeQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */; };
@@ -107,6 +108,7 @@
 		12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakDeviceConfigurationTests.m; sourceTree = "<group>"; };
 		2286E8051950D4EC6E1C79EF /* TeakSessionDeferredCallbackTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakSessionDeferredCallbackTests.m; sourceTree = "<group>"; };
 		2CC8154D37CB560E22904A43 /* Pods-AutomatedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedTests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedTests/Pods-AutomatedTests.debug.xcconfig"; sourceTree = "<group>"; };
+		2F0B163A675BB4810C732B49 /* RaceTripwireTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RaceTripwireTests.m; sourceTree = "<group>"; };
 		3FFF5A9E3FBB614BDDAF98EC /* Pods-Automated.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.release.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.release.xcconfig"; sourceTree = "<group>"; };
 		433392902654423400B10DE4 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 		4358FF7F22541E540068A4FD /* Automated.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Automated.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -285,6 +287,7 @@
 				DC251E1F09B0739648086440 /* TeakRequestSocketErrorTests.m */,
 				B165DB88E09CABE8CFB776BA /* TeakWaitForDeepLinkTests.m */,
 				A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */,
+				2F0B163A675BB4810C732B49 /* RaceTripwireTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -623,6 +626,7 @@
 				CF22EC2983C75A4444F429C6 /* TeakRequestSocketErrorTests.m in Sources */,
 				5E6B9B4295CBD9D24A0CF31D /* TeakWaitForDeepLinkTests.m in Sources */,
 				137B2D87B7DFDBCC7B5DC85A /* TeakUserProfileAttributeQueueTests.m in Sources */,
+				01DF60A7FDB4617C18BBEAE2 /* RaceTripwireTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -1,0 +1,244 @@
+#import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+#import <stdatomic.h>
+
+#import "TeakAppConfiguration.h"
+#import "TeakConfiguration.h"
+#import "TeakDeviceConfiguration.h"
+#import "TeakLog.h"
+#import "TeakRaven.h"
+#import "TeakSession.h"
+#import "TeakUserProfile.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Race-detection tripwires. Each reconstructs a known concurrency defect and pins a property or
+// invariant that a detector can observe. This whole class is skipped by the per-commit Automated
+// run — several tripwires assert an as-yet-unfixed invariant and so fail by design — and is run
+// under ThreadSanitizer by the nightly `test_race` lane, where a red tripwire means the defect it
+// guards is still open.
+//
+// Two kinds live here, and they must not be confused:
+//   - real-code guards drive or introspect production types directly. A red one is a live defect
+//     (or, for the regression guard, a reverted fix).
+//   - mechanism reconstructions prove a detection technique against a standalone model; they do NOT
+//     touch production code and are NOT regression guards for any shipped fix. They pass by
+//     reproducing the modeled failure.
+// The PR description maps each test to its source defect and kind.
+
+@interface Teak (RaceTripwire)
++ (dispatch_queue_t)operationQueue;
+@property (strong, nonatomic) TeakConfiguration* _Nonnull configuration;
+@property (strong, nonatomic) TeakLog* _Nonnull log;
+@property (strong, nonatomic, readwrite) NSString* _Nonnull sdkVersion;
+@end
+
+@interface TeakUserProfile (RaceTripwire)
+@property (strong, nonatomic) NSMutableDictionary* stringAttributes;
+@end
+
+@interface TeakRaven (RaceTripwire)
+@property (strong, nonatomic) NSMutableDictionary* payloadTemplate;
+@end
+
+@interface TeakRavenReport : NSObject
+- (id)initForRaven:(nonnull TeakRaven*)raven message:(nonnull NSString*)message additions:(NSDictionary*)additions;
+@property (strong, nonatomic) NSMutableDictionary* payload;
+@end
+
+// A profile whose send is a no-op: the tripwire drives a bare-alloc profile that has no backing
+// request or session, so the real send would reach into unrelated networking. The tripwire only
+// needs the setter's dictionary access to run.
+@interface RaceGuardUserProfile : TeakUserProfile
+@end
+@implementation RaceGuardUserProfile
+- (void)send {
+}
+@end
+
+@interface RaceTripwireTests : XCTestCase
+@property (strong, nonatomic) Teak* teakMock;
+@end
+
+@implementation RaceTripwireTests
+
+- (void)setUp {
+  // Only the raven tripwire needs this; the others introspect the class or run standalone GCD.
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:@"test-device-id"];
+  TeakAppConfiguration* appConfig = mock([TeakAppConfiguration class]);
+  [given([appConfig appId]) willReturn:@"test-app-id"];
+  [given([appConfig appVersion]) willReturn:@"1"];
+  [given([appConfig appVersionName]) willReturn:@"1.0.0"];
+  [given([appConfig isProduction]) willReturn:@NO];
+  TeakConfiguration* config = mock([TeakConfiguration class]);
+  [given([config deviceConfiguration]) willReturn:deviceConfig];
+  [given([config appConfiguration]) willReturn:appConfig];
+  self.teakMock = mock([Teak class]);
+  [given([self.teakMock sdkVersion]) willReturn:@"4.3.13-test"];
+  [given([self.teakMock configuration]) willReturn:config];
+  TeakLog* log = [[TeakLog alloc] initForTeak:self.teakMock withAppId:@"test"];
+  [given([self.teakMock log]) willReturn:log];
+}
+
+// Spin-barrier rendezvous: both blocks arrive at the barrier, then bust out within nanoseconds of
+// each other, so short loops still overlap for their full duration. A single-signal gate would let
+// the second block finish before the first even woke — a false "no race".
+- (void)raceBlockA:(void (^)(void))a blockB:(void (^)(void))b {
+  dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+  dispatch_group_t group = dispatch_group_create();
+  _Atomic(int)* ready = calloc(1, sizeof(_Atomic(int)));
+  void (^rendezvous)(void) = ^{
+    atomic_fetch_add(ready, 1);
+    while (atomic_load(ready) < 2) {
+    }
+  };
+  dispatch_group_async(group, q, ^{ rendezvous(); a(); });
+  dispatch_group_async(group, q, ^{ rendezvous(); b(); });
+  dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+  free(ready);
+}
+
+- (BOOL)isNonatomicSessionProperty:(NSString*)name {
+  objc_property_t property = class_getProperty([TeakSession class], name.UTF8String);
+  XCTAssertTrue(property != NULL, @"TeakSession has no property named %@", name);
+  if (property == NULL) return YES;
+  NSString* attributes = @(property_getAttributes(property));
+  return [[attributes componentsSeparatedByString:@","] containsObject:@"N"];
+}
+
+#pragma mark - Real-code guards
+
+// C-955 regression guard (real code, ThreadSanitizer). Two threads drive the real setter
+// concurrently with changing values on the same key, so each call performs the guarded read AND the
+// dictionary write. The fix hops every access onto the serial operationQueue, so TSan stays silent
+// here; if that hop is removed the read and write land on these two caller threads at once and TSan
+// reports a race on the dictionary. Green now, red on revert.
+- (void)testUserProfileAttributeDictIsSerializedUnderConcurrency {
+  RaceGuardUserProfile* profile = [[RaceGuardUserProfile alloc] init];
+  profile.stringAttributes = [@{@"level" : @"seed"} mutableCopy];
+
+  [self raceBlockA:^{
+    for (int i = 0; i < 8000; i++) [profile setStringAttribute:[NSString stringWithFormat:@"a-%d", i] forKey:@"level"];
+  }
+            blockB:^{
+              for (int i = 0; i < 8000; i++) [profile setStringAttribute:[NSString stringWithFormat:@"b-%d", i] forKey:@"level"];
+            }];
+
+  // Drain the queued setter blocks so none outlive the test.
+  dispatch_sync([Teak operationQueue], ^{
+  });
+}
+
+// U1 deterministic floor (real code, property introspection). The session reply block reassigns
+// these strong properties on one queue while the duration/report path reads and uses them on
+// another; nonatomic strong reassignment releases the prior object mid-read (use-after-free).
+// Making them atomic hands the reader a retained snapshot. Red while they remain nonatomic.
+- (void)testSessionStrongSessionPropertiesAreAtomic {
+  for (NSString* name in @[ @"serverSessionId", @"countryCode", @"userProfile" ]) {
+    XCTAssertFalse([self isNonatomicSessionProperty:name],
+                   @"TeakSession.%@ must be atomic — it is reassigned on one queue and read+used on another; nonatomic strong releases the prior value mid-read", name);
+  }
+}
+
+// U2 deterministic guard (real code, identity). The report shallow-copies the raven's payload
+// template, so its "user" entry is the SAME mutable dictionary the raven keeps mutating (on
+// identify) while a report is being JSON-encoded. The report must own a distinct copy. Red until
+// the report deep-copies. No sanitizer, no flakiness.
+- (void)testRavenReportDoesNotShareUserDict {
+  TeakRaven* raven = [TeakRaven ravenForTeak:self.teakMock];
+  TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:raven message:@"tripwire" additions:nil];
+  XCTAssertNotIdentical(report.payload[@"user"], raven.payloadTemplate[@"user"],
+                        @"report.payload[user] must be a distinct dictionary, not the raven's live mutable one");
+}
+
+#pragma mark - Mechanism reconstructions
+
+// Deadlock-detection technique (mechanism, not production code). Dedicated lock objects reproduce a
+// two-lock AB-BA ordering; a barrier forces both first-locks to be held before either reaches its
+// second, so the inversion deadlocks deterministically. A watchdog timeout is the detection. Passes
+// by catching the forced deadlock.
+- (void)testForcedLockInversionIsCaughtByWatchdog {
+  NSObject* lockOne = [NSObject new];
+  NSObject* lockTwo = [NSObject new];
+  dispatch_semaphore_t aHasFirst = dispatch_semaphore_create(0);
+  dispatch_semaphore_t bHasFirst = dispatch_semaphore_create(0);
+  dispatch_semaphore_t done = dispatch_semaphore_create(0);
+  dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+
+  dispatch_async(q, ^{ // path A: one → two
+    @synchronized(lockOne) {
+      dispatch_semaphore_signal(aHasFirst);
+      dispatch_semaphore_wait(bHasFirst, DISPATCH_TIME_FOREVER);
+      @synchronized(lockTwo) {
+      }
+    }
+    dispatch_semaphore_signal(done);
+  });
+  dispatch_async(q, ^{ // path B: two → one
+    @synchronized(lockTwo) {
+      dispatch_semaphore_signal(bHasFirst);
+      dispatch_semaphore_wait(aHasFirst, DISPATCH_TIME_FOREVER);
+      @synchronized(lockOne) {
+      }
+    }
+    dispatch_semaphore_signal(done);
+  });
+
+  long timedOut = dispatch_semaphore_wait(done, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+  XCTAssertNotEqual(timedOut, 0, @"barrier-forced AB-BA lock ordering must deadlock — the watchdog timeout is the detection");
+}
+
+// Check-then-act drop technique (mechanism, not production code). Models a batching path whose
+// cancel and re-lock are separate critical sections: in the gap between them a concurrent send can
+// flip the batch to "sent", so a request added after that flip lands in an already-shipped batch
+// and is silently dropped. Access is fully lock-serialized, so no memory tool sees it — the barrier
+// forces the interleaving and the assertion catches the drop. Passes by reproducing the drop.
+- (void)testDroppedRequestReproducedByBarrieredInterleaving {
+  NSObject* lock = [NSObject new];
+  __block BOOL sent = NO;
+  NSMutableArray* contents = [NSMutableArray array];
+  __block NSMutableArray* shipped = nil;
+  dispatch_semaphore_t aInGap = dispatch_semaphore_create(0);
+  dispatch_semaphore_t bShipped = dispatch_semaphore_create(0);
+  dispatch_semaphore_t done = dispatch_semaphore_create(0);
+  dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+
+  dispatch_async(q, ^{ // add path: cancel (crit 1), gap, then add under crit 2
+    BOOL cancelled;
+    @synchronized(lock) {
+      cancelled = !sent;
+    }
+    XCTAssertTrue(cancelled);
+    dispatch_semaphore_signal(aInGap);
+    dispatch_semaphore_wait(bShipped, DISPATCH_TIME_FOREVER);
+    @synchronized(lock) {
+      [contents addObject:@"reqA"];
+      if (!sent) {
+        shipped = [contents mutableCopy];
+        sent = YES;
+      }
+    }
+    dispatch_semaphore_signal(done);
+  });
+  dispatch_async(q, ^{ // send path: ships whatever is batched, inside the add path's gap
+    dispatch_semaphore_wait(aInGap, DISPATCH_TIME_FOREVER);
+    @synchronized(lock) {
+      if (!sent) {
+        shipped = [contents mutableCopy];
+        sent = YES;
+      }
+    }
+    dispatch_semaphore_signal(bShipped);
+    dispatch_semaphore_signal(done);
+  });
+
+  dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
+  dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
+  XCTAssertFalse([shipped containsObject:@"reqA"],
+                 @"the barrier-forced cancel→relock interleaving must reproduce the dropped request");
+}
+
+@end

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -1,43 +1,24 @@
 #import <XCTest/XCTest.h>
-#import <objc/runtime.h>
 #import <stdatomic.h>
 
-#import "TeakAppConfiguration.h"
-#import "TeakConfiguration.h"
-#import "TeakDeviceConfiguration.h"
-#import "TeakLog.h"
-#import "TeakRaven.h"
-#import "TeakSession.h"
 #import "TeakUserProfile.h"
 #import <Teak/Teak.h>
 
-@import OCHamcrest;
-@import OCMockito;
-
-// Race-detection tripwires. Each drives or introspects a real Teak type and pins a property or
-// invariant that a detector can observe, so a red one is a live defect (or, for the regression
-// guard, a reverted fix). The fast per-commit `test` lane skips this class — some tripwires assert
-// an as-yet-unfixed invariant and so fail by design — while the `test_race` lane runs it under
-// ThreadSanitizer on every commit, where a red tripwire means the defect it guards is still open.
+// Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
+// detector can observe, so a red run means a real regression — the fix it guards was reverted. The
+// fast per-commit `test` lane skips this class (it carries signal only under a sanitizer); the
+// `test_race` lane runs it under ThreadSanitizer, where the race resurfaces if the serialization fix
+// is removed.
+//
+// See Automated/RACE_TESTING.md for the race-testing methodology — which detector catches which
+// race class, and why some classes (e.g. lock-inversion deadlocks) get no in-process guard here.
 
 @interface Teak (RaceTripwire)
 + (dispatch_queue_t)operationQueue;
-@property (strong, nonatomic) TeakConfiguration* _Nonnull configuration;
-@property (strong, nonatomic) TeakLog* _Nonnull log;
-@property (strong, nonatomic, readwrite) NSString* _Nonnull sdkVersion;
 @end
 
 @interface TeakUserProfile (RaceTripwire)
 @property (strong, nonatomic) NSMutableDictionary* stringAttributes;
-@end
-
-@interface TeakRaven (RaceTripwire)
-@property (strong, nonatomic) NSMutableDictionary* payloadTemplate;
-@end
-
-@interface TeakRavenReport : NSObject
-- (id)initForRaven:(nonnull TeakRaven*)raven message:(nonnull NSString*)message additions:(NSDictionary*)additions;
-@property (strong, nonatomic) NSMutableDictionary* payload;
 @end
 
 // A profile whose send is a no-op: the tripwire drives a bare-alloc profile that has no backing
@@ -51,30 +32,9 @@
 @end
 
 @interface RaceTripwireTests : XCTestCase
-@property (strong, nonatomic) Teak* teakMock;
 @end
 
 @implementation RaceTripwireTests
-
-- (void)setUp {
-  // Only the raven-report tripwire needs this configuration; the dict-serialization guard drives a
-  // bare-alloc profile and the session-atomicity guard introspects the class.
-  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
-  [given([deviceConfig deviceId]) willReturn:@"test-device-id"];
-  TeakAppConfiguration* appConfig = mock([TeakAppConfiguration class]);
-  [given([appConfig appId]) willReturn:@"test-app-id"];
-  [given([appConfig appVersion]) willReturn:@"1"];
-  [given([appConfig appVersionName]) willReturn:@"1.0.0"];
-  [given([appConfig isProduction]) willReturn:@NO];
-  TeakConfiguration* config = mock([TeakConfiguration class]);
-  [given([config deviceConfiguration]) willReturn:deviceConfig];
-  [given([config appConfiguration]) willReturn:appConfig];
-  self.teakMock = mock([Teak class]);
-  [given([self.teakMock sdkVersion]) willReturn:@"4.3.13-test"];
-  [given([self.teakMock configuration]) willReturn:config];
-  TeakLog* log = [[TeakLog alloc] initForTeak:self.teakMock withAppId:@"test"];
-  [given([self.teakMock log]) willReturn:log];
-}
 
 // Spin-barrier rendezvous: both blocks arrive at the barrier, then bust out within nanoseconds of
 // each other, so short loops still overlap for their full duration. A single-signal gate would let
@@ -92,14 +52,6 @@
   dispatch_group_async(group, q, ^{ rendezvous(); b(); });
   dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
   free(ready);
-}
-
-- (BOOL)isNonatomicSessionProperty:(NSString*)name {
-  objc_property_t property = class_getProperty([TeakSession class], name.UTF8String);
-  XCTAssertTrue(property != NULL, @"TeakSession has no property named %@", name);
-  if (property == NULL) return YES;
-  NSString* attributes = @(property_getAttributes(property));
-  return [[attributes componentsSeparatedByString:@","] containsObject:@"N"];
 }
 
 // Attribute-dict serialization regression guard (ThreadSanitizer). Two threads drive the real setter
@@ -122,36 +74,5 @@
   dispatch_sync([Teak operationQueue], ^{
   });
 }
-
-// Session strong-property atomicity guard (property introspection). The session reply block
-// reassigns these strong properties on one queue while the duration/report path reads and uses them
-// on another; nonatomic strong reassignment releases the prior object mid-read (use-after-free).
-// Making them atomic hands the reader a retained snapshot. Red while they remain nonatomic.
-- (void)testSessionStrongSessionPropertiesAreAtomic {
-  for (NSString* name in @[ @"serverSessionId", @"countryCode", @"userProfile" ]) {
-    XCTAssertFalse([self isNonatomicSessionProperty:name],
-                   @"TeakSession.%@ must be atomic — it is reassigned on one queue and read+used on another; nonatomic strong releases the prior value mid-read", name);
-  }
-}
-
-// Raven report dictionary-identity guard (identity). The report shallow-copies the raven's payload
-// template, so its "user" entry is the SAME mutable dictionary the raven keeps mutating (on identify)
-// while a report is being JSON-encoded. The report must own a distinct copy. Red until the report
-// deep-copies.
-- (void)testRavenReportDoesNotShareUserDict {
-  TeakRaven* raven = [TeakRaven ravenForTeak:self.teakMock];
-  TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:raven message:@"tripwire" additions:nil];
-  XCTAssertNotIdentical(report.payload[@"user"], raven.payloadTemplate[@"user"],
-                        @"report.payload[user] must be a distinct dictionary, not the raven's live mutable one");
-}
-
-// Two audited concurrency defects have no data race for a sanitizer to catch, so they get no
-// tripwire here — a standalone reconstruction would assert on a model, not on Teak, and would stay
-// green even if the real bug shipped. The detection techniques, confirmed workable, are recorded so
-// the real guards can be built against production code when each fix lands:
-//   - Lock-inversion deadlock: a watchdog-forced AB-BA ordering (hold both first-locks at a barrier,
-//     then cross-lock) deadlocks deterministically; a timeout is the detection.
-//   - Batch cancel/relock drop: a barrier that forces a concurrent send into the gap between the add
-//     path's cancel and re-lock reproduces the silently-dropped request.
 
 @end

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -14,19 +14,11 @@
 @import OCHamcrest;
 @import OCMockito;
 
-// Race-detection tripwires. Each reconstructs a known concurrency defect and pins a property or
-// invariant that a detector can observe. This whole class is skipped by the per-commit Automated
-// run — several tripwires assert an as-yet-unfixed invariant and so fail by design — and is run
-// under ThreadSanitizer by the nightly `test_race` lane, where a red tripwire means the defect it
-// guards is still open.
-//
-// Two kinds live here, and they must not be confused:
-//   - real-code guards drive or introspect production types directly. A red one is a live defect
-//     (or, for the regression guard, a reverted fix).
-//   - mechanism reconstructions prove a detection technique against a standalone model; they do NOT
-//     touch production code and are NOT regression guards for any shipped fix. They pass by
-//     reproducing the modeled failure.
-// The PR description maps each test to its source defect and kind.
+// Race-detection tripwires. Each drives or introspects a real Teak type and pins a property or
+// invariant that a detector can observe, so a red one is a live defect (or, for the regression
+// guard, a reverted fix). The fast per-commit `test` lane skips this class — some tripwires assert
+// an as-yet-unfixed invariant and so fail by design — while the `test_race` lane runs it under
+// ThreadSanitizer on every commit, where a red tripwire means the defect it guards is still open.
 
 @interface Teak (RaceTripwire)
 + (dispatch_queue_t)operationQueue;
@@ -65,7 +57,8 @@
 @implementation RaceTripwireTests
 
 - (void)setUp {
-  // Only the raven tripwire needs this; the others introspect the class or run standalone GCD.
+  // Only the raven-report tripwire needs this configuration; the dict-serialization guard drives a
+  // bare-alloc profile and the session-atomicity guard introspects the class.
   TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
   [given([deviceConfig deviceId]) willReturn:@"test-device-id"];
   TeakAppConfiguration* appConfig = mock([TeakAppConfiguration class]);
@@ -109,9 +102,7 @@
   return [[attributes componentsSeparatedByString:@","] containsObject:@"N"];
 }
 
-#pragma mark - Real-code guards
-
-// C-955 regression guard (real code, ThreadSanitizer). Two threads drive the real setter
+// Attribute-dict serialization regression guard (ThreadSanitizer). Two threads drive the real setter
 // concurrently with changing values on the same key, so each call performs the guarded read AND the
 // dictionary write. The fix hops every access onto the serial operationQueue, so TSan stays silent
 // here; if that hop is removed the read and write land on these two caller threads at once and TSan
@@ -132,9 +123,9 @@
   });
 }
 
-// U1 deterministic floor (real code, property introspection). The session reply block reassigns
-// these strong properties on one queue while the duration/report path reads and uses them on
-// another; nonatomic strong reassignment releases the prior object mid-read (use-after-free).
+// Session strong-property atomicity guard (property introspection). The session reply block
+// reassigns these strong properties on one queue while the duration/report path reads and uses them
+// on another; nonatomic strong reassignment releases the prior object mid-read (use-after-free).
 // Making them atomic hands the reader a retained snapshot. Red while they remain nonatomic.
 - (void)testSessionStrongSessionPropertiesAreAtomic {
   for (NSString* name in @[ @"serverSessionId", @"countryCode", @"userProfile" ]) {
@@ -143,10 +134,10 @@
   }
 }
 
-// U2 deterministic guard (real code, identity). The report shallow-copies the raven's payload
-// template, so its "user" entry is the SAME mutable dictionary the raven keeps mutating (on
-// identify) while a report is being JSON-encoded. The report must own a distinct copy. Red until
-// the report deep-copies. No sanitizer, no flakiness.
+// Raven report dictionary-identity guard (identity). The report shallow-copies the raven's payload
+// template, so its "user" entry is the SAME mutable dictionary the raven keeps mutating (on identify)
+// while a report is being JSON-encoded. The report must own a distinct copy. Red until the report
+// deep-copies.
 - (void)testRavenReportDoesNotShareUserDict {
   TeakRaven* raven = [TeakRaven ravenForTeak:self.teakMock];
   TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:raven message:@"tripwire" additions:nil];
@@ -154,91 +145,13 @@
                         @"report.payload[user] must be a distinct dictionary, not the raven's live mutable one");
 }
 
-#pragma mark - Mechanism reconstructions
-
-// Deadlock-detection technique (mechanism, not production code). Dedicated lock objects reproduce a
-// two-lock AB-BA ordering; a barrier forces both first-locks to be held before either reaches its
-// second, so the inversion deadlocks deterministically. A watchdog timeout is the detection. Passes
-// by catching the forced deadlock.
-- (void)testForcedLockInversionIsCaughtByWatchdog {
-  NSObject* lockOne = [NSObject new];
-  NSObject* lockTwo = [NSObject new];
-  dispatch_semaphore_t aHasFirst = dispatch_semaphore_create(0);
-  dispatch_semaphore_t bHasFirst = dispatch_semaphore_create(0);
-  dispatch_semaphore_t done = dispatch_semaphore_create(0);
-  dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
-
-  dispatch_async(q, ^{ // path A: one → two
-    @synchronized(lockOne) {
-      dispatch_semaphore_signal(aHasFirst);
-      dispatch_semaphore_wait(bHasFirst, DISPATCH_TIME_FOREVER);
-      @synchronized(lockTwo) {
-      }
-    }
-    dispatch_semaphore_signal(done);
-  });
-  dispatch_async(q, ^{ // path B: two → one
-    @synchronized(lockTwo) {
-      dispatch_semaphore_signal(bHasFirst);
-      dispatch_semaphore_wait(aHasFirst, DISPATCH_TIME_FOREVER);
-      @synchronized(lockOne) {
-      }
-    }
-    dispatch_semaphore_signal(done);
-  });
-
-  long timedOut = dispatch_semaphore_wait(done, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
-  XCTAssertNotEqual(timedOut, 0, @"barrier-forced AB-BA lock ordering must deadlock — the watchdog timeout is the detection");
-}
-
-// Check-then-act drop technique (mechanism, not production code). Models a batching path whose
-// cancel and re-lock are separate critical sections: in the gap between them a concurrent send can
-// flip the batch to "sent", so a request added after that flip lands in an already-shipped batch
-// and is silently dropped. Access is fully lock-serialized, so no memory tool sees it — the barrier
-// forces the interleaving and the assertion catches the drop. Passes by reproducing the drop.
-- (void)testDroppedRequestReproducedByBarrieredInterleaving {
-  NSObject* lock = [NSObject new];
-  __block BOOL sent = NO;
-  NSMutableArray* contents = [NSMutableArray array];
-  __block NSMutableArray* shipped = nil;
-  dispatch_semaphore_t aInGap = dispatch_semaphore_create(0);
-  dispatch_semaphore_t bShipped = dispatch_semaphore_create(0);
-  dispatch_semaphore_t done = dispatch_semaphore_create(0);
-  dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
-
-  dispatch_async(q, ^{ // add path: cancel (crit 1), gap, then add under crit 2
-    BOOL cancelled;
-    @synchronized(lock) {
-      cancelled = !sent;
-    }
-    XCTAssertTrue(cancelled);
-    dispatch_semaphore_signal(aInGap);
-    dispatch_semaphore_wait(bShipped, DISPATCH_TIME_FOREVER);
-    @synchronized(lock) {
-      [contents addObject:@"reqA"];
-      if (!sent) {
-        shipped = [contents mutableCopy];
-        sent = YES;
-      }
-    }
-    dispatch_semaphore_signal(done);
-  });
-  dispatch_async(q, ^{ // send path: ships whatever is batched, inside the add path's gap
-    dispatch_semaphore_wait(aInGap, DISPATCH_TIME_FOREVER);
-    @synchronized(lock) {
-      if (!sent) {
-        shipped = [contents mutableCopy];
-        sent = YES;
-      }
-    }
-    dispatch_semaphore_signal(bShipped);
-    dispatch_semaphore_signal(done);
-  });
-
-  dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
-  dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER);
-  XCTAssertFalse([shipped containsObject:@"reqA"],
-                 @"the barrier-forced cancel→relock interleaving must reproduce the dropped request");
-}
+// Two audited concurrency defects have no data race for a sanitizer to catch, so they get no
+// tripwire here — a standalone reconstruction would assert on a model, not on Teak, and would stay
+// green even if the real bug shipped. The detection techniques, confirmed workable, are recorded so
+// the real guards can be built against production code when each fix lands:
+//   - Lock-inversion deadlock: a watchdog-forced AB-BA ordering (hold both first-locks at a barrier,
+//     then cross-lock) deadlocks deterministically; a timeout is the detection.
+//   - Batch cancel/relock drop: a barrier that forces a concurrent send into the gap between the add
+//     path's cancel and re-lock reproduces the silently-dropped request.
 
 @end

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -1,0 +1,166 @@
+# Race-condition testing
+
+How to write a test that actually catches a given concurrency bug in this SDK, and how to prove the
+test is trustworthy. Methodology first: the right detector depends on what kind of shared state is
+racing, so start by classifying that.
+
+## 1. Classify the shared state first
+
+The detector that will actually fire depends on what's being shared. Three cases cover almost
+everything here:
+
+- **Immortal scalar or pointer** — the slot is written concurrently but the pointee is never freed
+  (e.g. a state-machine field that only ever points at long-lived singletons). On arm64 an aligned
+  load/store can't tear, so the race is formal (undefined behavior) but won't misbehave observably.
+  A static "is this declared atomic?" assertion is the deterministic guard.
+- **Strong pointer whose pointee CAN be freed concurrently** — a `nonatomic` strong property
+  reassigned on one thread while another reads it (e.g. `TeakSession.serverSessionId`). Aligned-load
+  atomicity stops a torn pointer, but not use-after-free: the reader loads the pointer, the writer's
+  setter releases and frees the old object, and the reader then retains and dereferences freed
+  memory. This is the dangerous case — and, as §2 shows, the one ThreadSanitizer is blind to.
+- **Mutable container** — an `NSMutableDictionary` / `NSMutableArray` mutated on two threads at once
+  (e.g. the `userProfile` string-attributes dict). The container's internal backing buffer
+  reallocates on mutation, so a concurrent access touches freed/moved memory. Atomicity of the
+  pointer to the container does nothing here; the access itself must be serialized.
+
+The class tells you which tool below will fire — and, just as important, which will stay silent
+while the bug is still there.
+
+## The revert check (trustworthiness gate)
+
+**A race test you haven't watched fail is not yet a test.** Every technique below — TSan test,
+dynamic crash repro, static assertion — is only trustworthy once you have:
+
+1. seen it **RED** with the bug present (fix reverted or not yet applied), and
+2. seen it **GREEN** with the fix in place.
+
+A test that stays green when you revert the fix guards nothing — it will stay green when the bug
+comes back, too. Do the revert, watch the red, restore the fix, watch the green. Skip this and
+you've written decoration, not a guard. This gate is non-negotiable, and it applies to all three
+techniques equally.
+
+## 2. ThreadSanitizer: what it catches, what it's blind to
+
+TSan instruments memory accesses in first-party (Teak) code and reports when two threads touch the
+same location without synchronization and at least one writes.
+
+**It catches races where both sides are instrumented.** The mutable-container case is the sweet
+spot: two threads mutating the same `NSMutableDictionary` both execute instrumented code, and TSan
+reports `race on NSMutableDictionary`. Live template:
+`testUserProfileAttributeDictIsSerializedUnderConcurrency` in
+`Automated/AutomatedTests/RaceTripwireTests.m` drives the real attribute setter from two threads;
+with the serialization fix it stays green, and reverting the fix (removing the operationQueue hop)
+makes TSan fire. Open it as a starting point for a container-race test.
+
+**It is blind to the nonatomic-strong use-after-free.** For a `nonatomic` strong property, the
+synthesized setter's store lands inside `objc_storeStrong` — libobjc, which is not instrumented.
+TSan sees the reader's instrumented load of the ivar but never the writer's store, so it never pairs
+them into a race and reports nothing. This was confirmed empirically against
+`TeakSession.serverSessionId`: hammering the real setter and getter on two threads for hundreds of
+thousands of iterations produced **zero** TSan output, even though the code is unambiguously racing
+(see §3, where the same probe crashes hard).
+
+> **Rule: a green TSan run does not mean "safe."** It clears the both-sides-instrumented classes
+> (mutable containers, first-party field races). It says nothing about a nonatomic-strong pointer
+> whose release lives in libobjc. Never read a green TSan as proof that a freeable-pointer property
+> is race-free.
+
+## 3. The dynamic crash repro (for the class TSan can't see)
+
+The nonatomic-strong UAF has no TSan signal, but it is not undetectable: CoreFoundation's
+reference-count machinery has an always-on over-release guard that traps (`SIGTRAP` /
+`EXC_BREAKPOINT` in `_CFRelease`) when an object is released below a retain count of zero. The race
+drives exactly that — the reader retains a pointer the writer already freed, then releases it — so a
+well-built repro crashes deterministically, with or without TSan.
+
+Building one that's trustworthy (a green must mean "no bug," not "I missed the window"):
+
+- **Drive the real production accessors** — not a hand-rolled reconstruction. A model proves things
+  about the model, not about the SDK.
+- **Writer thread: assign fresh, distinct, heap-allocated strings over 15 characters.** Short
+  strings become tagged pointers, which are not heap objects and never deallocate — the old value
+  never frees, the UAF never happens, and you get a false green. Long unique strings force a real
+  allocation and a real free on each overwrite.
+- **Reader thread: load via the getter and touch the pointee** (e.g. read `.length`), not just the
+  pointer. The dereference is what lands in freed memory during the load→retain window.
+- **Overlap for real** — a spin-barrier rendezvous so both threads bust out together and race for
+  their full duration, not a single-signal gate that lets one finish before the other wakes.
+- **Iterate hard** — hundreds of thousands of iterations. At 500k the `serverSessionId` probe
+  crashed 10/10 runs; tune the count up until the crash is effectively deterministic.
+
+Minimal skeleton (drop into an XCTest case; `raceBlockA:blockB:` is the spin-barrier helper in
+`RaceTripwireTests.m`):
+
+```objc
+// `property` is a nonatomic strong pointer whose pointee can be freed (e.g. TeakSession.serverSessionId).
+// If it's internal, re-declare it in a class extension in the test file so the accessors compile.
+- (void)testPropertyDynamicUAF {
+  MyType* object = /* a live instance whose accessor you can drive — see the construction note below */;
+  const int N = 500000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      // Real setter: objc_storeStrong releases the prior value. Fresh >15-char heap string each time.
+      object.property = [[NSString alloc] initWithFormat:@"race-probe-value-%d", i];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSString* s = object.property;  // real getter: nonatomic load; ARC retains into s
+                (void)s.length;                 // touch the pointee inside the load->retain window
+              }
+            }];
+}
+```
+
+**Construction note:** you only need an instance whose accessors you can drive, not a fully wired
+one. If the type's designated initializer has side effects, or its `dealloc` assumes init ran (e.g.
+it removes an observer that only init registered), construct a bare instance and keep it alive for
+the test's duration rather than letting it deinit — the synthesized accessors are the real
+production code regardless of whether init ran.
+
+Then apply the **revert check**: run it against the unfixed property and watch it crash; apply the
+fix (§4) and watch the crash vanish. Red→green.
+
+## 4. Why `atomic` fixes the nonatomic-strong UAF
+
+Declaring the property `atomic` (strong) routes reads through `objc_getProperty`, which **retains
+the value under the property's per-slot spinlock and hands the reader a +1 snapshot.** The reader
+now holds its own strong reference across the dereference, so the writer's concurrent release can't
+free the object out from under it — the load→retain gap is closed.
+
+This is a different mechanism from aligned-load atomicity. On arm64 the pointer read already doesn't
+*tear*; that was never the problem. The problem is *free-during-use*, and only a retained snapshot
+(or a lock held across both the read and the use) prevents it. So the fix has two requirements:
+
+- every read goes **through the accessor** — a direct ivar read bypasses the spinlock and reopens
+  the gap, and
+- multi-read sites **capture to a local** once, then use the local — re-reading the property for
+  each use reopens the window between reads.
+
+## 5. Harness limitation and the standing workflow
+
+The dynamic crash repro takes down the whole test process — the CF trap is a hard crash, not an
+assertion failure. In a shared test lane that aborts every sibling test in the same run. Until an
+isolated per-test death-test harness exists, that shapes how these tests ship:
+
+**Each fix ships its own red→green test in the same PR as the fix.** We do not carry standing red
+tests on a branch. The sequence for any concurrency fix is: add the failing test → watch it go red
+(crash or assert) → apply the fix → watch the suite go green → ship both together. A green branch
+stays green; a red appears only transiently, inside the fix PR that resolves it.
+
+Some race classes don't fit a reliable in-process dynamic repro at all — forced lock-inversion
+deadlocks (which hang rather than crash) and dropped-request ordering bugs (which have no data race
+to detect and no crash) among them. Those need a different approach — a watchdog timeout, a
+forced-interleaving barrier, or a static/structural assertion — chosen when the fix is tackled,
+rather than a copy of the crash-repro pattern above.
+
+## 6. Quick reference
+
+| Shared state | Detector | Signal | Example source |
+|---|---|---|---|
+| Mutable container (dict/array) | ThreadSanitizer | `race on NSMutableDictionary` | `userProfile` string-attributes dict |
+| nonatomic-strong, freeable pointee | Dynamic crash repro (CF over-release trap) | `SIGTRAP` in `_CFRelease` | `TeakSession.serverSessionId` |
+| Immortal scalar/pointer | Static atomic-declaration assertion | assertion red | state-machine fields |
+| Deadlock / dropped-order | No in-process race signal | case-by-case: watchdog, barrier, structural | — |
+
+Whatever the technique, it isn't a guard until you've run the **revert check** and watched it fail.

--- a/Automated/tsan-suppressions.txt
+++ b/Automated/tsan-suppressions.txt
@@ -1,0 +1,14 @@
+# ThreadSanitizer suppressions for the nightly race lane (bundle exec fastlane test_race).
+#
+# Vendored third-party code ONLY. Never suppress a race in Teak's own code — fix it, or add a
+# tripwire to RaceTripwireTests instead. Each entry must name the vendored library it silences and
+# say why. This file lives outside Teak/ on purpose so a suppression can never be mistaken for a
+# blessed race in first-party source.
+#
+# Format: https://github.com/google/sanitizers/wiki/threadsanitizersuppressions
+#
+# No active suppressions: the nightly runs only the targeted RaceTripwireTests, which touch no
+# vendored code. Add entries here if a vendored library (e.g. libtommath) ever trips TSan.
+#
+# Example (disabled):
+# race:libtommath

--- a/Automated/tsan-suppressions.txt
+++ b/Automated/tsan-suppressions.txt
@@ -1,4 +1,4 @@
-# ThreadSanitizer suppressions for the nightly race lane (bundle exec fastlane test_race).
+# ThreadSanitizer suppressions for the race lane (bundle exec fastlane test_race).
 #
 # Vendored third-party code ONLY. Never suppress a race in Teak's own code — fix it, or add a
 # tripwire to RaceTripwireTests instead. Each entry must name the vendored library it silences and
@@ -7,7 +7,7 @@
 #
 # Format: https://github.com/google/sanitizers/wiki/threadsanitizersuppressions
 #
-# No active suppressions: the nightly runs only the targeted RaceTripwireTests, which touch no
+# No active suppressions: the race lane runs only the targeted RaceTripwireTests, which touch no
 # vendored code. Add entries here if a vendored library (e.g. libtommath) ever trips TSan.
 #
 # Example (disabled):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ The generator creates a boilerplate XCTest file with OCMockito/OCHamcrest import
 - `LogTests.m` — OCMockito mocking with `mock()`, `given()`, `stubProperty()`, `assertThat()`
 - `NotificationSettingsTests.m` — bare Teak instance with mocked dependencies, internal property re-declaration
 
+**Testing for race conditions:** see [`Automated/RACE_TESTING.md`](Automated/RACE_TESTING.md) — how to pick a detector for a given race class (ThreadSanitizer vs. a dynamic crash repro vs. a static assertion), why a green TSan run doesn't mean "safe" for nonatomic-strong pointers, and the revert check that makes any race test trustworthy. The `test_race` fastlane lane runs these guards under TSan (per-commit and as a release gate).
+
 **Format code:**
 ```bash
 ./format-code

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,9 +5,9 @@ platform :ios do
   lane :test do
     scan(
       workspace: 'Automated/Automated.xcworkspace',
-      # RaceTripwireTests are the ThreadSanitizer nightly tripwires — several assert an as-yet-unfixed
-      # invariant and fail by design, so they are excluded here to keep the per-commit run green. The
-      # nightly `test_race` lane runs them.
+      # RaceTripwireTests are the ThreadSanitizer race tripwires — several assert an as-yet-unfixed
+      # invariant and fail by design. They are excluded from this fast lane so it stays a quick green
+      # signal; the `test_race` lane runs them under TSan on every commit.
       skip_testing: ['AutomatedTests/RaceTripwireTests'],
       output_directory: 'test_output/automated',
       output_files: 'results.xml',
@@ -15,7 +15,7 @@ platform :ios do
     )
   end
 
-  desc "Run the race-detection tripwires under ThreadSanitizer (nightly on 4.3-stable)"
+  desc "Run the race-detection tripwires under ThreadSanitizer (per-commit)"
   lane :test_race do
     tripwires = 'AutomatedTests/RaceTripwireTests'
     # The watchdog tripwire parks two threads on a forced deadlock, so it runs in its own process to

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,9 +23,11 @@ platform :ios do
     watchdog = 'AutomatedTests/RaceTripwireTests/testForcedLockInversionIsCaughtByWatchdog'
     derived = 'test_output/race/derived'
 
-    # Suppressions apply to vendored code only (see Automated/tsan-suppressions.txt). Passed to the
-    # simulator test process via the SIMCTL_CHILD_ prefix.
-    ENV['SIMCTL_CHILD_TSAN_OPTIONS'] = "suppressions=#{File.expand_path('Automated/tsan-suppressions.txt')}"
+    # TSan options for the simulator test process, via the SIMCTL_CHILD_ prefix:
+    #   halt_on_error=0 — report every race and keep running, so one tripwire tripping TSan can't
+    #                     abort the process before the others report.
+    #   suppressions    — vendored code only (see Automated/tsan-suppressions.txt).
+    ENV['SIMCTL_CHILD_TSAN_OPTIONS'] = "halt_on_error=0 suppressions=#{File.expand_path('Automated/tsan-suppressions.txt')}"
 
     # Build once under TSan, then test in two processes.
     scan(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,53 +17,23 @@ platform :ios do
 
   desc "Run the race-detection tripwires under ThreadSanitizer (per-commit)"
   lane :test_race do
-    tripwires = 'AutomatedTests/RaceTripwireTests'
-    # The watchdog tripwire parks two threads on a forced deadlock, so it runs in its own process to
-    # keep it from starving the shared queue for the other tripwires.
-    watchdog = 'AutomatedTests/RaceTripwireTests/testForcedLockInversionIsCaughtByWatchdog'
-    derived = 'test_output/race/derived'
-
     # TSan options for the simulator test process, via the SIMCTL_CHILD_ prefix:
     #   halt_on_error=0 — report every race and keep running, so one tripwire tripping TSan can't
     #                     abort the process before the others report.
     #   suppressions    — vendored code only (see Automated/tsan-suppressions.txt).
     ENV['SIMCTL_CHILD_TSAN_OPTIONS'] = "halt_on_error=0 suppressions=#{File.expand_path('Automated/tsan-suppressions.txt')}"
 
-    # Build once under TSan, then test in two processes.
+    # Runs the tripwires under TSan. Some assert an as-yet-unfixed invariant and fail by design; a
+    # red run is the signal that a guarded defect is still open. scan writes the JUnit report before
+    # it raises on failure, so the result is always stored and the lane exits nonzero for CI.
     scan(
       workspace: 'Automated/Automated.xcworkspace',
       scheme: 'Automated',
       thread_sanitizer: true,
-      build_for_testing: true,
-      derived_data_path: derived
+      only_testing: ['AutomatedTests/RaceTripwireTests'],
+      output_directory: 'test_output/race',
+      output_files: 'race.xml',
+      output_types: 'junit'
     )
-
-    reported_failure = false
-    [
-      {only: [tripwires], skip: [watchdog], out: 'race.xml'},
-      {only: [watchdog], skip: [], out: 'race-watchdog.xml'}
-    ].each do |run|
-      begin
-        scan(
-          workspace: 'Automated/Automated.xcworkspace',
-          scheme: 'Automated',
-          thread_sanitizer: true,
-          test_without_building: true,
-          derived_data_path: derived,
-          only_testing: run[:only],
-          skip_testing: run[:skip],
-          output_directory: 'test_output/race',
-          output_files: run[:out],
-          output_types: 'junit'
-        )
-      rescue StandardError => e
-        # A red tripwire is the signal that a guarded defect is still open. Keep going so every
-        # tripwire reports, then fail the lane at the end so the nightly surfaces the result.
-        reported_failure = true
-        UI.important("race tripwire reported a failure (expected while a guarded defect is open): #{e.message}")
-      end
-    end
-
-    UI.user_error!('race tripwires reported failures — see test_output/race') if reported_failure
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,9 +5,63 @@ platform :ios do
   lane :test do
     scan(
       workspace: 'Automated/Automated.xcworkspace',
+      # RaceTripwireTests are the ThreadSanitizer nightly tripwires — several assert an as-yet-unfixed
+      # invariant and fail by design, so they are excluded here to keep the per-commit run green. The
+      # nightly `test_race` lane runs them.
+      skip_testing: ['AutomatedTests/RaceTripwireTests'],
       output_directory: 'test_output/automated',
       output_files: 'results.xml',
       output_types: 'junit'
     )
+  end
+
+  desc "Run the race-detection tripwires under ThreadSanitizer (nightly on 4.3-stable)"
+  lane :test_race do
+    tripwires = 'AutomatedTests/RaceTripwireTests'
+    # The watchdog tripwire parks two threads on a forced deadlock, so it runs in its own process to
+    # keep it from starving the shared queue for the other tripwires.
+    watchdog = 'AutomatedTests/RaceTripwireTests/testForcedLockInversionIsCaughtByWatchdog'
+    derived = 'test_output/race/derived'
+
+    # Suppressions apply to vendored code only (see Automated/tsan-suppressions.txt). Passed to the
+    # simulator test process via the SIMCTL_CHILD_ prefix.
+    ENV['SIMCTL_CHILD_TSAN_OPTIONS'] = "suppressions=#{File.expand_path('Automated/tsan-suppressions.txt')}"
+
+    # Build once under TSan, then test in two processes.
+    scan(
+      workspace: 'Automated/Automated.xcworkspace',
+      scheme: 'Automated',
+      thread_sanitizer: true,
+      build_for_testing: true,
+      derived_data_path: derived
+    )
+
+    reported_failure = false
+    [
+      {only: [tripwires], skip: [watchdog], out: 'race.xml'},
+      {only: [watchdog], skip: [], out: 'race-watchdog.xml'}
+    ].each do |run|
+      begin
+        scan(
+          workspace: 'Automated/Automated.xcworkspace',
+          scheme: 'Automated',
+          thread_sanitizer: true,
+          test_without_building: true,
+          derived_data_path: derived,
+          only_testing: run[:only],
+          skip_testing: run[:skip],
+          output_directory: 'test_output/race',
+          output_files: run[:out],
+          output_types: 'junit'
+        )
+      rescue StandardError => e
+        # A red tripwire is the signal that a guarded defect is still open. Keep going so every
+        # tripwire reports, then fail the lane at the end so the nightly surfaces the result.
+        reported_failure = true
+        UI.important("race tripwire reported a failure (expected while a guarded defect is open): #{e.message}")
+      end
+    end
+
+    UI.user_error!('race tripwires reported failures — see test_output/race') if reported_failure
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,9 +5,9 @@ platform :ios do
   lane :test do
     scan(
       workspace: 'Automated/Automated.xcworkspace',
-      # RaceTripwireTests are the ThreadSanitizer race tripwires — several assert an as-yet-unfixed
-      # invariant and fail by design. They are excluded from this fast lane so it stays a quick green
-      # signal; the `test_race` lane runs them under TSan on every commit.
+      # RaceTripwireTests is the ThreadSanitizer race regression guard — it carries signal only under
+      # a sanitizer, so it's excluded from this fast (non-TSan) lane to keep it a quick green signal;
+      # the `test_race` lane runs it under TSan on every commit.
       skip_testing: ['AutomatedTests/RaceTripwireTests'],
       output_directory: 'test_output/automated',
       output_files: 'results.xml',
@@ -15,17 +15,16 @@ platform :ios do
     )
   end
 
-  desc "Run the race-detection tripwires under ThreadSanitizer (per-commit)"
+  desc "Run the race-detection regression guard under ThreadSanitizer (per-commit)"
   lane :test_race do
     # TSan options for the simulator test process, via the SIMCTL_CHILD_ prefix:
-    #   halt_on_error=0 — report every race and keep running, so one tripwire tripping TSan can't
-    #                     abort the process before the others report.
+    #   halt_on_error=0 — report every race and keep running, rather than aborting on the first.
     #   suppressions    — vendored code only (see Automated/tsan-suppressions.txt).
     ENV['SIMCTL_CHILD_TSAN_OPTIONS'] = "halt_on_error=0 suppressions=#{File.expand_path('Automated/tsan-suppressions.txt')}"
 
-    # Runs the tripwires under TSan. Some assert an as-yet-unfixed invariant and fail by design; a
-    # red run is the signal that a guarded defect is still open. scan writes the JUnit report before
-    # it raises on failure, so the result is always stored and the lane exits nonzero for CI.
+    # Runs the race regression guard under TSan. Green in normal operation; a red run means a real
+    # regression — a guarded fix was reverted, or a new race landed. scan writes the JUnit report
+    # before it raises on failure, so the result is always stored and the lane exits nonzero for CI.
     scan(
       workspace: 'Automated/Automated.xcworkspace',
       scheme: 'Automated',


### PR DESCRIPTION
Stands up ThreadSanitizer as a race-detection guard for the SDK — run per-commit for visibility and wired as a release gate on tag — plus a methodology doc for writing race tests. **No production fixes.**

Linear: https://linear.app/teakio/issue/C-961

## What's here

- `Automated/AutomatedTests/RaceTripwireTests.m` — a race-detection regression guard driving a real Teak type under ThreadSanitizer.
- `Automated/RACE_TESTING.md` — how to test a concurrency bug in this SDK and prove the test is trustworthy (linked from CLAUDE.md's Adding Tests section).
- A `test_race` fastlane lane that runs the guard under TSan: per-commit in `un-tagged-build` for visibility, and as a release gate in `tagged-build` (a red run blocks the deploy).
- `Automated/tsan-suppressions.txt` — vendored-code-only suppressions (empty for now), deliberately outside `Teak/`.

## The guard

`testUserProfileAttributeDictIsSerializedUnderConcurrency` drives the real attribute setter from two threads under TSan. The serialization fix (hopping every access onto the serial operationQueue) keeps it green; reverting the fix makes TSan report `race on NSMutableDictionary` in `-[__NSDictionaryM setObject:forKeyedSubscript:]`. It exercises production code and fails when the fix is reverted — a real regression guard, verified both ways.

The fast `test` lane skips this class (it carries signal only under a sanitizer); `test_race` carries the TSan run separately, so no double-run.

## Methodology doc

`Automated/RACE_TESTING.md` captures what standing this up taught us. Classify the shared state first (immortal / freeable-pointer / mutable-container), because that decides which detector fires: ThreadSanitizer for both-sides-instrumented races, a dynamic CoreFoundation over-release crash repro for the nonatomic-strong UAF that TSan is **blind** to (the setter's release lives in uninstrumented `objc_storeStrong`, so TSan never pairs it with the reader's load), a static assertion for immortal slots. It includes a buildable crash-repro skeleton, the "revert check" that makes any race test trustworthy, why `atomic` closes the load→retain gap, and the standing workflow — each fix ships its own red→green test in its fix PR, so this branch stays green.

## Why no standing reds

An earlier revision carried two red guards for still-open defects (a nonatomic-strong session-property UAF and a shared raven report dict). Per review, standing reds don't belong on this branch — each fix ships its own red→green test in its fix PR — so those were stripped and their tests move to their fix PRs. `test_race` is now all-green.

## Wiring notes

- **Per-commit visibility + tag-build release gate**: `test_race` runs per-commit in `un-tagged-build` (non-gating there) and again in `tagged-build`, where `deploy_versioned` and `hold` require it, so a red guard blocks the release deploy chain. This supersedes the original nightly cron.
- **halt_on_error=0**: the lane sets TSan `halt_on_error=0` explicitly so it reports every race without aborting on the first. `store_test_results`/`store_artifacts` run `when: always`, so results upload on a red too.
- **Suppressions**: vendored-only and outside `Teak/`, so a suppression can never be mistaken for a blessed race in first-party code.
