### PR TITLE
Make TeakSession serverSessionId/countryCode/userProfile atomic (UAF fix)

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -9,10 +9,11 @@
 // detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
 // kinds of guard live here: deterministic CF-over-release crash repros (serverSessionId/countryCode/
 // userProfile) that carry signal on their own, and a ThreadSanitizer-only serialization guard (the
-// attribute-dict test) that needs the sanitizer to see the race at all. The fast per-commit `test`
-// lane skips the whole class — the crash repros are too slow (up to 2M iterations) for a quick
-// per-commit signal, and the serialization test needs TSan anyway; the dedicated `test_race` lane
-// runs all of them, with ThreadSanitizer attached for the one test that needs it.
+// attribute-dict test) that needs the sanitizer to see the race at all. Both run every commit, just
+// on different lanes: the `test` lane skips this whole class to keep the fast per-commit signal
+// quick — the crash repros are too slow (up to 2M iterations) for it, and the serialization test
+// needs TSan anyway. The `test_race` lane runs all of them, every commit, with ThreadSanitizer
+// attached for the one test that needs it, and additionally gates tagged-build releases.
 //
 // See Automated/RACE_TESTING.md for the race-testing methodology — which detector catches which
 // race class, and why some classes (e.g. lock-inversion deadlocks) get no in-process guard here.

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -6,10 +6,13 @@
 #import <Teak/Teak.h>
 
 // Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
-// detector can observe, so a red run means a real regression — the fix it guards was reverted. The
-// fast per-commit `test` lane skips this class (it carries signal only under a sanitizer); the
-// `test_race` lane runs it under ThreadSanitizer, where the race resurfaces if the serialization fix
-// is removed.
+// detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
+// kinds of guard live here: deterministic CF-over-release crash repros (serverSessionId/countryCode/
+// userProfile) that carry signal on their own, and a ThreadSanitizer-only serialization guard (the
+// attribute-dict test) that needs the sanitizer to see the race at all. The fast per-commit `test`
+// lane skips the whole class — the crash repros are too slow (up to 2M iterations) for a quick
+// per-commit signal, and the serialization test needs TSan anyway; the dedicated `test_race` lane
+// runs all of them, with ThreadSanitizer attached for the one test that needs it.
 //
 // See Automated/RACE_TESTING.md for the race-testing methodology — which detector catches which
 // race class, and why some classes (e.g. lock-inversion deadlocks) get no in-process guard here.

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -1,6 +1,7 @@
 #import <XCTest/XCTest.h>
 #import <stdatomic.h>
 
+#import "TeakSession.h"
 #import "TeakUserProfile.h"
 #import <Teak/Teak.h>
 
@@ -19,6 +20,16 @@
 
 @interface TeakUserProfile (RaceTripwire)
 @property (strong, nonatomic) NSMutableDictionary* stringAttributes;
+@end
+
+// countryCode/serverSessionId are private (declared only in TeakSession.m's class extension);
+// userProfile is public but readonly there. Re-declared here for full read-write access, per the
+// project convention of redeclaring internal properties in the test file rather than importing
+// Teak+Internal.h.
+@interface TeakSession (RaceTripwire)
+@property (strong, atomic) NSString* countryCode;
+@property (strong, atomic) NSString* serverSessionId;
+@property (strong, atomic, readwrite) TeakUserProfile* userProfile;
 @end
 
 // A profile whose send is a no-op: the tripwire drives a bare-alloc profile that has no backing
@@ -52,6 +63,89 @@
   dispatch_group_async(group, q, ^{ rendezvous(); b(); });
   dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
   free(ready);
+}
+
+// TeakSession's designated initializer (-init) registers KVO observers and an event handler that
+// -dealloc unconditionally unregisters; skipping -init and then letting the instance deinit would
+// itself crash (NSRangeException from removeObserver:forKeyPath: on a path never added). These
+// tests only drive the atomic property accessors, not a fully wired-up session, so they construct
+// a bare `[TeakSession alloc]` (no -init) and hold it in this array for the rest of the process's
+// lifetime rather than let it deinit.
+static NSMutableArray* keepAliveBareSessions;
+
+- (TeakSession*)bareSessionKeptAlive {
+  if (keepAliveBareSessions == nil) {
+    keepAliveBareSessions = [NSMutableArray array];
+  }
+  TeakSession* session = [TeakSession alloc];
+  [keepAliveBareSessions addObject:session];
+  return session;
+}
+
+// Session strong-property use-after-free repro (CF over-release trap). countryCode, userProfile,
+// and serverSessionId are reassigned in the identify-reply request callback while read cross-thread
+// by the heartbeat queue and the duration-report background block. A nonatomic strong reassignment
+// on one thread races a read+retain on another, retaining a pointer that's being freed underneath
+// it. See Automated/RACE_TESTING.md §3 for the technique this drives: fresh, distinct >15-char
+// heap-allocated values on the writer side (short NSStrings become tagged pointers that never
+// free, giving a false green), a spin-barrier so both threads race for their full duration, and a
+// dereference (not just a pointer bind) on the reader side so a use-after-free lands inside the
+// freed object. Green now (atomic).
+- (void)testServerSessionIdIsAtomicUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 200000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      session.serverSessionId = [[NSString alloc] initWithFormat:@"race-serversessionid-value-%d", i];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSString* s = session.serverSessionId;
+                (void)s.length;
+              }
+            }];
+}
+
+- (void)testCountryCodeIsAtomicUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 200000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      session.countryCode = [[NSString alloc] initWithFormat:@"race-countrycode-value-%d", i];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSString* s = session.countryCode;
+                (void)s.length;
+              }
+            }];
+}
+
+// userProfile's pointee is a plain object, not a CFString — reading .stringAttributes.count alone
+// wasn't a reliable enough dereference to reproduce (freed memory quickly reused by the next
+// same-shaped allocation reads back as "valid"); touching the isa via NSStringFromClass forces a
+// class-table lookup that reliably traps on the freed/reused pointer, at a higher iteration count
+// than the two NSString properties above needed. Confirmed both ways: crashes reliably with
+// userProfile reverted to nonatomic, clean with atomic restored.
+- (void)testUserProfileIsAtomicUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 2000000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      RaceGuardUserProfile* profile = [[RaceGuardUserProfile alloc] init];
+      profile.stringAttributes = [@{@"seed" : [[NSString alloc] initWithFormat:@"race-userprofile-value-%d", i]} mutableCopy];
+      session.userProfile = profile;
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                TeakUserProfile* p = session.userProfile;
+                (void)NSStringFromClass([p class]).length;
+                (void)p.stringAttributes.count;
+              }
+            }];
 }
 
 // Attribute-dict serialization regression guard (ThreadSanitizer). Two threads drive the real setter

--- a/Automated/AutomatedTests/TeakSessionLockingTests.m
+++ b/Automated/AutomatedTests/TeakSessionLockingTests.m
@@ -12,10 +12,15 @@
 //     background-queue body reads it lock-free to check for cancellation. atomic keeps that
 //     read from retaining a pointer the setter is releasing out from under it (a use-after-free
 //     seen in production as an EXC_BAD_ACCESS in dispatch_block_testcancel).
+//   - countryCode / userProfile / serverSessionId are reassigned in the identify-reply request
+//     callback while read cross-thread by the heartbeat queue and the duration-report background
+//     block. See RaceTripwireTests.m for the dynamic use-after-free repro backing these three.
 //
-// A behavioral race test isn't feasible — on ARM64 aligned pointer reads don't actually tear, so
-// the race is formal (UB / TSan-detectable) rather than observable. These tests instead pin the
-// property declarations to atomic via the Objective-C runtime, and fail if any reverts.
+// A behavioral race test for currentState/previousState/reportDurationBlock isn't feasible — on
+// ARM64 aligned pointer reads don't actually tear, so the race is formal (UB / TSan-detectable)
+// rather than observable, and these tests instead pin the declarations to atomic via the
+// Objective-C runtime, failing if any reverts. countryCode/userProfile/serverSessionId get the
+// same static pin here as a cheap permanent guard, on top of the dynamic repro.
 @interface TeakSessionLockingTests : XCTestCase
 @end
 
@@ -44,6 +49,21 @@
 - (void)testReportDurationBlockIsAtomic {
   XCTAssertFalse([self isNonatomicProperty:"reportDurationBlock"],
                  @"TeakSession.reportDurationBlock must stay atomic — its background-queue body reads it outside @synchronized(self) while resetReportDurationBlock cancels and frees it under the lock");
+}
+
+- (void)testCountryCodeIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"countryCode"],
+                 @"TeakSession.countryCode must stay atomic — reassigned in the identify-reply callback while sendHeartbeat reads it on the heartbeat queue");
+}
+
+- (void)testUserProfileIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"userProfile"],
+                 @"TeakSession.userProfile must stay atomic — reassigned in the identify-reply callback while read and sent on the operation queue");
+}
+
+- (void)testServerSessionIdIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"serverSessionId"],
+                 @"TeakSession.serverSessionId must stay atomic — reassigned in the identify-reply callback while read by the duration-report background block");
 }
 
 @end

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -88,6 +88,13 @@ Building one that's trustworthy (a green must mean "no bug," not "I missed the w
 - **Iterate hard** — hundreds of thousands of iterations. At 500k the `serverSessionId` probe
   crashed 10/10 runs; tune the count up until the crash is effectively deterministic.
 
+The skeleton above is validated against CFString-backed pointees (`NSString`). For a plain-object
+pointee, a shallow property/ivar read can false-green — freed memory gets reused by a same-shaped
+allocation quickly enough that the read lands on something that still looks "valid." Touch the isa
+instead (e.g. `NSStringFromClass([obj class]).length`) to force a class-table lookup that reliably
+traps on freed/reused memory, and expect to need a higher iteration count — roughly 10x — to
+reproduce as deterministically as the CFString case.
+
 Minimal skeleton (drop into an XCTest case; `raceBlockA:blockB:` is the spin-barrier helper in
 `RaceTripwireTests.m`):
 

--- a/Teak/TeakSession.h
+++ b/Teak/TeakSession.h
@@ -26,7 +26,7 @@ typedef void (^UserIdReadyBlock)(TeakSession* _Nonnull);
 @property (strong, nonatomic, readonly) NSString* _Nullable facebookId;
 @property (strong, nonatomic, readonly) NSString* _Nonnull sessionId;
 @property (strong, atomic, readonly) TeakState* _Nonnull currentState;
-@property (strong, nonatomic, readonly) TeakUserProfile* _Nonnull userProfile;
+@property (strong, atomic, readonly) TeakUserProfile* _Nonnull userProfile;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull emailStatus;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull pushStatus;
 @property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull smsStatus;

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -37,7 +37,11 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 @property (strong, atomic) TeakState* previousState;
 @property (strong, nonatomic) NSDate* startDate;
 @property (strong, nonatomic) NSDate* endDate;
-@property (strong, nonatomic) NSString* countryCode;
+// countryCode/userProfile/serverSessionId are reassigned in the identify-reply request callback
+// (below) while read cross-thread by the heartbeat queue and the duration-report background block.
+// atomic accessors hand those readers a retained snapshot so a concurrent reassignment can't free
+// the value out from under them (nonatomic strong reassignment releases the prior object mid-read).
+@property (strong, atomic) NSString* countryCode;
 @property (strong, nonatomic) dispatch_queue_t heartbeatQueue;
 @property (strong, nonatomic) dispatch_source_t heartbeat;
 @property (strong, nonatomic) TeakLaunchDataOperation* launchDataOperation;
@@ -57,7 +61,8 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 
 @property (strong, nonatomic, readwrite) NSDictionary* additionalData;
 
-@property (strong, nonatomic, readwrite) TeakUserProfile* userProfile;
+// Same cross-thread reassignment race as countryCode above.
+@property (strong, atomic, readwrite) TeakUserProfile* userProfile;
 
 @property (nonatomic) BOOL userIdentificationSent;
 // reportDurationBlock is created and stored under @synchronized(self) in the currentState
@@ -67,7 +72,8 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 @property (strong, atomic) dispatch_block_t reportDurationBlock;
 @property (nonatomic) BOOL reportDurationSent;
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundUpdateTask;
-@property (strong, nonatomic) NSString* serverSessionId;
+// Same cross-thread reassignment race as countryCode above.
+@property (strong, atomic) NSString* serverSessionId;
 @property int sessionVectorClock;
 @end
 
@@ -359,6 +365,9 @@ DefineTeakState(Expired, (@[]));
 }
 
 - (void)sendHeartbeat {
+  // Single read: countryCode is atomic but can still be reassigned between two reads, so the
+  // nil-check and the use below must see the same value.
+  NSString* countryCode = self.countryCode;
   NSString* urlString = [NSString stringWithFormat:
                                       @"https://%@/ping?game_id=%@&api_key=%@&sdk_version=%@&sdk_platform=%@&app_version=%@%@&buster=%08x",
                                       kTeakHostname,
@@ -367,7 +376,7 @@ DefineTeakState(Expired, (@[]));
                                       TeakURLEscapedString([Teak sharedInstance].sdkVersion),
                                       TeakURLEscapedString(self.deviceConfiguration.platformString),
                                       TeakURLEscapedString(self.appConfiguration.appVersion),
-                                      self.countryCode == nil ? @"" : [NSString stringWithFormat:@"&country_code=%@", self.countryCode],
+                                      countryCode == nil ? @"" : [NSString stringWithFormat:@"&country_code=%@", countryCode],
                                       arc4random()];
 
   NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]
@@ -823,8 +832,10 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
         if ([self resetReportDurationBlock]) {
           // The report duration got sent, so send a resume
           self.sessionVectorClock++;
+          // Single read: same nil-check-then-use hazard as sendHeartbeat's countryCode above.
+          NSString* serverSessionId = self.serverSessionId;
           NSDictionary* payload = @{
-            @"session_id" : self.serverSessionId == nil ? @"null" : TeakURLEscapedString(self.serverSessionId),
+            @"session_id" : serverSessionId == nil ? @"null" : TeakURLEscapedString(serverSessionId),
             @"session_vector_clock": [NSNumber numberWithLong:self.sessionVectorClock]
           };
 
@@ -846,12 +857,14 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
       self.heartbeat = nil;
       self.heartbeatQueue = nil;
 
-      // Send user profile out now
-      if (self.userProfile != nil) {
-        __weak typeof(self) weakSelf = self;
+      // Send user profile out now. Single read: capture the profile that's live now rather than
+      // re-reading self.userProfile when the async block runs, which could be a different (or nil)
+      // value by then. No weakSelf/blockSelf needed — userProfile.session strongly retains this
+      // session (TeakRequest+Internal), so self can't be deallocated while userProfile is live.
+      TeakUserProfile* userProfile = self.userProfile;
+      if (userProfile != nil) {
         dispatch_async([Teak operationQueue], ^{
-          __strong typeof(self) blockSelf = weakSelf;
-          [blockSelf.userProfile send];
+          [userProfile send];
         });
       }
 
@@ -871,15 +884,19 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
           // local is load-bearing: it retains the block across dispatch_block_testcancel so the
           // testcancel can't race the setter's release, and it removes the nil-window a second
           // read would open (testcancel(nil) crashes). Do not re-read the property here.
-          // In testing we encountered an issue where serverSessionId was nil here, but not nil earlier.
+          //
+          // serverSessionId is under the same hazard: the identify-reply callback can reassign it
+          // on another queue at any moment, so the nil-check and the later use below must see the
+          // same value — single-read it here too, rather than re-reading blockSelf.serverSessionId.
           dispatch_block_t canceledCheckBlock = blockSelf.reportDurationBlock;
-          if (canceledCheckBlock != nil && !dispatch_block_testcancel(canceledCheckBlock) && blockSelf.serverSessionId != nil) {
+          NSString* serverSessionId = blockSelf.serverSessionId;
+          if (canceledCheckBlock != nil && !dispatch_block_testcancel(canceledCheckBlock) && serverSessionId != nil) {
             blockSelf.reportDurationSent = YES;
             blockSelf.sessionVectorClock++;
 
             // Send request for "if you don't hear back from me, this session ended now"
             NSDictionary* payload = @{
-              @"session_id" : TeakURLEscapedString(blockSelf.serverSessionId),
+              @"session_id" : TeakURLEscapedString(serverSessionId),
               @"session_duration_ms" : [NSNumber numberWithLong:[blockSelf.endDate timeIntervalSinceDate:blockSelf.startDate] * 1000],
               @"session_vector_clock": [NSNumber numberWithLong:blockSelf.sessionVectorClock]
             };


### PR DESCRIPTION
Fixes a cross-thread use-after-free: `TeakSession.serverSessionId`, `countryCode`, and `userProfile` were `nonatomic` strong properties reassigned in the identify-reply request callback while read concurrently by the heartbeat queue and the duration-report background block. A nonatomic setter compiles to a bare `objc_storeStrong` with no synchronization, so a concurrent reader can retain a pointer mid-free.

Linear: https://linear.app/teakio/issue/C-965

## Changes

- `TeakSession.h`/`.m`: all three properties → `atomic` (matches the existing `currentState`/`reportDurationBlock` pattern).
- Capture-to-local at every multi-read site, since atomicity alone doesn't protect a nil-check-then-use pair from seeing the value change in between:
  - `sendHeartbeat` — single-read `countryCode` before the URL-building ternary.
  - The `Session_resume` payload builder (on the `Expiring` KVO transition) — single-read `serverSessionId`.
  - The `userProfile` send-dispatch site — replaced a `weakSelf`/`blockSelf` dance with a direct local capture; `TeakUserProfile` holds a *strong* `session` back-reference (`TeakRequest+Internal.h`), so `TeakSession` can't dealloc while it holds a live `userProfile` regardless of the weak-self dance — removing it is behavior-preserving, not just a simplification.
  - `reportDurationBlock`'s body — added a `serverSessionId` local capture alongside the existing cancellation-check capture.
- `TeakSessionLockingTests.m`: static atomic-declaration tests (`isNonatomicProperty:` introspection) for all three properties, as a cheap permanent guard on top of the dynamic repro below.
- `RaceTripwireTests.m`: three independent dynamic crash-repro tests (CF over-release trap, per `Automated/RACE_TESTING.md` §3) — one per property, not combined, so a revert of any single property's fix is independently attributable to a red result.

## Revert checks (observed, not asserted)

Each of the three dynamic tests was reverted and restored independently and watched crash/pass:

- `testServerSessionIdIsAtomicUnderConcurrency` — crashes reliably reverted to `nonatomic` (200k iterations, fresh >15-char heap `NSString`s, `.length` dereference on the reader); clean restored to `atomic`. Other two tests stayed green throughout.
- `testCountryCodeIsAtomicUnderConcurrency` — same pattern and result, independently.
- `testUserProfileIsAtomicUnderConcurrency` — needed more than the other two's baseline to reproduce reliably: `userProfile`'s pointee is a plain object, not a `CFString`, so touching only `.stringAttributes.count` was a false green (freed memory was often reused by a same-shaped allocation before the read landed). Bumped to 2,000,000 iterations and added an isa-touching dereference (`NSStringFromClass([p class]).length`) — confirmed crashing reliably reverted (3 runs) and clean restored (2 runs, one under `MallocScribble`/`MallocPreScribble`).

Full test suite (`bundle exec fastlane test`) and the race lane (`bundle exec fastlane test_race`) both green with the fix in place.