### PR TITLE
Make TeakPushState.stateChain atomic to fix a cross-thread use-after-free

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		01DF60A7FDB4617C18BBEAE2 /* RaceTripwireTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F0B163A675BB4810C732B49 /* RaceTripwireTests.m */; };
 		01E4848D5111513C772D7A82 /* TeakCExternLiveActivityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EBC630E46232B6C929C398A1 /* TeakCExternLiveActivityTests.m */; };
+		05E383DCE5E6B6B673C33275 /* TeakPushStateLockingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 978C851D0ADBB2D7302C5ECB /* TeakPushStateLockingTests.m */; };
 		0F9BB099DE5CFEDF8A8B30F9 /* Pods_AutomatedUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDCD65E1A5663F5B9041146E /* Pods_AutomatedUITests.framework */; };
 		137B2D87B7DFDBCC7B5DC85A /* TeakUserProfileAttributeQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */; };
 		20DF1A9F71CE2989A71C1277 /* TeakRequestClientErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F6BD644662C93410AC229F7F /* TeakRequestClientErrorTests.m */; };
@@ -150,6 +151,7 @@
 		7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = NotificationSettingsTests.m; sourceTree = "<group>"; };
 		864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakAttributedLaunchDataEnrichmentTests.m; sourceTree = "<group>"; };
 		90808DE4E189C0B1BDF95023 /* DebugConfigurationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DebugConfigurationTests.m; sourceTree = "<group>"; };
+		978C851D0ADBB2D7302C5ECB /* TeakPushStateLockingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakPushStateLockingTests.m; sourceTree = "<group>"; };
 		98067217DB9FF5953786EA99 /* PushToStartTokenRegistrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PushToStartTokenRegistrationTests.m; sourceTree = "<group>"; };
 		9F86877CA9B4C0AA27811874 /* RemoteConfigurationEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigurationEventTests.m; sourceTree = "<group>"; };
 		A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakUserProfileAttributeQueueTests.m; sourceTree = "<group>"; };
@@ -288,6 +290,7 @@
 				B165DB88E09CABE8CFB776BA /* TeakWaitForDeepLinkTests.m */,
 				A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */,
 				2F0B163A675BB4810C732B49 /* RaceTripwireTests.m */,
+				978C851D0ADBB2D7302C5ECB /* TeakPushStateLockingTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -627,6 +630,7 @@
 				5E6B9B4295CBD9D24A0CF31D /* TeakWaitForDeepLinkTests.m in Sources */,
 				137B2D87B7DFDBCC7B5DC85A /* TeakUserProfileAttributeQueueTests.m in Sources */,
 				01DF60A7FDB4617C18BBEAE2 /* RaceTripwireTests.m in Sources */,
+				05E383DCE5E6B6B673C33275 /* TeakPushStateLockingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -5,6 +5,7 @@
 #import "TeakConfiguration.h"
 #import "TeakDeviceConfiguration.h"
 #import "TeakLog.h"
+#import "TeakPushState.h"
 #import "TeakRaven.h"
 #import "TeakSession.h"
 #import "TeakUserProfile.h"
@@ -17,7 +18,7 @@
 // Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
 // detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
 // kinds of guard live here: deterministic CF-over-release crash repros (serverSessionId/countryCode/
-// userProfile) that carry signal on their own, and a ThreadSanitizer-only serialization guard (the
+// userProfile/stateChain) that carry signal on their own, and a ThreadSanitizer-only serialization guard (the
 // attribute-dict test) that needs the sanitizer to see the race at all. Both run every commit, just
 // on different lanes: the `test` lane skips this whole class to keep the fast per-commit signal
 // quick — the crash repros are too slow (up to 2M iterations) for it, and the serialization test
@@ -62,6 +63,13 @@
 @property (strong, atomic) NSString* countryCode;
 @property (strong, atomic) NSString* serverSessionId;
 @property (strong, atomic, readwrite) TeakUserProfile* userProfile;
+@end
+
+// stateChain is private (declared only in TeakPushState.m's class extension). Re-declared here
+// for full read-write access, per the project convention of redeclaring internal properties in
+// the test file rather than importing Teak+Internal.h (which doesn't expose it either).
+@interface TeakPushState (RaceTripwire)
+@property (strong, atomic) NSArray* stateChain;
 @end
 
 // A profile whose send is a no-op: the tripwire drives a bare-alloc profile that has no backing
@@ -253,6 +261,34 @@ static NSMutableArray* keepAliveBareSessions;
               for (int i = 0; i < 8000; i++) {
                 TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:raven message:@"test" additions:nil];
                 (void)report;
+              }
+            }];
+}
+
+// TeakPushState.stateChain is written under @synchronized(self) in updateCurrentState: but read
+// lock-free by cachedPushState and serializedStateChain. COW discipline means the writer already
+// swaps in a whole new array rather than mutating in place — but the old array is still freed on
+// swap, so a nonatomic-strong reassignment on one thread races a read+retain on another, same as
+// serverSessionId/countryCode/userProfile above. The array itself is a plain object (not a
+// CFString), and its element (a single string) is short-lived per iteration too, so — like
+// userProfile — a shallow read (e.g. .count alone) risks a same-shaped-allocation false green;
+// isa-touch via NSStringFromClass plus .count, at userProfile's higher iteration count, reproduces
+// reliably. Uses a bare `[TeakPushState alloc]` (no -init) since the test only drives the
+// stateChain accessor — -init would register a TeakEvent handler and spin up an operation queue
+// neither of which this repro needs.
+- (void)testStateChainIsAtomicUnderConcurrency {
+  TeakPushState* pushState = [TeakPushState alloc];
+  const int N = 2000000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      pushState.stateChain = @[ [[NSString alloc] initWithFormat:@"race-statechain-value-%d", i] ];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSArray* chain = pushState.stateChain;
+                (void)NSStringFromClass([chain class]).length;
+                (void)chain.count;
               }
             }];
 }

--- a/Automated/AutomatedTests/TeakPushStateLockingTests.m
+++ b/Automated/AutomatedTests/TeakPushStateLockingTests.m
@@ -1,0 +1,34 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakPushState.h"
+#import <objc/runtime.h>
+
+// TeakPushState.stateChain is written under @synchronized(self) (updateCurrentState:) but read
+// lock-free by cachedPushState and serializedStateChain. COW discipline means the writer swaps in
+// a brand-new array rather than mutating in place, so the old array is freed on swap — a
+// nonatomic-strong reassignment on one thread races a read+retain on another, retaining a pointer
+// that's being freed underneath it. See RaceTripwireTests.m for the dynamic use-after-free repro
+// backing this. This test is the same cheap permanent static pin used for TeakSession's
+// atomic properties in TeakSessionLockingTests.m — it isn't the guard that matters (the dynamic
+// repro is), but it catches an accidental revert before the slower dynamic lane even runs.
+@interface TeakPushStateLockingTests : XCTestCase
+@end
+
+@implementation TeakPushStateLockingTests
+
+// YES if the named property carries the nonatomic flag (the "N" token in its runtime
+// attribute string), which would reintroduce the torn-read race.
+- (BOOL)isNonatomicProperty:(const char*)name {
+  objc_property_t property = class_getProperty([TeakPushState class], name);
+  XCTAssertTrue(property != NULL, @"TeakPushState has no property named %s", name);
+  if (property == NULL) return YES;
+  NSString* attributes = @(property_getAttributes(property));
+  return [[attributes componentsSeparatedByString:@","] containsObject:@"N"];
+}
+
+- (void)testStateChainIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"stateChain"],
+                 @"TeakPushState.stateChain must stay atomic — written under @synchronized(self) in updateCurrentState: while cachedPushState/serializedStateChain read it lock-free");
+}
+
+@end

--- a/Teak/TeakPushState.m
+++ b/Teak/TeakPushState.m
@@ -94,7 +94,7 @@ extern UNNotificationSettings* UNNotificationCenterSettingsSync(void);
 
 @interface TeakPushState ()
 
-@property (strong, nonatomic) NSArray* stateChain;
+@property (strong, atomic) NSArray* stateChain;
 @property (strong, nonatomic) NSOperationQueue* operationQueue;
 
 - (TeakPushStateChainEntry*)determineCurrentPushStateBlocking;


### PR DESCRIPTION
https://linear.app/teakio/issue/C-972/teakpushstatestatechain-cow-swap-read-lock-free-u6

## Summary
- `stateChain` is written under `@synchronized(self)` in `updateCurrentState:` (COW discipline already in place — the writer swaps in a whole new array) but read lock-free by `cachedPushState` and `serializedStateChain`. That's the same nonatomic-strong freeable-pointee UAF class already fixed for `TeakSession`'s `countryCode`/`userProfile`/`serverSessionId` (#166) and Raven's user dict (#167). Flipped `stateChain` to `atomic`.
- Both lock-free read sites dereference the property exactly once, so no capture-to-local was needed beyond the atomic accessor.
- Added a static atomic-declaration test (`TeakPushStateLockingTests.m`) and a dynamic crash-repro test (`RaceTripwireTests.m`), per `Automated/RACE_TESTING.md` §3. The array's pointee is a plain object (not a CFString), so the repro uses the isa-touch technique + a higher iteration count (2M), same as `userProfile`'s.

## Revert-check
Reverted `stateChain` to `nonatomic` and confirmed both new tests go red (the dynamic repro crashes via the CF over-release trap; the static test fails the runtime introspection assertion). Restored `atomic` and confirmed both go green.

## Test plan
- [x] `bundle exec fastlane test` — 163 tests, 0 failures
- [x] Targeted run of `RaceTripwireTests` (7 tests) — 0 failures
- [x] Revert-check: red on nonatomic, green on atomic, for both new tests