### PR TITLE
Synchronize TeakLink's route registry against concurrent mutation and enumeration

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -4,6 +4,7 @@
 #import "TeakAppConfiguration.h"
 #import "TeakConfiguration.h"
 #import "TeakDeviceConfiguration.h"
+#import "TeakLink.h"
 #import "TeakLog.h"
 #import "TeakRaven.h"
 #import "TeakSession.h"
@@ -276,6 +277,34 @@ static NSMutableArray* keepAliveBareSessions;
   // Drain the queued setter blocks so none outlive the test.
   dispatch_sync([Teak operationQueue], ^{
   });
+}
+
+// TeakLink route-registry serialization regression guard (ThreadSanitizer). registerRoute writes the
+// static route dictionary from any host thread with no threading contract, while handleDeepLink and
+// routeNamesAndDescriptions enumerate it — the real contention window is a host registering routes
+// lazily post-launch while the launch deep link resolves concurrently on the op queue. Each writer
+// iteration registers a distinct route (a real key insertion, not a same-key overwrite) while the
+// reader iterates the real handleDeepLink: and routeNamesAndDescriptions methods. The fix wraps the
+// write and a copy-then-enumerate snapshot of the read in @synchronized on the registry; remove
+// either side and TSan reports a race on the dictionary. Green now, red on revert.
+- (void)testTeakLinkRouteRegistryIsSerializedUnderConcurrency {
+  const int N = 4000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      [TeakLink registerRoute:[NSString stringWithFormat:@"/race-tripwire/route-%d", i]
+                          name:@"race-tripwire"
+                   description:@"race tripwire probe route"
+                         block:^(NSDictionary* params){
+                         }];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSURL* url = [NSURL URLWithString:[NSString stringWithFormat:@"race-tripwire://race-tripwire/probe-%d", i]];
+                [TeakLink handleDeepLink:url];
+                (void)[TeakLink routeNamesAndDescriptions].count;
+              }
+            }];
 }
 
 @end

--- a/Teak/TeakLink.m
+++ b/Teak/TeakLink.m
@@ -15,6 +15,7 @@ NSString* const TeakLinkIncomingUrlPathKey = @"__incoming_path";
 - (nullable TeakLink*)initWithName:(NSString*)name description:(NSString*)description argumentOrder:(NSArray*)argumentOrder block:(TeakLinkBlock)block route:(NSString*)route;
 
 + (nonnull NSMutableDictionary*)deepLinkRegistration;
++ (nonnull NSDictionary*)deepLinkRegistrationSnapshot;
 
 @end
 
@@ -105,13 +106,16 @@ BOOL TeakLink_HandleDeepLink(NSURL* deepLink) {
   return dict;
 }
 
++ (nonnull NSDictionary*)deepLinkRegistrationSnapshot {
+  @synchronized([TeakLink deepLinkRegistration]) {
+    return [[TeakLink deepLinkRegistration] copy];
+  }
+}
+
 + (BOOL)handleDeepLink:(NSURL*)deepLink {
   if (deepLink == nil || deepLink.path == nil) return NO;
 
-  NSDictionary* deepLinkPatterns;
-  @synchronized([TeakLink deepLinkRegistration]) {
-    deepLinkPatterns = [[TeakLink deepLinkRegistration] copy];
-  }
+  NSDictionary* deepLinkPatterns = [TeakLink deepLinkRegistrationSnapshot];
   for (NSString* key in deepLinkPatterns) {
     NSError* error = nil;
     NSRegularExpression* regExp = [NSRegularExpression regularExpressionWithPattern:key options:0 error:&error];
@@ -171,10 +175,7 @@ BOOL TeakLink_HandleDeepLink(NSURL* deepLink) {
 
 + (nonnull NSArray*)routeNamesAndDescriptions {
   NSMutableArray* namesAndDescriptions = [[NSMutableArray alloc] init];
-  NSDictionary* deepLinkPatterns;
-  @synchronized([TeakLink deepLinkRegistration]) {
-    deepLinkPatterns = [[TeakLink deepLinkRegistration] copy];
-  }
+  NSDictionary* deepLinkPatterns = [TeakLink deepLinkRegistrationSnapshot];
   for (NSString* key in deepLinkPatterns) {
     TeakLink* link = deepLinkPatterns[key];
     if (link.name != nil && link.name.length > 0) {

--- a/Teak/TeakLink.m
+++ b/Teak/TeakLink.m
@@ -108,7 +108,10 @@ BOOL TeakLink_HandleDeepLink(NSURL* deepLink) {
 + (BOOL)handleDeepLink:(NSURL*)deepLink {
   if (deepLink == nil || deepLink.path == nil) return NO;
 
-  NSDictionary* deepLinkPatterns = [TeakLink deepLinkRegistration];
+  NSDictionary* deepLinkPatterns;
+  @synchronized([TeakLink deepLinkRegistration]) {
+    deepLinkPatterns = [[TeakLink deepLinkRegistration] copy];
+  }
   for (NSString* key in deepLinkPatterns) {
     NSError* error = nil;
     NSRegularExpression* regExp = [NSRegularExpression regularExpressionWithPattern:key options:0 error:&error];
@@ -168,7 +171,10 @@ BOOL TeakLink_HandleDeepLink(NSURL* deepLink) {
 
 + (nonnull NSArray*)routeNamesAndDescriptions {
   NSMutableArray* namesAndDescriptions = [[NSMutableArray alloc] init];
-  NSDictionary* deepLinkPatterns = [TeakLink deepLinkRegistration];
+  NSDictionary* deepLinkPatterns;
+  @synchronized([TeakLink deepLinkRegistration]) {
+    deepLinkPatterns = [[TeakLink deepLinkRegistration] copy];
+  }
   for (NSString* key in deepLinkPatterns) {
     TeakLink* link = deepLinkPatterns[key];
     if (link.name != nil && link.name.length > 0) {
@@ -216,7 +222,9 @@ BOOL TeakLink_HandleDeepLink(NSURL* deepLink) {
   pattern = [NSString stringWithFormat:@"^%@", pattern];
 
   TeakLink* link = [[TeakLink alloc] initWithName:name description:description argumentOrder:argumentOrder block:block route:route];
-  [[TeakLink deepLinkRegistration] setValue:link forKey:pattern];
+  @synchronized([TeakLink deepLinkRegistration]) {
+    [[TeakLink deepLinkRegistration] setValue:link forKey:pattern];
+  }
 }
 
 @end


### PR DESCRIPTION
Fixes a mutate-while-enumerate race in TeakLink's static route registry (C-969, from the C-962 audit, U3).

https://linear.app/teakio/issue/C-969/teaklink-static-route-registry-mutate-while-enumerate-u3

## Problem
`registerRoute` writes the static route-registry `NSMutableDictionary` from any host thread with no threading contract, while `handleDeepLink` and `routeNamesAndDescriptions` enumerate it on the op queue with no synchronization. A host registering routes lazily post-launch while the launch deep link resolves concurrently races a mutation against an enumeration — `NSGenericException` or a rehash-UAF.

## Fix
`deepLinkRegistration`'s existing `dispatch_once` already makes it a stable, create-once, never-reassigned `@synchronized` token. Wrap the write in `registerRoute` and take a copy-then-enumerate snapshot in `handleDeepLink`/`routeNamesAndDescriptions` (factored into a shared `+deepLinkRegistrationSnapshot` helper), all under that lock — matches the `TeakIntegrationChecker.m` precedent of synchronizing directly on the mutable container instance.

## Test
Mutable-container race per `Automated/RACE_TESTING.md` → ThreadSanitizer is the detector. New `testTeakLinkRouteRegistryIsSerializedUnderConcurrency` drives the real `registerRoute`/`handleDeepLink`/`routeNamesAndDescriptions` concurrently. Revert check (isolated runs, off the shared CI-adjacent simulator lane): **red** with the `@synchronized` removed — TSan reports `race on NSMutableDictionary` between `registerRoute`'s `setObject:forKey:` and `handleDeepLink`'s `countByEnumeratingWithState:` — **green** with the fix restored. Full non-TSan `test` lane also green (161/161).

## Changelog (proposed, for the consolidated 4.3.14 entry)
Fixed a rare crash/data race when registering a TeakLink deep link route concurrently with deep link resolution at launch.