### PR TITLE
Fix TeakSession lock-order inversion (currentSessionMutex vs self-lock)

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -21,25 +21,32 @@
 // The current-session global (external linkage), driven directly by the replacement guard below.
 extern TeakSession* currentSession;
 
+// The lifecycle class methods' lock (Path A of the AB-BA guard below). External linkage, so the
+// test can hold it directly to model a lifecycle transition that took the mutex.
+extern NSString* const currentSessionMutex;
+
 // Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
-// detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
+// detector can observe, so a red run means a real regression — the fix it guards was reverted. Three
 // kinds of guard live here: deterministic CF-over-release crash repros (serverSessionId/countryCode/
 // userProfile/stateChain/facebookAccessToken/additionalData/emailStatus/pushStatus/smsStatus, and
 // TeakDeviceConfiguration's pushToken/liveActivityPushToStartToken/advertisingIdentifier/
-// notificationDisplayEnabled) that carry signal on their own, and ThreadSanitizer-only serialization
+// notificationDisplayEnabled) that carry signal on their own, ThreadSanitizer-only serialization
 // guards (the attribute-dict test and the ProductRequest active-requests test) that need the
-// sanitizer to see the race at all. Both kinds run every commit, just on different lanes: the `test`
-// lane skips this whole class to keep the fast per-commit signal quick — the crash repros are too
-// slow (up to 2M iterations) for it, and the serialization tests need TSan anyway. The `test_race`
-// lane runs all of them, every commit, with ThreadSanitizer attached for the tests that need it, and
-// additionally gates tagged-build releases.
+// sanitizer to see the race at all, and a lock-inversion deadlock guard (the UserIdentified-transition
+// test) that forces an AB-BA interleaving and catches the hang with a watchdog rather than any
+// data-race signal. All run every commit, just on different lanes: the `test` lane skips this whole
+// class to keep the fast per-commit signal quick — the crash repros are too slow (up to 2M
+// iterations) for it, and the serialization tests need TSan anyway. The `test_race` lane runs all of
+// them, every commit, with ThreadSanitizer attached for the tests that need it, and additionally
+// gates tagged-build releases.
 //
 // launchDataOperation is atomic+capture-to-local too (see TeakSession.m), but its pointee never
 // frees — see the comment near testAdditionalDataIsAtomicUnderConcurrency below — so it's pinned
 // as a static atomic-declaration assertion in TeakSessionLockingTests.m instead.
 //
-// See Automated/RACE_TESTING.md for the race-testing methodology — which detector catches which
-// race class, and why some classes (e.g. lock-inversion deadlocks) get no in-process guard here.
+// See Automated/RACE_TESTING.md for the race-testing methodology — which detector catches which race
+// class, and why some classes (e.g. lock-inversion deadlocks) carry no in-process data-race signal
+// and get a watchdog or structural guard instead.
 
 @interface Teak (RaceTripwire)
 + (dispatch_queue_t)operationQueue;
@@ -84,6 +91,9 @@ extern TeakSession* currentSession;
 @property (nonatomic) BOOL deviceConfigurationObserversDetached;
 - (void)detachDeviceConfigurationObservers;
 + (void)logoutReusingCurrentSession:(BOOL)reuseSession;
+// The macro-generated currentState KVO handler. A bare-alloc session never registers the observer
+// (-init does), so the lock-order guard invokes the real handler directly to exercise its body.
+- (void)_TeakSession_currentState_ChangedFrom:(id)oldValue to:(id)newValue;
 @end
 
 // pushToken/liveActivityPushToStartToken/advertisingIdentifier/notificationDisplayEnabled are
@@ -670,6 +680,56 @@ static NSMutableArray* keepAliveBareSessions;
               for (int i = 0; i < 500; i++) [session detachDeviceConfigurationObservers];
             }];
   XCTAssertTrue(session.deviceConfigurationObserversDetached);
+}
+
+// Lock-order-inversion deadlock guard (forced AB-BA + watchdog). The currentState KVO handler runs
+// under @synchronized(self); its UserIdentified branch used to acquire currentSessionMutex there —
+// to drain the whenUserIdIsReadyRun queue and dispatch launch attribution — while the lifecycle
+// class methods (applicationDidBecomeActive/WillResignActive/didLaunchWithData) take
+// currentSessionMutex *then* the session self-lock. Independent event sources (host lifecycle vs
+// identify reply) overlapping = AB-BA deadlock: the app backgrounds as the reply lands, one thread
+// holds the mutex wanting self, the other holds self wanting the mutex, and every later lifecycle
+// call hangs on the mutex. The fix hops that mutex work off the self-lock, so the handler never
+// holds self while acquiring currentSessionMutex.
+//
+// The rendezvous forces the exact interleaving on the REAL handler: thread A takes
+// currentSessionMutex then wants the self-lock; thread B holds the self-lock then runs the handler,
+// which reaches for currentSessionMutex. A 5s watchdog turns a deadlock into a fast failure rather
+// than a hung suite. Green with the fix; revert the fix (mutex work back under the self-lock) and it
+// deadlocks here.
+- (void)testUserIdentifiedTransitionDoesNotInvertAgainstLifecycleMutex {
+  TeakSession* session = [self bareSessionKeptAlive];
+
+  dispatch_semaphore_t aHasMutex = dispatch_semaphore_create(0);
+  dispatch_semaphore_t bHasSelf = dispatch_semaphore_create(0);
+  dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+  dispatch_group_t group = dispatch_group_create();
+
+  // Thread A — a lifecycle class method: currentSessionMutex, then the session self-lock.
+  dispatch_group_async(group, q, ^{
+    @synchronized(currentSessionMutex) {
+      dispatch_semaphore_signal(aHasMutex);
+      dispatch_semaphore_wait(bHasSelf, DISPATCH_TIME_FOREVER);
+      @synchronized(session) {
+      }
+    }
+  });
+
+  // Thread B — inside the identify-reply transition: self-lock held, then the real KVO handler,
+  // which (unfixed) reaches for currentSessionMutex. Both threads hold their first lock before
+  // either crosses, so an unfixed handler deadlocks deterministically.
+  dispatch_group_async(group, q, ^{
+    @synchronized(session) {
+      dispatch_semaphore_wait(aHasMutex, DISPATCH_TIME_FOREVER);
+      dispatch_semaphore_signal(bHasSelf);
+      [session _TeakSession_currentState_ChangedFrom:[TeakSession IdentifyingUser]
+                                                  to:[TeakSession UserIdentified]];
+    }
+  });
+
+  long timedOut = dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+  XCTAssertEqual(timedOut, 0,
+                 @"AB-BA lock-order inversion: the currentState UserIdentified handler took currentSessionMutex while holding the session self-lock, deadlocking against a lifecycle mutex→self path");
 }
 
 @end

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -560,17 +560,11 @@ DefineTeakState(Expired, (@[]));
   return identifyUserOperation;
 }
 
-- (void)processAttributionAndDispatchEvents {
-  // Single read: launchDataOperation is atomic but can still be reassigned between reads, so the
-  // nil-check, .finished check, and .result use below must all see the same value.
-  TeakLaunchDataOperation* launchDataOperation = self.launchDataOperation;
-  if (launchDataOperation == nil || !launchDataOperation.finished || self.launchAttributionProcessed) return;
-  self.launchAttributionProcessed = YES;
-
-  // Grab the resolved launch data (it should never be nil, but let's still check)
-  TeakLaunchData* launchData = launchDataOperation.result;
-  if (launchData == nil) return;
-
+// Dispatches a resolved launch's attribution: reward, notification, deep link, and the app-launch
+// summary. Every hop acquires currentSessionMutex (via whenUserIdIsReadyRun / the TeakLink
+// operation), so this runs with the session self-lock released — the currentState KVO handler does
+// the one-shot guard + launchData capture under @synchronized(self), then dispatches here off it.
+- (void)dispatchLaunchAttributionEvents:(nonnull TeakLaunchData*)launchData {
   if ([launchData isKindOfClass:[TeakAttributedLaunchData class]]) {
     TeakAttributedLaunchData* attributedLaunchData = (TeakAttributedLaunchData*)launchData;
 
@@ -912,19 +906,39 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
         dispatch_resume(self.heartbeat);
       }
 
-      // Process WhenUserIdIsReadyRun queue
-      @synchronized(currentSessionMutex) {
-        NSMutableArray* blocks = [TeakSession whenUserIdIsReadyRunBlocks];
-        for (UserIdReadyBlock block in blocks) {
-          dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            block(self);
-          });
-        }
-        [blocks removeAllObjects];
+      // Resolve the one-shot launch attribution under the self-lock: capture launch data for the
+      // single transition that wins the guard; later transitions get nil and only drain the queue.
+      // Single read: launchDataOperation is atomic but can still be reassigned between reads, so the
+      // nil-check, .finished check, and .result use must all see the same value.
+      TeakLaunchDataOperation* launchDataOperation = self.launchDataOperation;
+      TeakLaunchData* attributionLaunchData = nil;
+      if (launchDataOperation != nil && launchDataOperation.finished && !self.launchAttributionProcessed) {
+        self.launchAttributionProcessed = YES;
+        attributionLaunchData = launchDataOperation.result;
       }
 
-      // Process deep links and/or rewards
-      [self processAttributionAndDispatchEvents];
+      // Draining the whenUserIdIsReadyRun queue and dispatching launch attribution both acquire
+      // currentSessionMutex. Taking it here, under the session self-lock, inverts against the
+      // lifecycle class methods (currentSessionMutex → self-lock) and deadlocks when a lifecycle
+      // transition overlaps this identify-reply transition. Hop off the self-lock first so
+      // currentSessionMutex is only ever acquired with the self-lock released.
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        // Process WhenUserIdIsReadyRun queue
+        @synchronized(currentSessionMutex) {
+          NSMutableArray* blocks = [TeakSession whenUserIdIsReadyRunBlocks];
+          for (UserIdReadyBlock block in blocks) {
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+              block(self);
+            });
+          }
+          [blocks removeAllObjects];
+        }
+
+        // Process deep links and/or rewards
+        if (attributionLaunchData != nil) {
+          [self dispatchLaunchAttributionEvents:attributionLaunchData];
+        }
+      });
 
       // Send the server a "hey nevermind that" message if needed
       if (oldValue == [TeakSession Expiring]) {


### PR DESCRIPTION
Fixes an AB-BA lock-order inversion in `TeakSession`. The lifecycle class methods take `currentSessionMutex` then the session self-lock (`@synchronized(self)`); the identify-reply transition ran the other way — the `currentState` KVO handler's `UserIdentified` branch acquired `currentSessionMutex` while already under the self-lock, to drain `whenUserIdIsReadyRun` and dispatch launch attribution. Overlapping event sources (host lifecycle vs an identify reply landing as the app backgrounds) deadlock, and every later lifecycle call then hangs on the mutex.

**Fix:** hop that mutex work off the self-lock into a global-queue block, so `currentSessionMutex` is only ever acquired with the self-lock released. The one-shot attribution guard (`launchAttributionProcessed`) and the `launchData` capture stay under `@synchronized(self)` in the handler — only the transition that wins the guard passes non-nil launch data into the async block, so a second transition can't double-dispatch.

**Behaviorally equivalent from the host's view:** every effect this dispatches was already async — launch notifications via `whenUserIdIsReadyRun`'s `dispatch_async`, deep-link routes via an `operationQueue` op gated on `waitForDeepLink`. The added hop only changes *when* those already-async effects are enqueued, not what the host observes.

**Regression guard:** `RaceTripwireTests` forces the exact AB-BA interleaving on the real KVO handler (kept-alive bare session; thread A holds the mutex then wants self, thread B holds self then runs the handler) with a 5s watchdog. Runs on the `test_race`/TSan lane. Revert-check: green with the fix (0.002s, TSan-clean); revert it and the watchdog fires (deadlock, ~5s).

**Completeness — every self→mutex path is removed, not just the drain.** `currentSessionMutex` is acquired at 11 sites in `TeakSession.m`. Ten are class methods (`+`) taking it in the safe direction — mutex→self or mutex-only: `whenUserIdIsReadyRun`/`whenUserIdIsOrWasReadyRun`/`whenDeviceIsAwakeRun`, `logoutReusingCurrentSession`, `setUserId:andEmail:andFacebookId:`, `applicationDidBecomeActive`, `applicationWillResignActive`, `didLaunchWithData:`, `currentSession`, `currentSessionOrNil`. The eleventh was the `UserIdentified` KVO-handler drain — the only site that took the mutex while holding the session self-lock (self→mutex) — and this PR hops it into an async block so the mutex is acquired with `self` released.

I audited every method that runs under `@synchronized(self)` for a synchronous mutex acquisition (direct, or via a mutex-taking class method): `setState`, the `currentState` KVO handler (all six branches), `sendUserIdentifier`, `identifyUserInfoHasChanged`, `dispatchUserDataEvent`, `hasExpired`. Only the drain qualified; the rest do pure local work under the lock or `dispatch_async` before touching the mutex. Notably `identifyUserInfoHasChanged` calls `whenDeviceIsAwakeRun` (which takes the mutex) at the top with **no self-lock held** — its `@synchronized(self)` blocks sit in the deferred block and don't take the mutex.

With that one edge gone, every mutex/self interaction now orders mutex→self, so the AB-BA cycle can't form at *any* Path-A site (logout, `setUserId` ~:562, the lifecycle methods), not just the drain. (`@synchronized(currentSession)` is the same lock as `@synchronized(self)` when `self` is the current session.)

**Reconciled with #173 (C-967).** Rebased onto #173, which adds a dedicated `deviceConfigurationObserverMutex` and detach-at-replacement in this same region. That lock is orthogonal to this cycle — a true leaf: the only work held under it is `addObserver`/`removeObserver` (New|Old, no `Initial`), which fire no synchronous `observeValueForKeyPath:`, so nothing takes `self` or `currentSessionMutex` while holding it. It's always acquired last and released without waiting on another lock, so it can never be the back-edge of an inversion. TeakSession.m was a clean auto-merge (my hop is in the `currentState` handler; #173's changes are in `-init`/`-dealloc`/the class methods); RaceTripwireTests.m unions #173's observer-lifecycle guards with this deadlock guard.

Linear: https://linear.app/teakio/issue/C-968

---

Proposed changelog entry (for the consolidated 4.3.14 PR — not adding `4.3.14.yaml` here to avoid the add/add conflict across this wave):

- Fixed a lock-order inversion in `TeakSession` that could deadlock the SDK when a user-identify reply overlapped an app foreground/background transition.
