### PR TITLE
Serialize ProductRequest's active-requests array (SKPaymentObserver)

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -1,6 +1,7 @@
 #import <XCTest/XCTest.h>
 #import <stdatomic.h>
 
+#import "SKPaymentObserver.h"
 #import "TeakAppConfiguration.h"
 #import "TeakConfiguration.h"
 #import "TeakDeviceConfiguration.h"
@@ -17,12 +18,13 @@
 // Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
 // detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
 // kinds of guard live here: deterministic CF-over-release crash repros (serverSessionId/countryCode/
-// userProfile) that carry signal on their own, and a ThreadSanitizer-only serialization guard (the
-// attribute-dict test) that needs the sanitizer to see the race at all. Both run every commit, just
-// on different lanes: the `test` lane skips this whole class to keep the fast per-commit signal
-// quick — the crash repros are too slow (up to 2M iterations) for it, and the serialization test
-// needs TSan anyway. The `test_race` lane runs all of them, every commit, with ThreadSanitizer
-// attached for the one test that needs it, and additionally gates tagged-build releases.
+// userProfile) that carry signal on their own, and ThreadSanitizer-only serialization guards (the
+// attribute-dict test and the ProductRequest active-requests test) that need the sanitizer to see
+// the race at all. Both kinds run every commit, just on different lanes: the `test` lane skips this
+// whole class to keep the fast per-commit signal quick — the crash repros are too slow (up to 2M
+// iterations) for it, and the serialization tests need TSan anyway. The `test_race` lane runs all of
+// them, every commit, with ThreadSanitizer attached for the tests that need it, and additionally
+// gates tagged-build releases.
 //
 // See Automated/RACE_TESTING.md for the race-testing methodology — which detector catches which
 // race class, and why some classes (e.g. lock-inversion deadlocks) get no in-process guard here.
@@ -62,6 +64,14 @@
 @property (strong, atomic) NSString* countryCode;
 @property (strong, atomic) NSString* serverSessionId;
 @property (strong, atomic, readwrite) TeakUserProfile* userProfile;
+@end
+
+// addActiveProductRequest:/removeActiveProductRequest: are private (declared only in
+// SKPaymentObserver.m). Re-declared here so the test can drive the real synchronized mutation
+// methods directly, rather than reconstructing the array access by hand.
+@interface ProductRequest (RaceTripwire)
++ (void)addActiveProductRequest:(ProductRequest*)request;
++ (void)removeActiveProductRequest:(ProductRequest*)request;
 @end
 
 // A profile whose send is a no-op: the tripwire drives a bare-alloc profile that has no backing
@@ -276,6 +286,34 @@ static NSMutableArray* keepAliveBareSessions;
   // Drain the queued setter blocks so none outlive the test.
   dispatch_sync([Teak operationQueue], ^{
   });
+}
+
+// ProductRequest active-requests serialization guard (ThreadSanitizer). +activeProductRequests backs
+// a write-only keep-alive array: addObject: runs on the StoreKit payment-queue thread
+// (+productRequestForSku:callback:) while removeObject: runs on the SKProductsRequest delegate thread
+// (-productsRequest:didReceiveResponse:). Thread A adds fresh requests while thread B removes a
+// pre-seeded batch, landing both mutations on the shared NSMutableArray at once. The fix wraps both
+// call sites in @synchronized(ProductRequestActiveRequestsMutex), so TSan stays silent; removing that
+// synchronization reports a race on the array. Green now, red on revert.
+- (void)testProductRequestActiveRequestsIsSerializedUnderConcurrency {
+  const int N = 8000;
+  NSMutableArray* preSeeded = [NSMutableArray array];
+  for (int i = 0; i < N; i++) {
+    ProductRequest* request = [[ProductRequest alloc] init];
+    [preSeeded addObject:request];
+    [ProductRequest addActiveProductRequest:request];
+  }
+
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      [ProductRequest addActiveProductRequest:[[ProductRequest alloc] init]];
+    }
+  }
+            blockB:^{
+              for (ProductRequest* request in preSeeded) {
+                [ProductRequest removeActiveProductRequest:request];
+              }
+            }];
 }
 
 @end

--- a/Teak/Store/SKPaymentObserver.m
+++ b/Teak/Store/SKPaymentObserver.m
@@ -5,6 +5,8 @@
 
 #define _(_id) TeakValueOrNSNull(_id)
 
+NSString* const ProductRequestActiveRequestsMutex = @"io.teak.sdk.productRequestActiveRequestsMutex";
+
 @interface SKPaymentObserver () <SKPaymentTransactionObserver, TeakEventHandler>
 @property (nonatomic) NSTimeInterval paymentStart;
 
@@ -157,13 +159,25 @@
   return array;
 }
 
++ (void)addActiveProductRequest:(ProductRequest*)request {
+  @synchronized(ProductRequestActiveRequestsMutex) {
+    [[ProductRequest activeProductRequests] addObject:request];
+  }
+}
+
++ (void)removeActiveProductRequest:(ProductRequest*)request {
+  @synchronized(ProductRequestActiveRequestsMutex) {
+    [[ProductRequest activeProductRequests] removeObject:request];
+  }
+}
+
 + (ProductRequest*)productRequestForSku:(NSString*)sku callback:(ProductRequestCallback)callback {
   ProductRequest* ret = [[ProductRequest alloc] init];
   ret.callback = callback;
   ret.productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:[NSSet setWithObject:sku]];
   ret.productsRequest.delegate = ret;
   [ret.productsRequest start];
-  [[ProductRequest activeProductRequests] addObject:ret];
+  [ProductRequest addActiveProductRequest:ret];
   return ret;
 }
 
@@ -189,7 +203,7 @@
   } else {
     self.callback(@{}, nil);
   }
-  [[ProductRequest activeProductRequests] removeObject:self];
+  [ProductRequest removeActiveProductRequest:self];
 }
 
 - (NSString*)description {

--- a/Teak/Store/SKPaymentObserver.m
+++ b/Teak/Store/SKPaymentObserver.m
@@ -5,7 +5,7 @@
 
 #define _(_id) TeakValueOrNSNull(_id)
 
-NSString* const ProductRequestActiveRequestsMutex = @"io.teak.sdk.productRequestActiveRequestsMutex";
+static NSString* const ProductRequestActiveRequestsMutex = @"io.teak.sdk.productRequestActiveRequestsMutex";
 
 @interface SKPaymentObserver () <SKPaymentTransactionObserver, TeakEventHandler>
 @property (nonatomic) NSTimeInterval paymentStart;


### PR DESCRIPTION
https://linear.app/teakio/issue/C-970/skpaymentobserver-static-activeproductrequests-unsynchronized-u4

`+[ProductRequest activeProductRequests]` backs a write-only keep-alive array mutated on two threads with no synchronization: `addObject:` on the StoreKit payment-queue thread (`productRequestForSku:callback:`), `removeObject:` on the `SKProductsRequest` delegate thread (`didReceiveResponse:`). Two purchases in flight, or a purchase overlapping a slow product response, race a structural mutation of the same `NSMutableArray`.

- Extracts the two mutation sites into `addActiveProductRequest:`/`removeActiveProductRequest:` class methods, each wrapped in `@synchronized(ProductRequestActiveRequestsMutex)` — same mutex-string convention as `TeakRequestsInFlightMutex`/`currentSessionMutex`.
- Adds a red→green TSan regression test in `RaceTripwireTests.m` driving the real accessors under concurrency (mutable-container class per `RACE_TESTING.md`).

Confirmed write-only scope (grepped the repo — 3 total hits: accessor + the two mutation sites, no reads/enumeration) and that the lazy `dispatch_once` init needs no additional guard (already race-free by construction). Revert-checked in isolation: removing the `@synchronized` reproduces a deterministic crash + `WARNING: ThreadSanitizer: race on NSMutableArray` between `addActiveProductRequest:`/`removeActiveProductRequest:`; restoring the fix goes back to green.

## Proposed changelog entry

Fixed a potential crash when multiple in-app purchases (or a purchase overlapping a slow product-info response) were in flight at the same time.