### PR TITLE
Deep-copy the shared user dict in TeakRavenReport

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -1,9 +1,18 @@
 #import <XCTest/XCTest.h>
 #import <stdatomic.h>
 
+#import "TeakAppConfiguration.h"
+#import "TeakConfiguration.h"
+#import "TeakDeviceConfiguration.h"
+#import "TeakLog.h"
+#import "TeakRaven.h"
 #import "TeakSession.h"
 #import "TeakUserProfile.h"
+#import "UserIdEvent.h"
 #import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
 
 // Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
 // detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
@@ -20,6 +29,25 @@
 
 @interface Teak (RaceTripwire)
 + (dispatch_queue_t)operationQueue;
+@end
+
+// Re-expose internal Teak properties needed to build a real TeakRaven (mirrors TeakRavenTests.m).
+@interface Teak ()
+@property (strong, nonatomic) TeakConfiguration* _Nonnull configuration;
+@property (strong, nonatomic) TeakLog* _Nonnull log;
+@end
+
+// TeakRavenReport is a private class declared only inside TeakRaven.m; re-declare its shape here so
+// the tripwire can drive the real initializer and inspect the resulting payload.
+@interface TeakRavenReport : NSObject
+@property (strong, nonatomic) NSMutableDictionary* payload;
+- (id)initForRaven:(nonnull TeakRaven*)raven message:(nonnull NSString*)message additions:(NSDictionary*)additions;
+@end
+
+// userId is read-only in the public header; re-expose as read-write so the tripwire can construct
+// UserIdEvent instances directly, the same way TeakRaven's own handleEvent: receives them.
+@interface UserIdEvent ()
+@property (strong, nonatomic, readwrite) NSString* _Nonnull userId;
 @end
 
 @interface TeakUserProfile (RaceTripwire)
@@ -148,6 +176,56 @@ static NSMutableArray* keepAliveBareSessions;
                 TeakUserProfile* p = session.userProfile;
                 (void)NSStringFromClass([p class]).length;
                 (void)p.stringAttributes.count;
+              }
+            }];
+}
+
+// Builds a real TeakRaven the same way TeakRavenTests.m does: a fully-stubbed Teak mock so
+// payloadTemplate construction runs to completion without touching the network.
+- (TeakRaven*)makeRaven {
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig deviceId]) willReturn:@"test-device-id"];
+
+  TeakAppConfiguration* appConfig = mock([TeakAppConfiguration class]);
+  [given([appConfig appId]) willReturn:@"test-app-id"];
+  [given([appConfig appVersion]) willReturn:@"1"];
+  [given([appConfig appVersionName]) willReturn:@"1.0.0"];
+  [given([appConfig isProduction]) willReturn:@NO];
+
+  TeakConfiguration* config = mock([TeakConfiguration class]);
+  [given([config deviceConfiguration]) willReturn:deviceConfig];
+  [given([config appConfiguration]) willReturn:appConfig];
+
+  Teak* teakMock = mock([Teak class]);
+  [given([teakMock sdkVersion]) willReturn:@"4.3.13-test"];
+  [given([teakMock configuration]) willReturn:config];
+  [given([teakMock log]) willReturn:[[TeakLog alloc] initForTeak:teakMock withAppId:@"test"]];
+
+  return [TeakRaven ravenForTeak:teakMock];
+}
+
+// Raven-report shared-dict regression guard (ThreadSanitizer). TeakRavenReport shallow-copies
+// TeakRaven's payloadTemplate at initForRaven: — a plain top-level dictionaryWithDictionary: copy,
+// which leaves nested mutable values (the "user" dict) as the SAME object referenced by both the
+// live template and the report. Thread A drives the real UserIdentified mutation path
+// (handleEvent:), which writes into that "user" dict on every call; thread B reads from the
+// report's copy of it, the same access send performs while JSON-serializing the payload. Fixed,
+// the report holds its own copy of "user" and the two threads touch different objects, so TSan
+// stays silent. Reverting the fix re-aliases them and TSan reports a race on the dictionary.
+- (void)testRavenReportDoesNotShareUserDict {
+  TeakRaven* raven = [self makeRaven];
+  TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:raven message:@"test" additions:nil];
+
+  [self raceBlockA:^{
+    for (int i = 0; i < 8000; i++) {
+      UserIdEvent* event = [[UserIdEvent alloc] initWithType:UserIdentified];
+      event.userId = [NSString stringWithFormat:@"user-%d", i];
+      [raven handleEvent:event];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < 8000; i++) {
+                (void)[report.payload[@"user"] objectForKey:@"device_id"];
               }
             }];
 }

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -231,6 +231,32 @@ static NSMutableArray* keepAliveBareSessions;
             }];
 }
 
+// Construction-read regression guard (ThreadSanitizer). initForRaven:'s copy-read of "user" used
+// to run concurrently with handleEvent:'s in-place mutation of the SAME payloadTemplate sub-dict —
+// a much smaller window than the lifetime-aliasing race above, but the same container-race class.
+// Thread A drives the real mutation path; thread B repeatedly constructs fresh reports, exercising
+// the real copy-read on every call. Fixed (userContext published as an atomic immutable snapshot),
+// the read is a lock-free getter grab that never touches a dict another thread is mutating, so
+// TSan stays silent. Reverting to the shared-mutable-dict design re-opens the window and TSan
+// reports a race on the dictionary.
+- (void)testRavenReportConstructionDoesNotRaceUserIdMutation {
+  TeakRaven* raven = [self makeRaven];
+
+  [self raceBlockA:^{
+    for (int i = 0; i < 8000; i++) {
+      UserIdEvent* event = [[UserIdEvent alloc] initWithType:UserIdentified];
+      event.userId = [NSString stringWithFormat:@"user-%d", i];
+      [raven handleEvent:event];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < 8000; i++) {
+                TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:raven message:@"test" additions:nil];
+                (void)report;
+              }
+            }];
+}
+
 // Attribute-dict serialization regression guard (ThreadSanitizer). Two threads drive the real setter
 // concurrently with changing values on the same key, so each call performs the guarded read AND the
 // dictionary write. The fix hops every access onto the serial operationQueue, so TSan stays silent

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -208,10 +208,11 @@ static NSMutableArray* keepAliveBareSessions;
 // TeakRaven's payloadTemplate at initForRaven: — a plain top-level dictionaryWithDictionary: copy,
 // which leaves nested mutable values (the "user" dict) as the SAME object referenced by both the
 // live template and the report. Thread A drives the real UserIdentified mutation path
-// (handleEvent:), which writes into that "user" dict on every call; thread B reads from the
-// report's copy of it, the same access send performs while JSON-serializing the payload. Fixed,
-// the report holds its own copy of "user" and the two threads touch different objects, so TSan
-// stays silent. Reverting the fix re-aliases them and TSan reports a race on the dictionary.
+// (handleEvent:), which writes into that "user" dict on every call; thread B reads directly from
+// the report's copy of it via objectForKey: — a stand-in for send's NSJSONSerialization read,
+// which doesn't trip TSan's dictionary interceptor here, but pins the same aliasing invariant.
+// Fixed, the report holds its own copy of "user" and the two threads touch different objects, so
+// TSan stays silent. Reverting the fix re-aliases them and TSan reports a race on the dictionary.
 - (void)testRavenReportDoesNotShareUserDict {
   TeakRaven* raven = [self makeRaven];
   TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:raven message:@"test" additions:nil];

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -32,6 +32,13 @@ extern bool AmIBeingDebugged(void);
 @property (strong, nonatomic) NSString* sentryKey;
 @property (strong, nonatomic) NSString* sentrySecret;
 @property (strong, nonatomic) NSMutableDictionary* payloadTemplate;
+
+// Published as an immutable snapshot on every UserIdentified event (see handleEvent:) instead of
+// mutated in place, so a concurrent reader (report construction, possibly on a signal handler's
+// thread) always gets a fully-formed dict via a lock-free atomic getter rather than racing a
+// mutation. copy freezes each new snapshot at assignment; atomic makes the getter itself safe to
+// call from a crash/signal context, unlike a mutex or GCD queue.
+@property (atomic, copy) NSDictionary* userContext;
 @property (nonatomic) BOOL isSdkRaven;
 
 @property (strong, nonatomic) NSArray* runLoopModes;
@@ -275,6 +282,7 @@ void TeakSignalHandler(int signal) {
       if (runId != nil) {
         tags[@"run_id"] = runId;
       }
+      self.userContext = @{@"device_id" : teak.configuration.deviceConfiguration.deviceId};
       self.payloadTemplate = [NSMutableDictionary dictionaryWithDictionary:@{
         @"logger" : @"teak",
         @"platform" : @"objc",
@@ -284,9 +292,6 @@ void TeakSignalHandler(int signal) {
           @"name" : @"teak",
           @"version" : TeakSentryVersion
         },
-        @"user" : [[NSMutableDictionary alloc] initWithDictionary:@{
-          @"device_id" : teak.configuration.deviceConfiguration.deviceId
-        }],
         @"contexts" : @{
           @"os" : @{
             @"name" : @"iOS",
@@ -455,8 +460,9 @@ void TeakSignalHandler(int signal) {
 
 - (void)handleEvent:(TeakEvent* _Nonnull)event {
   if (event.type == UserIdentified) {
-    NSMutableDictionary* user = [self.payloadTemplate objectForKey:@"user"];
-    [user setValue:((UserIdEvent*)event).userId forKey:@"id"];
+    NSMutableDictionary* user = [self.userContext mutableCopy];
+    user[@"id"] = ((UserIdEvent*)event).userId;
+    self.userContext = user;
   } else if (event.type == RemoteConfigurationReady) {
     TeakRemoteConfiguration* remoteConfiguration = ((RemoteConfigurationEvent*)event).remoteConfiguration;
     if (self.isSdkRaven) {
@@ -483,11 +489,11 @@ void TeakSignalHandler(int signal) {
       self.raven = raven;
       self.payload = [NSMutableDictionary dictionaryWithDictionary:self.raven.payloadTemplate];
 
-      // dictionaryWithDictionary: is shallow, so without this the "user" entry stays the
-      // very same NSMutableDictionary that raven's handleEvent: keeps mutating on every
-      // UserIdentified for the rest of the raven's life. Give the report its own copy so
-      // that mutation and this report's JSON serialization never touch the same object.
-      self.payload[@"user"] = [self.payload[@"user"] mutableCopy];
+      // userContext is published as an immutable snapshot (see handleEvent:), never mutated
+      // in place, so grabbing it here is a lock-free atomic read — safe even when this runs on
+      // a signal handler's thread — and the result can never be shared with a dict some other
+      // thread is still writing to.
+      self.payload[@"user"] = self.raven.userContext;
 
       CFUUIDRef theUUID = CFUUIDCreate(NULL);
       CFStringRef string = CFUUIDCreateString(NULL, theUUID);

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -35,9 +35,11 @@ extern bool AmIBeingDebugged(void);
 
 // Published as an immutable snapshot on every UserIdentified event (see handleEvent:) instead of
 // mutated in place, so a concurrent reader (report construction, possibly on a signal handler's
-// thread) always gets a fully-formed dict via a lock-free atomic getter rather than racing a
-// mutation. copy freezes each new snapshot at assignment; atomic makes the getter itself safe to
-// call from a crash/signal context, unlike a mutex or GCD queue.
+// thread) always gets a fully-formed dict via an atomic getter rather than racing a mutation.
+// copy freezes each new snapshot at assignment. The getter isn't strictly async-signal-safe
+// (objc_getProperty takes a striped lock under the hood), but it's no worse than the rest of
+// this best-effort crash reporter, and it can't self-deadlock the way a mutex or GCD queue
+// could if a crash landed mid-mutation on the same thread that's reporting it.
 @property (atomic, copy) NSDictionary* userContext;
 @property (nonatomic) BOOL isSdkRaven;
 
@@ -490,9 +492,8 @@ void TeakSignalHandler(int signal) {
       self.payload = [NSMutableDictionary dictionaryWithDictionary:self.raven.payloadTemplate];
 
       // userContext is published as an immutable snapshot (see handleEvent:), never mutated
-      // in place, so grabbing it here is a lock-free atomic read — safe even when this runs on
-      // a signal handler's thread — and the result can never be shared with a dict some other
-      // thread is still writing to.
+      // in place, so grabbing it here — even on a signal handler's thread — can't land on a
+      // dict some other thread is still writing to.
       self.payload[@"user"] = self.raven.userContext;
 
       CFUUIDRef theUUID = CFUUIDCreate(NULL);

--- a/Teak/TeakRaven.m
+++ b/Teak/TeakRaven.m
@@ -483,6 +483,12 @@ void TeakSignalHandler(int signal) {
       self.raven = raven;
       self.payload = [NSMutableDictionary dictionaryWithDictionary:self.raven.payloadTemplate];
 
+      // dictionaryWithDictionary: is shallow, so without this the "user" entry stays the
+      // very same NSMutableDictionary that raven's handleEvent: keeps mutating on every
+      // UserIdentified for the rest of the raven's life. Give the report its own copy so
+      // that mutation and this report's JSON serialization never touch the same object.
+      self.payload[@"user"] = [self.payload[@"user"] mutableCopy];
+
       CFUUIDRef theUUID = CFUUIDCreate(NULL);
       CFStringRef string = CFUUIDCreateString(NULL, theUUID);
       CFRelease(theUUID);


### PR DESCRIPTION
## Summary
- TeakRavenReport's `initForRaven:` shallow-copies TeakRaven's `payloadTemplate`, so the nested "user" dict stays the same mutable object that `handleEvent:` writes to on every `UserIdentified` event.
- A crash report could JSON-serialize that shared dict on the reporting thread while a live event mutated it on another — container-mutation-during-read, same class as the userProfile race fixed alongside this one.
- Fix: give each report its own copy of the "user" entry so the report and the live template never alias.

## Key decisions
- Scoped the copy to just the "user" entry — it's the only nested mutable value `handleEvent:` touches after construction (`tags`/`contexts`/`sdk` are either immutable literals or written once at raven init).
- Regression guard is a ThreadSanitizer test (`RaceTripwireTests.m`), matching this repo's classification for shared-mutable-container races (see `Automated/RACE_TESTING.md`). Confirmed red on the unfixed code, green with the fix (revert check).

## Test plan
- `bundle exec fastlane test_race` — new `testRavenReportDoesNotShareUserDict` passes; reverting the one-line fix reproduces `WARNING: ThreadSanitizer: race on NSMutableDictionary`.
- `bundle exec fastlane test` — full suite green (159 tests).

Linear issue: https://linear.app/teakio/issue/C-966/deep-copy-the-raven-user-dict-in-teakravenreport-initforraven-u2