### PR TITLE
Stop TeakAttributedLaunchData.updateDeepLink from mutating post-publication

### DIFF
--- a/Automated/AutomatedTests/TeakAttributedLaunchDataEnrichmentTests.m
+++ b/Automated/AutomatedTests/TeakAttributedLaunchDataEnrichmentTests.m
@@ -37,11 +37,10 @@
 
 #pragma mark - Bare attributed launch data (no pre-existing attribution)
 
-/// When there's no pre-existing attribution, a later updateDeepLink: with a URL
-/// that carries teak_* params must actually populate the attribution fields.
-/// Before the initWithUrl:andShortLink: fix, newLaunchData was built via the
-/// parent's initWithUrl: (no query parsing), so NewIfNotOld(nil, nil) always
-/// returned nil and the enrichment merge was a no-op.
+/// When there's no pre-existing attribution, updatedWithDeepLink: with a URL that
+/// carries teak_* params must populate the attribution fields on the RETURNED
+/// object, and must leave the receiver untouched (C-973: the receiver may already
+/// be published/read from another queue by the time this runs).
 - (void)testUpdateDeepLinkPopulatesAttributionWhenOldIsNil {
   NSURL* bareUrl = [NSURL URLWithString:@"teaktest-app://menu"];
   TeakAttributedLaunchData* data = [[TeakAttributedLaunchData alloc] initWithUrl:bareUrl andShortLink:nil];
@@ -50,31 +49,46 @@
   XCTAssertNil(data.rewardId);
 
   NSURL* enrichedUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=7&teak_schedule_name=daily&teak_creative_id=42&teak_creative_name=banner&teak_reward_id=99&teak_channel_name=push&teak_opt_out_category=promos"];
-  [data updateDeepLink:enrichedUrl];
+  TeakAttributedLaunchData* updated = (TeakAttributedLaunchData*)[data updatedWithDeepLink:enrichedUrl];
 
-  XCTAssertEqualObjects(data.scheduleId, @"7");
-  XCTAssertEqualObjects(data.scheduleName, @"daily");
-  XCTAssertEqualObjects(data.creativeId, @"42");
-  XCTAssertEqualObjects(data.creativeName, @"banner");
-  XCTAssertEqualObjects(data.rewardId, @"99");
-  XCTAssertEqualObjects(data.channelName, @"push");
-  XCTAssertEqualObjects(data.optOutCategory, @"promos");
-  XCTAssertEqualObjects(data.deepLink, enrichedUrl);
+  XCTAssertTrue(updated != data, @"updatedWithDeepLink: must return a fresh object, not mutate the receiver");
+  XCTAssertEqualObjects(updated.scheduleId, @"7");
+  XCTAssertEqualObjects(updated.scheduleName, @"daily");
+  XCTAssertEqualObjects(updated.creativeId, @"42");
+  XCTAssertEqualObjects(updated.creativeName, @"banner");
+  XCTAssertEqualObjects(updated.rewardId, @"99");
+  XCTAssertEqualObjects(updated.channelName, @"push");
+  XCTAssertEqualObjects(updated.optOutCategory, @"promos");
+  XCTAssertEqualObjects(updated.deepLink, enrichedUrl);
+
+  // Regression guard for C-973: the receiver must remain exactly as constructed.
+  XCTAssertNil(data.scheduleId);
+  XCTAssertNil(data.creativeId);
+  XCTAssertNil(data.rewardId);
+  XCTAssertNil(data.channelName);
+  XCTAssertNil(data.optOutCategory);
+  XCTAssertEqualObjects(data.deepLink, bareUrl);
 }
 
 /// to_h must surface the enriched fields too, since TeakPostLaunchSummary uses
-/// this dict as its userInfo. Previously blocked by the same newLaunchData bug.
+/// this dict as its userInfo — read off the returned object, not the receiver.
 - (void)testUpdateDeepLinkEnrichmentFlowsIntoToH {
   NSURL* bareUrl = [NSURL URLWithString:@"teaktest-app://menu"];
   TeakAttributedLaunchData* data = [[TeakAttributedLaunchData alloc] initWithUrl:bareUrl andShortLink:nil];
 
   NSURL* enrichedUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=7&teak_creative_id=42&teak_reward_id=99"];
-  [data updateDeepLink:enrichedUrl];
+  TeakAttributedLaunchData* updated = (TeakAttributedLaunchData*)[data updatedWithDeepLink:enrichedUrl];
 
-  NSDictionary* dict = [data to_h];
+  NSDictionary* dict = [updated to_h];
   XCTAssertEqualObjects(dict[@"teakScheduleId"], @"7");
   XCTAssertEqualObjects(dict[@"teakCreativeId"], @"42");
   XCTAssertEqualObjects(dict[@"teakRewardId"], @"99");
+
+  // The receiver's own to_h must be unaffected by the enrichment.
+  NSDictionary* originalDict = [data to_h];
+  XCTAssertEqualObjects(originalDict[@"teakScheduleId"], [NSNull null]);
+  XCTAssertEqualObjects(originalDict[@"teakCreativeId"], [NSNull null]);
+  XCTAssertEqualObjects(originalDict[@"teakRewardId"], [NSNull null]);
 }
 
 #pragma mark - Pre-existing attribution (behavior preservation)
@@ -87,12 +101,16 @@
   XCTAssertEqualObjects(data.scheduleId, @"ORIGINAL");
 
   NSURL* enrichedUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=ENRICHED&teak_creative_id=ENRICHED_CREATIVE&teak_reward_id=ENRICHED_REWARD"];
-  [data updateDeepLink:enrichedUrl];
+  TeakAttributedLaunchData* updated = (TeakAttributedLaunchData*)[data updatedWithDeepLink:enrichedUrl];
 
-  XCTAssertEqualObjects(data.scheduleId, @"ORIGINAL", @"old non-nil attribution must win over enriched URL values");
-  XCTAssertEqualObjects(data.creativeId, @"ORIGINAL_CREATIVE");
-  XCTAssertEqualObjects(data.rewardId, @"ORIGINAL_REWARD");
-  XCTAssertEqualObjects(data.deepLink, enrichedUrl, @"deepLink itself should still update");
+  XCTAssertEqualObjects(updated.scheduleId, @"ORIGINAL", @"old non-nil attribution must win over enriched URL values");
+  XCTAssertEqualObjects(updated.creativeId, @"ORIGINAL_CREATIVE");
+  XCTAssertEqualObjects(updated.rewardId, @"ORIGINAL_REWARD");
+  XCTAssertEqualObjects(updated.deepLink, enrichedUrl, @"deepLink itself should still update");
+
+  // The receiver's own deepLink must not have changed.
+  XCTAssertEqualObjects(data.deepLink, originalUrl);
+  XCTAssertEqualObjects(data.scheduleId, @"ORIGINAL");
 }
 
 /// A mix: old has some slots, new fills in the rest.
@@ -103,10 +121,13 @@
   XCTAssertNil(data.creativeId);
 
   NSURL* enrichedUrl = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=ENRICHED_SCHEDULE&teak_creative_id=NEW_CREATIVE"];
-  [data updateDeepLink:enrichedUrl];
+  TeakAttributedLaunchData* updated = (TeakAttributedLaunchData*)[data updatedWithDeepLink:enrichedUrl];
 
-  XCTAssertEqualObjects(data.scheduleId, @"ORIGINAL_SCHEDULE", @"slot with old value preserves it");
-  XCTAssertEqualObjects(data.creativeId, @"NEW_CREATIVE", @"slot that was nil gets filled by enriched URL");
+  XCTAssertEqualObjects(updated.scheduleId, @"ORIGINAL_SCHEDULE", @"slot with old value preserves it");
+  XCTAssertEqualObjects(updated.creativeId, @"NEW_CREATIVE", @"slot that was nil gets filled by enriched URL");
+
+  // The receiver never gets the new creativeId — it was never mutated.
+  XCTAssertNil(data.creativeId);
 }
 
 @end

--- a/Automated/AutomatedTests/TeakAttributedLaunchDataEnrichmentTests.m
+++ b/Automated/AutomatedTests/TeakAttributedLaunchDataEnrichmentTests.m
@@ -39,8 +39,8 @@
 
 /// When there's no pre-existing attribution, updatedWithDeepLink: with a URL that
 /// carries teak_* params must populate the attribution fields on the RETURNED
-/// object, and must leave the receiver untouched (C-973: the receiver may already
-/// be published/read from another queue by the time this runs).
+/// object, and must leave the receiver untouched — the receiver may already be
+/// published/read from another queue by the time this runs.
 - (void)testUpdateDeepLinkPopulatesAttributionWhenOldIsNil {
   NSURL* bareUrl = [NSURL URLWithString:@"teaktest-app://menu"];
   TeakAttributedLaunchData* data = [[TeakAttributedLaunchData alloc] initWithUrl:bareUrl andShortLink:nil];
@@ -61,7 +61,7 @@
   XCTAssertEqualObjects(updated.optOutCategory, @"promos");
   XCTAssertEqualObjects(updated.deepLink, enrichedUrl);
 
-  // Regression guard for C-973: the receiver must remain exactly as constructed.
+  // Regression guard: the receiver must remain exactly as constructed.
   XCTAssertNil(data.scheduleId);
   XCTAssertNil(data.creativeId);
   XCTAssertNil(data.rewardId);

--- a/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
+++ b/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
@@ -148,7 +148,9 @@ static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD
 /// Simulates the users.json reply path: server responds with a `deep_link` carrying
 /// teak_* query params, TeakSession calls updateDeepLink:withLaunchLink: on our
 /// launch data operation, and the enriched fields surface in both sessionAttribution
-/// (already-identified sessions) and to_h (TeakPostLaunchSummary userInfo).
+/// (already-identified sessions) and to_h (TeakPostLaunchSummary userInfo). The
+/// replacement operation runs synchronously (no I/O involved), and the original
+/// operation/result must be left untouched (C-973).
 - (void)testUpdateDeepLinkEnrichesAttributedFieldsAndPreservesSystemActivityId {
   TeakLaunchDataOperation* op = [TeakLaunchDataOperation fromLiveActivityTap:kSystemActivityId];
   NSOperationQueue* queue = [[NSOperationQueue alloc] init];
@@ -156,9 +158,12 @@ static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD
   [queue waitUntilAllOperationsAreFinished];
 
   NSURL* enrichedDeepLink = [NSURL URLWithString:@"teaktest-app://chest?teak_schedule_id=7&teak_creative_id=42&teak_reward_id=99"];
-  [op updateDeepLink:enrichedDeepLink withLaunchLink:nil];
+  TeakLaunchDataOperation* updatedOp = [op updateDeepLink:enrichedDeepLink withLaunchLink:nil];
 
-  TeakLiveActivityLaunchData* data = (TeakLiveActivityLaunchData*)op.result;
+  XCTAssertTrue(updatedOp != op, @"updateDeepLink:withLaunchLink: must return a fresh operation, not mutate the original");
+  XCTAssertTrue(updatedOp.finished, @"the replacement operation wraps an already-computed object and runs synchronously");
+
+  TeakLiveActivityLaunchData* data = (TeakLiveActivityLaunchData*)updatedOp.result;
   XCTAssertEqualObjects(data.systemActivityId, kSystemActivityId, @"updateDeepLink: must not clobber systemActivityId");
 
   NSDictionary* attribution = [data sessionAttribution];
@@ -172,6 +177,12 @@ static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD
   XCTAssertEqualObjects(dict[@"teakScheduleId"], @"7");
   XCTAssertEqualObjects(dict[@"teakCreativeId"], @"42");
   XCTAssertEqualObjects(dict[@"teakRewardId"], @"99");
+
+  // Regression guard for C-973: the original operation's result must be untouched.
+  TeakLiveActivityLaunchData* originalData = (TeakLiveActivityLaunchData*)op.result;
+  XCTAssertEqualObjects(originalData.systemActivityId, kSystemActivityId);
+  NSDictionary* originalAttribution = [originalData sessionAttribution];
+  XCTAssertNil(originalAttribution[@"teak_schedule_id"], @"the original launch data must not see the enrichment");
 }
 
 - (void)testFromUserActivityHandlesBrowsingWeb {

--- a/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
+++ b/Automated/AutomatedTests/TeakLiveActivityLaunchDataTests.m
@@ -150,7 +150,7 @@ static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD
 /// launch data operation, and the enriched fields surface in both sessionAttribution
 /// (already-identified sessions) and to_h (TeakPostLaunchSummary userInfo). The
 /// replacement operation runs synchronously (no I/O involved), and the original
-/// operation/result must be left untouched (C-973).
+/// operation/result must be left untouched.
 - (void)testUpdateDeepLinkEnrichesAttributedFieldsAndPreservesSystemActivityId {
   TeakLaunchDataOperation* op = [TeakLaunchDataOperation fromLiveActivityTap:kSystemActivityId];
   NSOperationQueue* queue = [[NSOperationQueue alloc] init];
@@ -178,7 +178,7 @@ static NSString* const kSystemActivityId = @"D3CBB9AF-7292-4FD9-B22D-DEAC3D033BD
   XCTAssertEqualObjects(dict[@"teakCreativeId"], @"42");
   XCTAssertEqualObjects(dict[@"teakRewardId"], @"99");
 
-  // Regression guard for C-973: the original operation's result must be untouched.
+  // Regression guard: the original operation's result must be untouched.
   TeakLiveActivityLaunchData* originalData = (TeakLiveActivityLaunchData*)op.result;
   XCTAssertEqualObjects(originalData.systemActivityId, kSystemActivityId);
   NSDictionary* originalAttribution = [originalData sessionAttribution];

--- a/Teak/Core/TeakLaunchData.h
+++ b/Teak/Core/TeakLaunchData.h
@@ -18,7 +18,6 @@
 
 - (NSDictionary*)sessionAttribution;
 - (NSDictionary*)to_h;
-- (void)updateDeepLink:(NSURL*)updatedDeepLink;
 @end
 
 @interface TeakAttributedLaunchData : TeakLaunchData
@@ -32,14 +31,17 @@
 @property (copy, nonatomic, readonly) NSString* optOutCategory;
 
 - (NSDictionary*)sessionAttribution;
-- (void)updateDeepLink:(NSURL*)updatedDeepLink;
+
+// Returns a new, fully-independent launch data object with deep-link attribution
+// merged in — never mutates the receiver, which may already be published/read
+// from other queues (see TeakLaunchDataOperation's updateDeepLink:withLaunchLink:).
+- (TeakLaunchData*)updatedWithDeepLink:(NSURL*)updatedDeepLink;
 @end
 
 @interface TeakNotificationLaunchData : TeakAttributedLaunchData
 @property (copy, nonatomic, readonly) NSString* sourceSendId;
 
 - (NSDictionary*)sessionAttribution;
-- (void)updateDeepLink:(NSURL*)updatedDeepLink;
 @end
 
 @interface TeakRewardlinkLaunchData : TeakAttributedLaunchData

--- a/Teak/Core/TeakLaunchData.m
+++ b/Teak/Core/TeakLaunchData.m
@@ -147,15 +147,17 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
 - (TeakLaunchDataOperation*)updateDeepLink:(NSURL*)updatedDeepLink withLaunchLink:(NSURL*)launchLink {
   TeakLaunchData* launchData = self.result;
   if ([launchData isKindOfClass:TeakAttributedLaunchData.class]) {
-    [launchData updateDeepLink:updatedDeepLink];
-    return self;
+    launchData = [(TeakAttributedLaunchData*)launchData updatedWithDeepLink:updatedDeepLink];
+  } else {
+    launchData = [TeakLaunchDataOperation launchDataFromUrl:updatedDeepLink withShortlink:launchLink];
   }
 
-  // Create a new launch data operation and queue it (it uses the returnLaunchData: path)
-  launchData = [TeakLaunchDataOperation launchDataFromUrl:updatedDeepLink
-                                            withShortlink:launchLink];
+  // Run synchronously rather than via the shared operationQueue: this just wraps an
+  // already-computed object (no I/O), and callers (e.g. TeakSession's
+  // processAttributionAndDispatchEvents) check .finished immediately after this call
+  // returns, in the same call stack as the reassignment below.
   TeakLaunchDataOperation* launchDataOperation = [[TeakLaunchDataOperation alloc] initWithLaunchData:launchData];
-  [[Teak sharedInstance].operationQueue addOperation:launchDataOperation];
+  [launchDataOperation start];
   return launchDataOperation;
 }
 
@@ -289,10 +291,6 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
   return dictionary;
 }
 
-- (void)updateDeepLink:(NSURL*)updatedDeepLink {
-  // Empty on purpose
-}
-
 @end
 
 @implementation TeakAttributedLaunchData
@@ -391,17 +389,8 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
   return dictionary;
 }
 
-- (void)updateDeepLink:(NSURL*)updatedDeepLink {
-  TeakAttributedLaunchData* updatedLaunchData = [[TeakAttributedLaunchData alloc] initWithAttributedLaunchData:self andUpdatedDeepLink:updatedDeepLink];
-  self.scheduleName = updatedLaunchData.scheduleName;
-  self.scheduleId = updatedLaunchData.scheduleId;
-  self.creativeName = updatedLaunchData.creativeName;
-  self.creativeId = updatedLaunchData.creativeId;
-  self.rewardId = updatedLaunchData.rewardId;
-  self.channelName = updatedLaunchData.channelName;
-  self.deepLink = updatedLaunchData.deepLink;
-  self.optOutCategory = updatedLaunchData.optOutCategory;
-  self.deepLinkUrlQuery = updatedLaunchData.deepLinkUrlQuery;
+- (TeakLaunchData*)updatedWithDeepLink:(NSURL*)updatedDeepLink {
+  return [[[self class] alloc] initWithAttributedLaunchData:self andUpdatedDeepLink:updatedDeepLink];
 }
 
 @end
@@ -444,13 +433,6 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
   return dictionary;
 }
 
-- (void)updateDeepLink:(NSURL*)updatedDeepLink {
-  [super updateDeepLink:updatedDeepLink];
-
-  TeakNotificationLaunchData* updatedLaunchData = [[TeakNotificationLaunchData alloc] initWithAttributedLaunchData:self andUpdatedDeepLink:updatedDeepLink];
-  self.sourceSendId = updatedLaunchData.sourceSendId;
-}
-
 @end
 
 @implementation TeakRewardlinkLaunchData
@@ -471,6 +453,14 @@ static NSString* const kTeakWGWidgetUserInfoKeyActivityID = @"WGWidgetUserInfoKe
   self = [super initWithUrl:nil andShortLink:nil];
   if (self) {
     self.systemActivityId = systemActivityId;
+  }
+  return self;
+}
+
+- (id)initWithAttributedLaunchData:(TeakLiveActivityLaunchData*)oldLaunchData andUpdatedDeepLink:(NSURL*)updatedDeepLink {
+  self = [super initWithAttributedLaunchData:oldLaunchData andUpdatedDeepLink:updatedDeepLink];
+  if (self) {
+    self.systemActivityId = oldLaunchData.systemActivityId;
   }
   return self;
 }

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -322,10 +322,11 @@ DefineTeakState(Expired, (@[]));
                                                     if (reply[@"deep_link"]) {
                                                       NSString* deepLink = reply[@"deep_link"];
                                                       NSURL* url = [NSURL URLWithString:deepLink];
-                                                      if (url && blockSelf.launchDataOperation != nil) {
+                                                      TeakLaunchDataOperation* launchDataOperation = blockSelf.launchDataOperation;
+                                                      if (url && launchDataOperation != nil) {
                                                         NSString* payloadLaunchLink = payload[@"launch_link"];
                                                         NSURL* launchLink = payloadLaunchLink == nil || payloadLaunchLink == ((NSString*)[NSNull null]) ? nil : [NSURL URLWithString:payloadLaunchLink];
-                                                        blockSelf.launchDataOperation = [blockSelf.launchDataOperation updateDeepLink:url withLaunchLink:launchLink];
+                                                        blockSelf.launchDataOperation = [launchDataOperation updateDeepLink:url withLaunchLink:launchLink];
                                                       }
                                                       TeakLog_i(@"deep_link.processed", deepLink);
                                                     }


### PR DESCRIPTION
https://linear.app/teakio/issue/C-973/teakattributedlaunchdataupdatedeeplink-mutates-post-publication-u7

## What

`TeakLaunchDataOperation.updateDeepLink:withLaunchLink:` mutated the existing `TeakAttributedLaunchData` object's copy-setters in place when the identify-reply's `deep_link` enriched an already-attributed launch — while that object was already visible to `sessionAttribution` (read on the op queue while building the identify payload) and to `to_h` consumers dispatched onto the global queue (`TeakPostLaunchSummary`, `TeakOnReward`, `TeakNotificationAppLaunch`, `TeakLaunchedFromLink`). Concurrent copy-setter writes racing those reads is a freeable-pointee UAF (copy-setters release the old `NSString`/`NSURL` as they swap in the new one).

## Fix

- `TeakAttributedLaunchData`'s mutating `updateDeepLink:` is replaced with `updatedWithDeepLink:`, which returns a **new** object (via the existing `initWithAttributedLaunchData:andUpdatedDeepLink:` initializer) instead of touching the receiver. Subclasses inherit it — it dispatches through `[[self class] alloc] initWithAttributedLaunchData:...]`, so `TeakNotificationLaunchData`'s existing init override (for `sourceSendId`) is reached automatically; added the same kind of override to `TeakLiveActivityLaunchData` for `systemActivityId` (previously relied on in-place mutation to preserve it, no override existed).
- `TeakLaunchDataOperation.updateDeepLink:withLaunchLink:` now always builds and runs a **fresh** operation for both branches (attributed and not — previously only the non-attributed branch did this). The old operation/object is never touched again, so anything already holding a reference to it (e.g. a block already captured for a global-queue dispatch) keeps reading a safe, frozen snapshot.
- The fresh operation runs via `-start` rather than `[Teak sharedInstance].operationQueue addOperation:`. This is deliberate, not a stylistic choice: `TeakSession.processAttributionAndDispatchEvents` checks `.finished` synchronously, in the same call stack, right after the reassignment — the old mutate-in-place code satisfied that check implicitly (same op, already finished). Routing through the shared queue would make that check racy against queue scheduling, silently dropping attribution processing (no other call site re-triggers it). Two things to make this auditable without re-deriving:
  - **Side-effect equivalence**: `returnLaunchData:` (`TeakLaunchData.m`) is `{ return launchData; }` — a pure passthrough, no I/O, no notifications, no shared-state writes. It's the same selector every `TeakLaunchDataOperation` built via `initWithLaunchData:` already runs (just via `addOperation:` elsewhere). Running it again on a *distinct* new operation object can't double-process anything; the actual dispatch logic lives entirely in `processAttributionAndDispatchEvents`, called from one site, guarded by `launchAttributionProcessed`.
  - **`-start` preserves finished-immediately**: verified empirically (not just from docs) — a throwaway `NSInvocationOperation`, `isFinished` is `0` before `[op start]` and `1` with `.result` populated immediately after `start` returns (Foundation runs `main` synchronously for non-concurrent operations; `TeakLaunchDataOperation` has no `isConcurrent`/`isAsynchronous` override).
- `TeakSession.m`'s deep-link block now captures `blockSelf.launchDataOperation` to a local once instead of reading the property twice (nil-check, then use) — closes a TOCTOU independent of whether the property itself is atomic (a parallel PR is making it so).

## Testing

Rewrote `TeakAttributedLaunchDataEnrichmentTests` and `TeakLiveActivityLaunchDataTests` against the new non-mutating API: each asserts the *returned* object carries the enrichment and the *receiver* is left untouched — the regression guard for this bug. Revert-checked: stashing the source fix back out makes these tests fail to compile (`No visible @interface ... declares the selector 'updatedWithDeepLink:'`), confirming they actually exercise the fix. Full suite green (161 tests, 0 failures) both before and after the revert-check.

## Changelog

> Fixed a rare crash when server-side deep link attribution arrived while launch data was being read elsewhere.