### PR TITLE
Serialize TeakSession deviceConfiguration KVO observers on a dedicated lock, detach at replacement

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -617,13 +617,14 @@ static NSMutableArray* keepAliveBareSessions;
 // --- Cross-session deviceConfiguration KVO observer-lifecycle guards ---
 //
 // Every session registers KVO observers on the process-shared deviceConfiguration in -init, and
-// those must be removed exactly once. The fix removes them deterministically at session replacement
-// under currentSessionMutex — the same lock every -init addObserver holds — so all add/remove on the
-// shared object are serialized, and makes the removal idempotent so -dealloc's fallback can't
-// double-remove. The cross-thread add/remove race itself has no reliable in-process crash signal
-// (RACE_TESTING.md §5), so these two guards pin the structural invariants deterministically (clean
-// assertions, not a crash repro): idempotent removal, and the removal actually happening at
-// replacement rather than being left to a background dealloc.
+// those must be removed exactly once. The fix serializes every add and remove on the shared object
+// under one dedicated leaf lock (deviceConfigurationObserverMutex, held directly in -init and in
+// detach), removes them deterministically at session replacement rather than from a background
+// -dealloc, and makes the removal idempotent so -dealloc's fallback can't double-remove. The
+// cross-thread add/remove race itself has no reliable in-process crash signal (RACE_TESTING.md §5),
+// so these two guards pin the structural invariants deterministically (clean assertions, not a crash
+// repro): idempotent removal, and the removal actually happening at replacement rather than being
+// left to a background dealloc.
 
 // Idempotent removal. -init registered the observers, so the first detach removes them and the
 // second must no-op; without the flag guard the second removeObserver throws "not registered as an
@@ -637,8 +638,8 @@ static NSMutableArray* keepAliveBareSessions;
                    @"second detach must no-op, not double-remove the deviceConfiguration observers");
 }
 
-// Replacement detaches the outgoing session deterministically, under the mutex, rather than leaving
-// its removeObserver to a background -dealloc that races a new session's addObserver. After a logout
+// Replacement detaches the outgoing session deterministically, rather than leaving its removeObserver
+// to a background -dealloc that races a new session's addObserver. After a logout
 // swaps the current session, the outgoing one must be flagged detached. Revert (drop the detach call
 // in logoutReusingCurrentSession) → the flag stays NO → red.
 - (void)testReplacementDetachesOutgoingSession {

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -18,6 +18,9 @@
 @import OCHamcrest;
 @import OCMockito;
 
+// The current-session global (external linkage), driven directly by the replacement guard below.
+extern TeakSession* currentSession;
+
 // Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
 // detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
 // kinds of guard live here: deterministic CF-over-release crash repros (serverSessionId/countryCode/
@@ -78,6 +81,9 @@
 @property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull emailStatus;
 @property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull pushStatus;
 @property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull smsStatus;
+@property (nonatomic) BOOL deviceConfigurationObserversDetached;
+- (void)detachDeviceConfigurationObservers;
++ (void)logoutReusingCurrentSession:(BOOL)reuseSession;
 @end
 
 // pushToken/liveActivityPushToStartToken/advertisingIdentifier/notificationDisplayEnabled are
@@ -119,6 +125,18 @@
 @end
 
 @implementation RaceTripwireTests
+
+// The C-967 observer-lifecycle guards below drive real init'd sessions, which read
+// TeakConfiguration.configuration; seed the singleton once (guarded — another test class may have
+// configured it already). The other tests in this class don't depend on it.
++ (void)setUp {
+  [super setUp];
+  @try {
+    [TeakConfiguration configureForAppId:@"test-app" andSecret:@"test-secret"];
+  } @catch (NSException* exception) {
+    // Already initialized by another test — fine.
+  }
+}
 
 // Spin-barrier rendezvous: both blocks arrive at the barrier, then bust out within nanoseconds of
 // each other, so short loops still overlap for their full duration. A single-signal gate would let
@@ -573,6 +591,61 @@ static NSMutableArray* keepAliveBareSessions;
                 (void)[TeakLink routeNamesAndDescriptions].count;
               }
             }];
+}
+
+// --- Cross-session deviceConfiguration KVO observer-lifecycle guards ---
+//
+// Every session registers KVO observers on the process-shared deviceConfiguration in -init, and
+// those must be removed exactly once. The fix removes them deterministically at session replacement
+// under currentSessionMutex — the same lock every -init addObserver holds — so all add/remove on the
+// shared object are serialized, and makes the removal idempotent so -dealloc's fallback can't
+// double-remove. The cross-thread add/remove race itself has no reliable in-process crash signal
+// (RACE_TESTING.md §5), so these two guards pin the structural invariants deterministically (clean
+// assertions, not a crash repro): idempotent removal, and the removal actually happening at
+// replacement rather than being left to a background dealloc.
+
+// Idempotent removal. -init registered the observers, so the first detach removes them and the
+// second must no-op; without the flag guard the second removeObserver throws "not registered as an
+// observer". Drives a real init'd session — a bare [TeakSession alloc] has nil deviceConfiguration,
+// so removeObserver silently no-ops and the test would false-green. Revert (drop the flag) → red.
+- (void)testDetachDeviceConfigurationObserversIsIdempotent {
+  TeakSession* session = [[TeakSession alloc] init];
+  [session detachDeviceConfigurationObservers];
+  XCTAssertNoThrow([session detachDeviceConfigurationObservers],
+                   @"second detach must no-op, not double-remove the deviceConfiguration observers");
+}
+
+// Replacement detaches the outgoing session deterministically, under the mutex, rather than leaving
+// its removeObserver to a background -dealloc that races a new session's addObserver. After a logout
+// swaps the current session, the outgoing one must be flagged detached. Revert (drop the detach call
+// in logoutReusingCurrentSession) → the flag stays NO → red.
+- (void)testReplacementDetachesOutgoingSession {
+  TeakSession* outgoing = [[TeakSession alloc] init];
+  currentSession = outgoing;
+
+  [TeakSession logoutReusingCurrentSession:NO];
+
+  XCTAssertTrue(outgoing.deviceConfigurationObserversDetached,
+                @"logout must detach the outgoing session's deviceConfiguration observers under the mutex");
+
+  currentSession = nil;
+}
+
+// Concurrent detach must stay safe — the @synchronized(self) + flag serialize callers so exactly one
+// thread does the removeObserver and the rest no-op. Green-stable with the fix (concurrent detach is
+// genuinely safe, so this never crashes on a healthy tree); revert either the lock or the flag and
+// two threads removeObserver the same keypath at once → throw/crash. Best-effort in that it exercises
+// the concurrent path but isn't a deterministic signal for the broader KVO observationInfo
+// corruption the fix prevents (RACE_TESTING.md §5).
+- (void)testDetachDeviceConfigurationObserversIsConcurrencySafe {
+  TeakSession* session = [[TeakSession alloc] init];
+  [self raceBlockA:^{
+    for (int i = 0; i < 500; i++) [session detachDeviceConfigurationObservers];
+  }
+            blockB:^{
+              for (int i = 0; i < 500; i++) [session detachDeviceConfigurationObservers];
+            }];
+  XCTAssertTrue(session.deviceConfigurationObserversDetached);
 }
 
 @end

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -650,10 +650,10 @@ static NSMutableArray* keepAliveBareSessions;
   [self.createdSessions addObject:currentSession];  // logout's internally-created replacement session
 
   XCTAssertTrue(outgoing.deviceConfigurationObserversDetached,
-                @"logout must detach the outgoing session's deviceConfiguration observers under the mutex");
+                @"logout must detach the outgoing session's deviceConfiguration observers");
 }
 
-// Concurrent detach must stay safe — the detach token + flag serialize callers so exactly one thread
+// Concurrent detach must stay safe — the dedicated observer lock + flag serialize callers so exactly one thread
 // does the removeObserver and the rest no-op. Green-stable with the fix (concurrent detach is
 // genuinely safe, so this never crashes on a healthy tree); revert either the lock or the flag and
 // two threads removeObserver the same keypath at once → throw/crash. Best-effort in that it exercises

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -122,11 +122,13 @@ extern TeakSession* currentSession;
 @end
 
 @interface RaceTripwireTests : XCTestCase
+// Real init'd sessions created by the observer-lifecycle guards, flushed in -tearDown (see there).
+@property (nonatomic, strong) NSMutableArray<TeakSession*>* createdSessions;
 @end
 
 @implementation RaceTripwireTests
 
-// The C-967 observer-lifecycle guards below drive real init'd sessions, which read
+// The observer-lifecycle guards below drive real init'd sessions, which read
 // TeakConfiguration.configuration; seed the singleton once (guarded — another test class may have
 // configured it already). The other tests in this class don't depend on it.
 + (void)setUp {
@@ -136,6 +138,25 @@ extern TeakSession* currentSession;
   } @catch (NSException* exception) {
     // Already initialized by another test — fine.
   }
+}
+
+- (void)setUp {
+  [super setUp];
+  self.createdSessions = [NSMutableArray array];
+}
+
+- (void)tearDown {
+  // The observer-lifecycle guards drive real init'd sessions; -init retains each in the strong
+  // TeakEventHandlerSet, so they never -dealloc to self-detach. Detach every one here so none lingers
+  // as a live deviceConfiguration KVO observer — otherwise a later test mutating
+  // deviceConfiguration.advertisingIdentifier/pushToken would fire the stale observation block into a
+  // spent session. Detach is idempotent, so re-detaching an already-detached session no-ops.
+  for (TeakSession* session in self.createdSessions) {
+    [session detachDeviceConfigurationObservers];
+  }
+  [self.createdSessions removeAllObjects];
+  currentSession = nil;
+  [super tearDown];
 }
 
 // Spin-barrier rendezvous: both blocks arrive at the barrier, then bust out within nanoseconds of
@@ -610,6 +631,7 @@ static NSMutableArray* keepAliveBareSessions;
 // so removeObserver silently no-ops and the test would false-green. Revert (drop the flag) → red.
 - (void)testDetachDeviceConfigurationObserversIsIdempotent {
   TeakSession* session = [[TeakSession alloc] init];
+  [self.createdSessions addObject:session];
   [session detachDeviceConfigurationObservers];
   XCTAssertNoThrow([session detachDeviceConfigurationObservers],
                    @"second detach must no-op, not double-remove the deviceConfiguration observers");
@@ -621,24 +643,25 @@ static NSMutableArray* keepAliveBareSessions;
 // in logoutReusingCurrentSession) → the flag stays NO → red.
 - (void)testReplacementDetachesOutgoingSession {
   TeakSession* outgoing = [[TeakSession alloc] init];
+  [self.createdSessions addObject:outgoing];
   currentSession = outgoing;
 
   [TeakSession logoutReusingCurrentSession:NO];
+  [self.createdSessions addObject:currentSession];  // logout's internally-created replacement session
 
   XCTAssertTrue(outgoing.deviceConfigurationObserversDetached,
                 @"logout must detach the outgoing session's deviceConfiguration observers under the mutex");
-
-  currentSession = nil;
 }
 
-// Concurrent detach must stay safe — the @synchronized(self) + flag serialize callers so exactly one
-// thread does the removeObserver and the rest no-op. Green-stable with the fix (concurrent detach is
+// Concurrent detach must stay safe — the detach token + flag serialize callers so exactly one thread
+// does the removeObserver and the rest no-op. Green-stable with the fix (concurrent detach is
 // genuinely safe, so this never crashes on a healthy tree); revert either the lock or the flag and
 // two threads removeObserver the same keypath at once → throw/crash. Best-effort in that it exercises
 // the concurrent path but isn't a deterministic signal for the broader KVO observationInfo
 // corruption the fix prevents (RACE_TESTING.md §5).
 - (void)testDetachDeviceConfigurationObserversIsConcurrencySafe {
   TeakSession* session = [[TeakSession alloc] init];
+  [self.createdSessions addObject:session];
   [self raceBlockA:^{
     for (int i = 0; i < 500; i++) [session detachDeviceConfigurationObservers];
   }

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -161,6 +161,14 @@ to detect and no crash) among them. Those need a different approach — a watchd
 forced-interleaving barrier, or a static/structural assertion — chosen when the fix is tackled,
 rather than a copy of the crash-repro pattern above.
 
+Cross-object KVO observer add/remove is another: two sessions add/removing themselves as observers
+of the shared `deviceConfiguration` corrupts KVO's per-object observation info, which crashes
+somewhere later and nondeterministically, not at the racing site. The fix serializes all add/remove
+under one lock; the guard is structural — assert the removal is idempotent and that replacement
+deterministically detaches the outgoing session (see `RaceTripwireTests`), rather than trying to
+trap the corruption. The revert check still applies: drop the flag or the detach call and watch the
+structural assertions go red.
+
 ## 6. Quick reference
 
 | Shared state | Detector | Signal | Example source |
@@ -168,6 +176,7 @@ rather than a copy of the crash-repro pattern above.
 | Mutable container (dict/array) | ThreadSanitizer | `race on NSMutableDictionary` | `userProfile` string-attributes dict |
 | nonatomic-strong, freeable pointee | Dynamic crash repro (CF over-release trap) | `SIGTRAP` in `_CFRelease` | `TeakSession.serverSessionId` |
 | Immortal scalar/pointer | Static atomic-declaration assertion | assertion red | state-machine fields |
+| Cross-object KVO add/remove (shared observee) | Structural assertion (idempotent removal + detached-at-replacement) | assertion red | `TeakSession` deviceConfiguration observers |
 | Deadlock / dropped-order | No in-process race signal | case-by-case: watchdog, barrier, structural | — |
 
 Whatever the technique, it isn't a guard until you've run the **revert check** and watched it fail.

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -161,13 +161,13 @@ to detect and no crash) among them. Those need a different approach — a watchd
 forced-interleaving barrier, or a static/structural assertion — chosen when the fix is tackled,
 rather than a copy of the crash-repro pattern above.
 
-Cross-object KVO observer add/remove is another: two sessions add/removing themselves as observers
-of the shared `deviceConfiguration` corrupts KVO's per-object observation info, which crashes
-somewhere later and nondeterministically, not at the racing site. The fix serializes all add/remove
-under one lock; the guard is structural — assert the removal is idempotent and that replacement
-deterministically detaches the outgoing session (see `RaceTripwireTests`), rather than trying to
-trap the corruption. The revert check still applies: drop the flag or the detach call and watch the
-structural assertions go red.
+Cross-object KVO observer add/remove is another: an unserialized add on one session racing a remove
+on another for the shared `deviceConfiguration` corrupts KVO's per-object observation info, which
+crashes somewhere later and nondeterministically, not at the racing site. The fix serializes all
+add/remove under one lock and bounds the observer set by detaching at replacement; the guard is
+structural — assert the removal is idempotent and that replacement deterministically detaches the
+outgoing session (see `RaceTripwireTests`), rather than trying to trap the corruption. The revert
+check still applies: drop the flag or the detach call and watch the structural assertions go red.
 
 ## 6. Quick reference
 

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -20,13 +20,22 @@ NSTimeInterval TeakSameSessionDeltaSeconds = 120.0;
 TeakSession* currentSession;
 NSString* const currentSessionMutex = @"TeakCurrentSessionMutex";
 
-// Leaf lock serializing -detachDeviceConfigurationObservers. Deliberately NOT the session's own
-// monitor: detach runs under currentSessionMutex at every replacement site, so taking
-// @synchronized(self) there would add a currentSessionMutex→self ordering edge. The currentState
-// KVO handler holds @synchronized(self) and then drains under currentSessionMutex (self→mutex), so
-// that counter-edge would close an AB-BA deadlock cycle. This dedicated token acquires nothing else
-// while held, so it can't be one side of that cycle.
-static NSString* const deviceConfigurationObserverDetachMutex = @"io.teak.sdk.deviceConfigurationObserverDetachMutex";
+// Dedicated leaf lock serializing every addObserver/removeObserver on the process-shared
+// deviceConfiguration singleton. Held directly across -init's three addObserver calls and
+// -detachDeviceConfigurationObservers' three removeObserver calls, so add/remove serialization is
+// verifiable by reading this one lock's use sites — it does not rest on -init happening to run under
+// any other lock. KVO add/remove is not thread-safe: a concurrent add on one session and remove on
+// another corrupts the shared object's per-object observation info.
+//
+// A dedicated token, NOT @synchronized(self): self is entangled with currentSessionMutex (the class
+// methods acquire currentSessionMutex and call into self-synchronized session code, and the
+// currentState KVO handler runs under @synchronized(self)). Routing KVO add/remove through self —
+// which runs under currentSessionMutex at every replacement site — would couple it to that
+// self↔currentSessionMutex ordering. A dedicated token stays out of it, and it is a true leaf: the
+// only work done while it is held is addObserver/removeObserver (options New|Old, never Initial),
+// which fire no synchronous observeValueForKeyPath:, so nothing that takes self or currentSessionMutex
+// runs under it.
+static NSString* const deviceConfigurationObserverMutex = @"io.teak.sdk.deviceConfigurationObserverMutex";
 
 NSString* const TeakOptedIn = @"opted_in";
 NSString* const TeakOptedOut = @"opted_out";
@@ -90,9 +99,9 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 @property (strong, atomic) NSString* serverSessionId;
 @property int sessionVectorClock;
 
-// Set once, under deviceConfigurationObserverDetachMutex, when this session's observers on the
-// shared deviceConfiguration are removed, so the removal happens exactly once whether it comes from
-// session replacement or -dealloc. See -detachDeviceConfigurationObservers.
+// Set once, under deviceConfigurationObserverMutex, when this session's observers on the shared
+// deviceConfiguration are removed, so the removal happens exactly once whether it comes from session
+// replacement or -dealloc. See -detachDeviceConfigurationObservers.
 @property (nonatomic) BOOL deviceConfigurationObserversDetached;
 @end
 
@@ -452,9 +461,14 @@ DefineTeakState(Expired, (@[]));
     self.pushStatus = [TeakChannelStatus unknown];
     self.smsStatus = [TeakChannelStatus unknown];
 
-    RegisterKeyValueObserverFor(self.deviceConfiguration, advertisingIdentifier);
-    RegisterKeyValueObserverFor(self.deviceConfiguration, pushToken);
-    RegisterKeyValueObserverFor(self.deviceConfiguration, liveActivityPushToStartToken);
+    // Serialize the shared-deviceConfiguration adds through the dedicated observer lock so they can't
+    // race another session's concurrent remove. currentState below is observed on self (per-session),
+    // so it stays outside the lock and is torn down in -dealloc.
+    @synchronized(deviceConfigurationObserverMutex) {
+      RegisterKeyValueObserverFor(self.deviceConfiguration, advertisingIdentifier);
+      RegisterKeyValueObserverFor(self.deviceConfiguration, pushToken);
+      RegisterKeyValueObserverFor(self.deviceConfiguration, liveActivityPushToStartToken);
+    }
     RegisterKeyValueObserverFor(self, currentState);
 
     [TeakEvent addEventHandler:self];
@@ -481,28 +495,27 @@ DefineTeakState(Expired, (@[]));
     UnRegisterKeyValueObserverFor(self.remoteConfiguration, hostname);
   }
   // Fallback for a session that was never replaced (only the last session, torn down at process
-  // exit); every replaced session was already detached under the mutex, so this is a no-op there.
+  // exit); every replaced session was already detached at replacement time, so the flag makes this a
+  // no-op there.
   [self detachDeviceConfigurationObservers];
   UnRegisterKeyValueObserverFor(self, currentState);
 
   [TeakEvent removeEventHandler:self];
 }
 
-// Remove this session's observers on the shared deviceConfiguration singleton. Only the
-// deviceConfiguration observers are handled here — a session's other observers (its own currentState
-// and its per-session remoteConfiguration) are not shared across sessions, so they stay in -dealloc.
+// Remove this session's observers on the shared deviceConfiguration singleton, serialized on
+// deviceConfigurationObserverMutex — the same lock -init holds while adding them, so every add and
+// remove on the shared object is mutually serialized (see that lock's declaration for why it's a
+// dedicated leaf token rather than @synchronized(self)). Only the deviceConfiguration observers are
+// handled here; a session's other observers (its own currentState and its per-session
+// remoteConfiguration) are not shared across sessions, so they stay in -dealloc.
 //
-// Every session's -init adds these observers under @synchronized(currentSessionMutex); this removal
-// is called from the same lock domain at session-replacement time, so all add/remove on the shared
-// object are serialized. Left to -dealloc alone, the removeObserver would run on whatever background
-// queue releases the session last and could race a newer session's addObserver on that same object,
-// corrupting KVO's per-object observation info. The flag makes it idempotent so -dealloc's fallback
-// call can't double-remove (which throws "not registered as an observer").
-//
-// Serialized on deviceConfigurationObserverDetachMutex, not @synchronized(self): see that token's
-// declaration — locking self here (under currentSessionMutex) would close an AB-BA deadlock cycle.
+// Left to -dealloc alone, removeObserver would run on whatever background queue releases the session
+// last and could race a newer session's addObserver on that same object, corrupting KVO's per-object
+// observation info. The flag makes removal idempotent so -dealloc's fallback call can't double-remove
+// (which throws "not registered as an observer").
 - (void)detachDeviceConfigurationObservers {
-  @synchronized(deviceConfigurationObserverDetachMutex) {
+  @synchronized(deviceConfigurationObserverMutex) {
     if (self.deviceConfigurationObserversDetached) return;
     self.deviceConfigurationObserversDetached = YES;
 
@@ -603,21 +616,29 @@ DefineTeakState(Expired, (@[]));
 
 + (void)logoutReusingCurrentSession:(BOOL)reuseSession {
   @synchronized(currentSessionMutex) {
-    TeakSession* newSession = nil;
-    if (reuseSession) {
-      newSession = [[TeakSession alloc] initWithSession:currentSession];
-    } else {
-      newSession = [[TeakSession alloc] init];
+    // Hold the outgoing session's own monitor across its teardown. The two -setState: calls below each
+    // self-synchronize individually, but only locking the session across the pair keeps another
+    // thread's @synchronized(self) work — e.g. an in-flight hostname KVO callback firing
+    // -setState:Configured — from interleaving between Expiring and Expired. Expiring→Configured is a
+    // legal transition; the following Expired would then be rejected (Configured has no Expired
+    // successor), leaving the outgoing session stuck un-expired.
+    @synchronized(currentSession) {
+      TeakSession* newSession = nil;
+      if (reuseSession) {
+        newSession = [[TeakSession alloc] initWithSession:currentSession];
+      } else {
+        newSession = [[TeakSession alloc] init];
+      }
+
+      // Drop the outgoing session's shared-deviceConfiguration observers here instead of leaving them
+      // to its background -dealloc. See -detachDeviceConfigurationObservers.
+      [currentSession detachDeviceConfigurationObservers];
+
+      [currentSession setState:[TeakSession Expiring]];
+      [currentSession setState:[TeakSession Expired]];
+
+      currentSession = newSession;
     }
-
-    // Drop the outgoing session's shared-deviceConfiguration observers here, under the mutex,
-    // instead of leaving them to its background -dealloc. See -detachDeviceConfigurationObservers.
-    [currentSession detachDeviceConfigurationObservers];
-
-    [currentSession setState:[TeakSession Expiring]];
-    [currentSession setState:[TeakSession Expired]];
-
-    currentSession = newSession;
   }
 }
 

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -23,9 +23,12 @@ NSString* const currentSessionMutex = @"TeakCurrentSessionMutex";
 // Dedicated leaf lock serializing every addObserver/removeObserver on the process-shared
 // deviceConfiguration singleton. Held directly across -init's three addObserver calls and
 // -detachDeviceConfigurationObservers' three removeObserver calls, so add/remove serialization is
-// verifiable by reading this one lock's use sites — it does not rest on -init happening to run under
-// any other lock. KVO add/remove is not thread-safe: a concurrent add on one session and remove on
-// another corrupts the shared object's per-object observation info.
+// verifiable by reading this one lock's use sites — not by tracing which callers happen to hold
+// another lock. KVO add/remove is not thread-safe (concurrent add/remove on the shared object corrupts
+// its per-object observation info), so all of it must be serialized. Every live add/remove site also
+// runs under currentSessionMutex today, so this token is belt-and-suspenders for them; its job is to
+// make the serialization a local, grep-verifiable fact, and it becomes the sole guard once -dealloc's
+// removeObserver goes live (see -detachDeviceConfigurationObservers).
 //
 // A dedicated token, NOT @synchronized(self): self is entangled with currentSessionMutex (the class
 // methods acquire currentSessionMutex and call into self-synchronized session code, and the
@@ -461,9 +464,9 @@ DefineTeakState(Expired, (@[]));
     self.pushStatus = [TeakChannelStatus unknown];
     self.smsStatus = [TeakChannelStatus unknown];
 
-    // Serialize the shared-deviceConfiguration adds through the dedicated observer lock so they can't
-    // race another session's concurrent remove. currentState below is observed on self (per-session),
-    // so it stays outside the lock and is torn down in -dealloc.
+    // Serialize the shared-deviceConfiguration adds through the dedicated observer lock, ordering them
+    // against every remove on the same object under one grep-verifiable lock. currentState below is
+    // observed on self (per-session), so it stays outside the lock and is torn down in -dealloc.
     @synchronized(deviceConfigurationObserverMutex) {
       RegisterKeyValueObserverFor(self.deviceConfiguration, advertisingIdentifier);
       RegisterKeyValueObserverFor(self.deviceConfiguration, pushToken);
@@ -494,9 +497,11 @@ DefineTeakState(Expired, (@[]));
   if ([self currentState] == [TeakSession Created]) {
     UnRegisterKeyValueObserverFor(self.remoteConfiguration, hostname);
   }
-  // Fallback for a session that was never replaced (only the last session, torn down at process
-  // exit); every replaced session was already detached at replacement time, so the flag makes this a
-  // no-op there.
+  // Currently inert: a session retains itself through the shared event-handler registry and is
+  // released only here in -dealloc, so that cycle keeps -dealloc from running in practice — every
+  // session is detached at replacement instead. Kept because it goes live the moment that leak is
+  // fixed and sessions become mortal: then this is the sole detach for the last, never-replaced
+  // session, and the idempotence flag keeps it a no-op for any session already detached at replacement.
   [self detachDeviceConfigurationObservers];
   UnRegisterKeyValueObserverFor(self, currentState);
 
@@ -510,10 +515,13 @@ DefineTeakState(Expired, (@[]));
 // handled here; a session's other observers (its own currentState and its per-session
 // remoteConfiguration) are not shared across sessions, so they stay in -dealloc.
 //
-// Left to -dealloc alone, removeObserver would run on whatever background queue releases the session
-// last and could race a newer session's addObserver on that same object, corrupting KVO's per-object
-// observation info. The flag makes removal idempotent so -dealloc's fallback call can't double-remove
-// (which throws "not registered as an observer").
+// Called at each session replacement so removal is deterministic and bounded: sessions are immortal
+// (see -dealloc), so left to -dealloc alone these observers would never be removed and the shared
+// object's observer list would grow for the life of the process. Detaching here also forecloses the
+// race the leak fix would otherwise activate — once -dealloc runs, its removeObserver would run off
+// currentSessionMutex and could race a newer session's addObserver on this same object. The flag makes
+// removal idempotent so the -dealloc fallback can't double-remove (which throws "not registered as an
+// observer").
 - (void)detachDeviceConfigurationObservers {
   @synchronized(deviceConfigurationObserverMutex) {
     if (self.deviceConfigurationObserversDetached) return;

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -20,6 +20,14 @@ NSTimeInterval TeakSameSessionDeltaSeconds = 120.0;
 TeakSession* currentSession;
 NSString* const currentSessionMutex = @"TeakCurrentSessionMutex";
 
+// Leaf lock serializing -detachDeviceConfigurationObservers. Deliberately NOT the session's own
+// monitor: detach runs under currentSessionMutex at every replacement site, so taking
+// @synchronized(self) there would add a currentSessionMutex→self ordering edge. The currentState
+// KVO handler holds @synchronized(self) and then drains under currentSessionMutex (self→mutex), so
+// that counter-edge would close an AB-BA deadlock cycle. This dedicated token acquires nothing else
+// while held, so it can't be one side of that cycle.
+static NSString* const deviceConfigurationObserverDetachMutex = @"io.teak.sdk.deviceConfigurationObserverDetachMutex";
+
 NSString* const TeakOptedIn = @"opted_in";
 NSString* const TeakOptedOut = @"opted_out";
 NSString* const TeakAvailable = @"available";
@@ -82,8 +90,8 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 @property (strong, atomic) NSString* serverSessionId;
 @property int sessionVectorClock;
 
-// Set once, under @synchronized(self), when this session's observers on the shared
-// deviceConfiguration are removed, so the removal happens exactly once whether it comes from
+// Set once, under deviceConfigurationObserverDetachMutex, when this session's observers on the
+// shared deviceConfiguration are removed, so the removal happens exactly once whether it comes from
 // session replacement or -dealloc. See -detachDeviceConfigurationObservers.
 @property (nonatomic) BOOL deviceConfigurationObserversDetached;
 @end
@@ -490,8 +498,11 @@ DefineTeakState(Expired, (@[]));
 // queue releases the session last and could race a newer session's addObserver on that same object,
 // corrupting KVO's per-object observation info. The flag makes it idempotent so -dealloc's fallback
 // call can't double-remove (which throws "not registered as an observer").
+//
+// Serialized on deviceConfigurationObserverDetachMutex, not @synchronized(self): see that token's
+// declaration — locking self here (under currentSessionMutex) would close an AB-BA deadlock cycle.
 - (void)detachDeviceConfigurationObservers {
-  @synchronized(self) {
+  @synchronized(deviceConfigurationObserverDetachMutex) {
     if (self.deviceConfigurationObserversDetached) return;
     self.deviceConfigurationObserversDetached = YES;
 

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -81,6 +81,11 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 // Same cross-thread reassignment race as countryCode above.
 @property (strong, atomic) NSString* serverSessionId;
 @property int sessionVectorClock;
+
+// Set once, under @synchronized(self), when this session's observers on the shared
+// deviceConfiguration are removed, so the removal happens exactly once whether it comes from
+// session replacement or -dealloc. See -detachDeviceConfigurationObservers.
+@property (nonatomic) BOOL deviceConfigurationObserversDetached;
 @end
 
 @implementation TeakSession
@@ -467,12 +472,33 @@ DefineTeakState(Expired, (@[]));
   if ([self currentState] == [TeakSession Created]) {
     UnRegisterKeyValueObserverFor(self.remoteConfiguration, hostname);
   }
-  UnRegisterKeyValueObserverFor(self.deviceConfiguration, advertisingIdentifier);
-  UnRegisterKeyValueObserverFor(self.deviceConfiguration, pushToken);
-  UnRegisterKeyValueObserverFor(self.deviceConfiguration, liveActivityPushToStartToken);
+  // Fallback for a session that was never replaced (only the last session, torn down at process
+  // exit); every replaced session was already detached under the mutex, so this is a no-op there.
+  [self detachDeviceConfigurationObservers];
   UnRegisterKeyValueObserverFor(self, currentState);
 
   [TeakEvent removeEventHandler:self];
+}
+
+// Remove this session's observers on the shared deviceConfiguration singleton. Only the
+// deviceConfiguration observers are handled here — a session's other observers (its own currentState
+// and its per-session remoteConfiguration) are not shared across sessions, so they stay in -dealloc.
+//
+// Every session's -init adds these observers under @synchronized(currentSessionMutex); this removal
+// is called from the same lock domain at session-replacement time, so all add/remove on the shared
+// object are serialized. Left to -dealloc alone, the removeObserver would run on whatever background
+// queue releases the session last and could race a newer session's addObserver on that same object,
+// corrupting KVO's per-object observation info. The flag makes it idempotent so -dealloc's fallback
+// call can't double-remove (which throws "not registered as an observer").
+- (void)detachDeviceConfigurationObservers {
+  @synchronized(self) {
+    if (self.deviceConfigurationObserversDetached) return;
+    self.deviceConfigurationObserversDetached = YES;
+
+    UnRegisterKeyValueObserverFor(self.deviceConfiguration, advertisingIdentifier);
+    UnRegisterKeyValueObserverFor(self.deviceConfiguration, pushToken);
+    UnRegisterKeyValueObserverFor(self.deviceConfiguration, liveActivityPushToStartToken);
+  }
 }
 
 - (void)handleEvent:(TeakEvent*)event {
@@ -566,19 +592,21 @@ DefineTeakState(Expired, (@[]));
 
 + (void)logoutReusingCurrentSession:(BOOL)reuseSession {
   @synchronized(currentSessionMutex) {
-    @synchronized(currentSession) {
-      TeakSession* newSession = nil;
-      if (reuseSession) {
-        newSession = [[TeakSession alloc] initWithSession:currentSession];
-      } else {
-        newSession = [[TeakSession alloc] init];
-      }
-
-      [currentSession setState:[TeakSession Expiring]];
-      [currentSession setState:[TeakSession Expired]];
-
-      currentSession = newSession;
+    TeakSession* newSession = nil;
+    if (reuseSession) {
+      newSession = [[TeakSession alloc] initWithSession:currentSession];
+    } else {
+      newSession = [[TeakSession alloc] init];
     }
+
+    // Drop the outgoing session's shared-deviceConfiguration observers here, under the mutex,
+    // instead of leaving them to its background -dealloc. See -detachDeviceConfigurationObservers.
+    [currentSession detachDeviceConfigurationObservers];
+
+    [currentSession setState:[TeakSession Expiring]];
+    [currentSession setState:[TeakSession Expired]];
+
+    currentSession = newSession;
   }
 }
 
@@ -658,6 +686,7 @@ DefineTeakState(Expired, (@[]));
       TeakSession* oldSession = currentSession;
       currentSession = [[TeakSession alloc] initWithSession:oldSession];
 
+      [oldSession detachDeviceConfigurationObservers];
       [oldSession setState:[TeakSession Expiring]];
       [oldSession setState:[TeakSession Expired]];
     }
@@ -679,6 +708,7 @@ DefineTeakState(Expired, (@[]));
     if (currentSession == nil || [currentSession hasExpired]) {
       TeakSession* oldSession = currentSession;
       currentSession = [[TeakSession alloc] initWithSession:oldSession];
+      [oldSession detachDeviceConfigurationObservers];
     }
     return currentSession;
   }


### PR DESCRIPTION
Corrects the observer lifecycle for the process-shared `deviceConfiguration` KVO, and makes the add/remove serialization verifiable from a single lock.

## Background

Every `TeakSession` observes `advertisingIdentifier`/`pushToken`/`liveActivityPushToStartToken` on the singleton `deviceConfiguration`, adding those observers in `-init`. Two problems:

1. **Observers are never removed.** They were only unregistered in `-dealloc` — but a session retains itself through the shared event-handler registry (`TeakEventHandlerSet`, removed only in `-dealloc`), a retain cycle, so `-dealloc` never runs. The observers accumulate on the shared object for the life of the process.
2. **Serialization rested on an unstated call-site invariant.** KVO add/remove is not thread-safe (Swift **SR-6795** is exactly this observation-info corruption). Every construct and teardown happens under `currentSessionMutex` today, so add/remove *is* serialized — but only because every call site happens to hold that lock, which a reader can't verify locally.

## Fix

- **One dedicated leaf lock** (`deviceConfigurationObserverMutex`) is held directly across `-init`'s three `addObserver` calls **and** `-detachDeviceConfigurationObservers`' three `removeObserver` calls. Serialization is now verifiable by grepping that one lock's use sites, independent of the call-site invariant — the readability the review asked for. It's belt-and-suspenders for today's live paths (all under `currentSessionMutex`) and becomes the sole guard once `-dealloc` runs (below).
- **Detach at replacement bounds the growth.** The three replacement sites (`logoutReusingCurrentSession:`, `didLaunchWithData:`, `+currentSession`) call `-detachDeviceConfigurationObservers`, so the outgoing session's observers come off the shared object deterministically instead of accumulating. A flag makes removal idempotent.
- **Dedicated token, not `@synchronized(self)`**: `self` is entangled with `currentSessionMutex` (the `currentState` handler runs under `@synchronized(self)`), so routing KVO through `self` would couple it to that ordering. The token is a true leaf — `addObserver`/`removeObserver` use options `New|Old` (never `Initial`), fire no synchronous `observeValueForKeyPath:`, so nothing that takes `self`/`currentSessionMutex` runs while it's held.
- **Kept-but-inert `-dealloc` fallback.** The `-dealloc` detach can't run today (immortal sessions), but it's retained: the moment the self-retention leak is fixed and sessions become mortal, `-dealloc` runs on a background queue *off* `currentSessionMutex`, and its `removeObserver` would race a new session's `-init` `addObserver` — the leaf lock is what serializes that. The "dealloc races init" race is real but **dormant**; the fallback + leaf lock are its forward-defense. (Leak tracked separately as C-981.)
- **Keeps** logout's inner `@synchronized(currentSession)` (a prior revision had removed it): it holds the outgoing session's monitor across the `Expiring`→`Expired` pair, blocking an in-flight `hostname` KVO callback (`-setState:Configured`) from interleaving between the two `-setState:` calls. `Expiring`→`Configured` is legal; the following `Expired` would then be rejected (`Configured` has no `Expired` successor), stranding the outgoing session un-expired. That inner lock is Path A of an AB-BA cycle whose opposing `self`→`currentSessionMutex` edge is removed in **#174 (C-968)** — coordinated so the two PRs stay coherent and C-967 stays out of the cycle.

## Guards

This race class has no reliable in-process crash signal (`RACE_TESTING.md` §5), so the guards are structural and deterministic (`RaceTripwireTests`): idempotent removal, replacement deterministically detaching the outgoing session, plus a green-stable concurrent-detach check. Revert-check ran isolated on the test lane — green with the fix (3/3), red with it reverted (2/2: idempotence → `NSRangeException: not registered as an observer`; replacement → outgoing not flagged).

Not claiming this clears a specific production crash bucket — it makes the observer lifecycle correct, bounded, and verifiable; bucket movement is confirmed separately post-release.

---

Linear: https://linear.app/teakio/issue/C-967
