### PR TITLE
Make TeakDeviceConfiguration pushToken/liveActivityPushToStartToken/advertisingIdentifier/notificationDisplayEnabled atomic

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -17,12 +17,14 @@
 // Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
 // detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
 // kinds of guard live here: deterministic CF-over-release crash repros (serverSessionId/countryCode/
-// userProfile) that carry signal on their own, and a ThreadSanitizer-only serialization guard (the
-// attribute-dict test) that needs the sanitizer to see the race at all. Both run every commit, just
-// on different lanes: the `test` lane skips this whole class to keep the fast per-commit signal
-// quick — the crash repros are too slow (up to 2M iterations) for it, and the serialization test
-// needs TSan anyway. The `test_race` lane runs all of them, every commit, with ThreadSanitizer
-// attached for the one test that needs it, and additionally gates tagged-build releases.
+// userProfile, and TeakDeviceConfiguration's pushToken/liveActivityPushToStartToken/
+// advertisingIdentifier/notificationDisplayEnabled) that carry signal on their own, and a
+// ThreadSanitizer-only serialization guard (the attribute-dict test) that needs the sanitizer to see
+// the race at all. Both run every commit, just on different lanes: the `test` lane skips this whole
+// class to keep the fast per-commit signal quick — the crash repros are too slow (up to 2M
+// iterations) for it, and the serialization test needs TSan anyway. The `test_race` lane runs all of
+// them, every commit, with ThreadSanitizer attached for the one test that needs it, and additionally
+// gates tagged-build releases.
 //
 // See Automated/RACE_TESTING.md for the race-testing methodology — which detector catches which
 // race class, and why some classes (e.g. lock-inversion deadlocks) get no in-process guard here.
@@ -62,6 +64,16 @@
 @property (strong, atomic) NSString* countryCode;
 @property (strong, atomic) NSString* serverSessionId;
 @property (strong, atomic, readwrite) TeakUserProfile* userProfile;
+@end
+
+// pushToken/liveActivityPushToStartToken/advertisingIdentifier/notificationDisplayEnabled are
+// public but readonly on TeakDeviceConfiguration. Re-declared here for full read-write access,
+// same convention as TeakSession above.
+@interface TeakDeviceConfiguration (RaceTripwire)
+@property (strong, atomic, readwrite) NSString* pushToken;
+@property (strong, atomic, readwrite) NSString* liveActivityPushToStartToken;
+@property (strong, atomic, readwrite) NSString* advertisingIdentifier;
+@property (strong, atomic, readwrite) NSString* notificationDisplayEnabled;
 @end
 
 // A profile whose send is a no-op: the tripwire drives a bare-alloc profile that has no backing
@@ -253,6 +265,78 @@ static NSMutableArray* keepAliveBareSessions;
               for (int i = 0; i < 8000; i++) {
                 TeakRavenReport* report = [[TeakRavenReport alloc] initForRaven:raven message:@"test" additions:nil];
                 (void)report;
+              }
+            }];
+}
+
+// TeakDeviceConfiguration strong-property use-after-free repro (CF over-release trap). pushToken/
+// liveActivityPushToStartToken are reassigned from handleEvent on the event-processing queue;
+// advertisingIdentifier from getAdvertisingInformation (init, the LifecycleActivate event queue, and
+// a main-queue retry); notificationDisplayEnabled from the pushState operation queue's completion
+// block. All four are read cross-thread by TeakSession's operation queue while building the identify
+// payload (TeakSession.m's sendUserIdentifier/dispatchUserDataEvent). Same technique as the
+// TeakSession properties above — all four are plain NSStrings, so no isa-touch needed. Green now
+// (atomic).
+- (void)testPushTokenIsAtomicUnderConcurrency {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+  const int N = 200000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      config.pushToken = [[NSString alloc] initWithFormat:@"race-pushtoken-value-%d", i];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSString* s = config.pushToken;
+                (void)s.length;
+              }
+            }];
+}
+
+- (void)testLiveActivityPushToStartTokenIsAtomicUnderConcurrency {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+  const int N = 200000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      config.liveActivityPushToStartToken = [[NSString alloc] initWithFormat:@"race-liveactivitytoken-value-%d", i];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSString* s = config.liveActivityPushToStartToken;
+                (void)s.length;
+              }
+            }];
+}
+
+- (void)testAdvertisingIdentifierIsAtomicUnderConcurrency {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+  const int N = 200000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      config.advertisingIdentifier = [[NSString alloc] initWithFormat:@"race-advertisingid-value-%d", i];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSString* s = config.advertisingIdentifier;
+                (void)s.length;
+              }
+            }];
+}
+
+- (void)testNotificationDisplayEnabledIsAtomicUnderConcurrency {
+  TeakDeviceConfiguration* config = [[TeakDeviceConfiguration alloc] init];
+  const int N = 200000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      config.notificationDisplayEnabled = [[NSString alloc] initWithFormat:@"race-notificationdisplay-value-%d", i];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSString* s = config.notificationDisplayEnabled;
+                (void)s.length;
               }
             }];
 }

--- a/Automated/AutomatedTests/TeakDeviceConfigurationTests.m
+++ b/Automated/AutomatedTests/TeakDeviceConfigurationTests.m
@@ -1,4 +1,5 @@
 #import <XCTest/XCTest.h>
+#import <objc/runtime.h>
 
 #import "PushRegistrationEvent.h"
 #import "TeakDeviceConfiguration.h"
@@ -15,6 +16,41 @@
 @end
 
 @implementation TeakDeviceConfigurationTests
+
+#pragma mark - Atomicity
+
+// pushToken/liveActivityPushToStartToken/advertisingIdentifier/notificationDisplayEnabled are all
+// reassigned from a writer thread other than TeakSession's operation queue, which reads them while
+// building the identify payload (see RaceTripwireTests.m for the dynamic use-after-free repro
+// backing these four). A cheap permanent guard, complementary to the dynamic repro: pins the
+// declaration to atomic via the Objective-C runtime, failing if any reverts.
+- (BOOL)isNonatomicProperty:(const char*)name {
+  objc_property_t property = class_getProperty([TeakDeviceConfiguration class], name);
+  XCTAssertTrue(property != NULL, @"TeakDeviceConfiguration has no property named %s", name);
+  if (property == NULL) return YES;
+  NSString* attributes = @(property_getAttributes(property));
+  return [[attributes componentsSeparatedByString:@","] containsObject:@"N"];
+}
+
+- (void)testPushTokenIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"pushToken"],
+                 @"TeakDeviceConfiguration.pushToken must stay atomic — reassigned on the event-processing queue while read by TeakSession's operation queue");
+}
+
+- (void)testLiveActivityPushToStartTokenIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"liveActivityPushToStartToken"],
+                 @"TeakDeviceConfiguration.liveActivityPushToStartToken must stay atomic — same cross-thread reassignment hazard as pushToken");
+}
+
+- (void)testAdvertisingIdentifierIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"advertisingIdentifier"],
+                 @"TeakDeviceConfiguration.advertisingIdentifier must stay atomic — reassigned from init/the event queue/a main-queue retry while read by TeakSession's operation queue");
+}
+
+- (void)testNotificationDisplayEnabledIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"notificationDisplayEnabled"],
+                 @"TeakDeviceConfiguration.notificationDisplayEnabled must stay atomic — reassigned on the pushState operation queue's completion block while read by TeakSession's operation queue");
+}
 
 #pragma mark - Initial state
 

--- a/Teak/Configuration/TeakDeviceConfiguration.h
+++ b/Teak/Configuration/TeakDeviceConfiguration.h
@@ -10,11 +10,11 @@ extern NSString* _Nonnull const TeakDeviceConfiguration_NotificationDisplayState
 @interface TeakDeviceConfiguration : NSObject <TeakEventHandler>
 @property (strong, nonatomic, readonly) NSString* _Nonnull deviceId;
 @property (strong, nonatomic, readonly) NSString* _Nonnull deviceModel;
-@property (strong, nonatomic, readonly) NSString* _Nonnull pushToken;
-@property (strong, nonatomic, readonly) NSString* _Nonnull liveActivityPushToStartToken;
+@property (strong, atomic, readonly) NSString* _Nonnull pushToken;
+@property (strong, atomic, readonly) NSString* _Nonnull liveActivityPushToStartToken;
 @property (strong, nonatomic, readonly) NSString* _Nonnull platformString;
-@property (strong, nonatomic, readonly) NSString* _Nonnull advertisingIdentifier;
-@property (strong, nonatomic, readonly) NSString* _Nonnull notificationDisplayEnabled;
+@property (strong, atomic, readonly) NSString* _Nonnull advertisingIdentifier;
+@property (strong, atomic, readonly) NSString* _Nonnull notificationDisplayEnabled;
 @property (nonatomic, readonly) BOOL limitAdTracking;
 @property (nonatomic, readonly) unsigned long long phyiscalMemoryInBytes;
 @property (nonatomic, readonly) NSUInteger numberOfCores;

--- a/Teak/Configuration/TeakDeviceConfiguration.m
+++ b/Teak/Configuration/TeakDeviceConfiguration.m
@@ -17,11 +17,17 @@ NSString* const TeakDeviceConfiguration_NotificationDisplayState_NotDetermined =
 @interface TeakDeviceConfiguration ()
 @property (strong, nonatomic, readwrite) NSString* deviceId;
 @property (strong, nonatomic, readwrite) NSString* deviceModel;
-@property (strong, nonatomic, readwrite) NSString* pushToken;
-@property (strong, nonatomic, readwrite) NSString* liveActivityPushToStartToken;
+// pushToken/liveActivityPushToStartToken are reassigned from handleEvent on the event-processing
+// queue; advertisingIdentifier is reassigned from getAdvertisingInformation (init, the LifecycleActivate
+// event queue, and a main-queue retry); notificationDisplayEnabled is reassigned from the pushState
+// operation queue's completion block. All four are read cross-thread by TeakSession's operation queue
+// while building the identify payload. atomic accessors hand those readers a retained snapshot so a
+// concurrent reassignment can't free the value out from under them.
+@property (strong, atomic, readwrite) NSString* pushToken;
+@property (strong, atomic, readwrite) NSString* liveActivityPushToStartToken;
 @property (strong, nonatomic, readwrite) NSString* platformString;
-@property (strong, nonatomic, readwrite) NSString* advertisingIdentifier;
-@property (strong, nonatomic, readwrite) NSString* notificationDisplayEnabled;
+@property (strong, atomic, readwrite) NSString* advertisingIdentifier;
+@property (strong, atomic, readwrite) NSString* notificationDisplayEnabled;
 @property (nonatomic, readwrite) BOOL limitAdTracking;
 @property (nonatomic, readwrite) unsigned long long phyiscalMemoryInBytes;
 @property (nonatomic, readwrite) NSUInteger numberOfCores;
@@ -145,16 +151,19 @@ NSString* const TeakDeviceConfiguration_NotificationDisplayState_NotDetermined =
 }
 
 - (NSDictionary*)to_h {
+  // Single read: pushToken is atomic but reassignable cross-thread, so both uses below must see
+  // the same value.
+  NSString* pushToken = self.pushToken;
   return @{
     @"deviceId" : self.deviceId,
     @"deviceModel" : self.deviceModel,
-    @"pushToken" : self.pushToken,
+    @"pushToken" : pushToken,
     @"platformString" : self.platformString,
     @"advertisingIdentifier" : self.advertisingIdentifier,
     @"limitAdTracking" : [NSNumber numberWithBool:self.limitAdTracking],
     @"notificationDisplayEnabled" : self.notificationDisplayEnabled,
     @"pushRegistration" : @{
-      @"apns_push_key" : TeakValueOrNSNull(self.pushToken),
+      @"apns_push_key" : TeakValueOrNSNull(pushToken),
       @"live_activity_push_to_start_key" : TeakValueOrNSNull(self.liveActivityPushToStartToken)
     }
   };

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -243,8 +243,11 @@ DefineTeakState(Expired, (@[]));
 
     // Always send if ad tracking is limited, send empty string if it is limited (by either the game, or the OS)
     payload[@"ios_limit_ad_tracking"] = [NSNumber numberWithBool:!dataCollectionConfiguration.enableIDFA];
-    if ([self.deviceConfiguration.advertisingIdentifier length] > 0 && dataCollectionConfiguration.enableIDFA) {
-      payload[@"ios_ad_id"] = self.deviceConfiguration.advertisingIdentifier;
+    // Single read: advertisingIdentifier is atomic but reassignable cross-thread, so the length
+    // check and the use below must see the same value.
+    NSString* advertisingIdentifier = self.deviceConfiguration.advertisingIdentifier;
+    if ([advertisingIdentifier length] > 0 && dataCollectionConfiguration.enableIDFA) {
+      payload[@"ios_ad_id"] = advertisingIdentifier;
     } else {
       payload[@"ios_ad_id"] = @"";
     }
@@ -263,15 +266,19 @@ DefineTeakState(Expired, (@[]));
       payload[@"email"] = self.email;
     }
 
-    if ([self.deviceConfiguration.pushToken length] > 0 && dataCollectionConfiguration.enablePushKey) {
-      payload[@"apns_push_key"] = self.deviceConfiguration.pushToken;
+    // Single read: same cross-thread reassignment hazard as advertisingIdentifier above.
+    NSString* pushToken = self.deviceConfiguration.pushToken;
+    if ([pushToken length] > 0 && dataCollectionConfiguration.enablePushKey) {
+      payload[@"apns_push_key"] = pushToken;
       [payload addEntriesFromDictionary:[[Teak sharedInstance].pushState to_h]];
     } else {
       payload[@"apns_push_key"] = @"";
     }
 
-    if ([self.deviceConfiguration.liveActivityPushToStartToken length] > 0 && dataCollectionConfiguration.enablePushKey) {
-      payload[@"live_activity_push_to_start_key"] = self.deviceConfiguration.liveActivityPushToStartToken;
+    // Single read: same hazard as pushToken/advertisingIdentifier above.
+    NSString* liveActivityPushToStartToken = self.deviceConfiguration.liveActivityPushToStartToken;
+    if ([liveActivityPushToStartToken length] > 0 && dataCollectionConfiguration.enablePushKey) {
+      payload[@"live_activity_push_to_start_key"] = liveActivityPushToStartToken;
     }
 
     if (!self.appConfiguration.sdk5Behaviors) {
@@ -946,9 +953,11 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
     TeakDataCollectionConfiguration* dataCollectionConfiguration = [[TeakConfiguration configuration] dataCollectionConfiguration];
 
     NSDictionary* pushRegistration = (NSDictionary*)[NSNull null];
-    if ([self.deviceConfiguration.pushToken length] > 0 && dataCollectionConfiguration.enablePushKey) {
+    // Single read: same cross-thread reassignment hazard as sendUserIdentifier's pushToken.
+    NSString* pushToken = self.deviceConfiguration.pushToken;
+    if ([pushToken length] > 0 && dataCollectionConfiguration.enablePushKey) {
       pushRegistration = @{
-        @"apns" : self.deviceConfiguration.pushToken
+        @"apns" : pushToken
       };
     }
     [UserDataEvent userDataReceived:self.additionalData


### PR DESCRIPTION
https://linear.app/teakio/issue/C-971/teakdeviceconfiguration-nonatomic-strings-3-writer-domains-u5

## What

Four `TeakDeviceConfiguration` strong `NSString` props are each reassigned from a writer thread other than the reader:

- `pushToken` / `liveActivityPushToStartToken` — reassigned in `handleEvent` on the event-processing queue
- `advertisingIdentifier` — reassigned from `getAdvertisingInformation` (init, the `LifecycleActivate` event queue, and a main-queue retry)
- `notificationDisplayEnabled` — reassigned in the pushState operation queue's completion block

`TeakSession`'s operation queue reads all four cross-thread while building the identify payload (`sendUserIdentifier`) and the user-data event (`dispatchUserDataEvent`). A `nonatomic` strong reassignment on one thread races a read+retain on another, retaining a pointer that's being freed underneath it — same bug class as the `TeakSession` `serverSessionId`/`countryCode`/`userProfile` fix (#168).

`pushToken`/`advertisingIdentifier`/`notificationDisplayEnabled` were the three named in the C-962 audit; `liveActivityPushToStartToken` has the identical pattern in the same file and was folded in per lead review rather than filed separately.

## Fix

- All four properties made `atomic` (public readonly + private readwrite class-extension declarations, kept in agreement).
- Capture-to-local at every site that reads one of these props more than once (atomic alone only protects a single read): `sendUserIdentifier`'s three length-check-then-use pairs, `dispatchUserDataEvent`'s pushToken pair, and `TeakDeviceConfiguration`'s own `to_h` (read `pushToken` twice building the dict).

## Tests

- Static atomic-declaration tests (objc runtime introspection) for all four properties.
- Four separate dynamic crash-repro tests (CF over-release trap), one per property for unambiguous per-prop revert attribution. All four are plain NSStrings, so the CFString skeleton from `RACE_TESTING.md` §3 applies directly — no isa-touch needed.
- Revert-checked each of the four individually: flipped one property back to `nonatomic` at a time, watched its test crash, restored, watched it pass. Full `test` lane (165 tests) and `test_race` lane (10 RaceTripwireTests under ThreadSanitizer) both green with all four fixes in place.

## Note

Branch was 5 commits behind `origin/4.3-stable` (including #167, which also touched `RaceTripwireTests.m`) — fast-forwarded and resolved the resulting merge conflict by keeping both PRs' new tests.

## Proposed changelog entry

- Fix a crash from a cross-thread use-after-free on device push tokens, advertising identifier, and notification-permission state during identify.