### PR TITLE
Make TeakSession identify-reply properties atomic

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -2,6 +2,7 @@
 #import <stdatomic.h>
 
 #import "TeakAppConfiguration.h"
+#import "TeakChannelStatus.h"
 #import "TeakConfiguration.h"
 #import "TeakDeviceConfiguration.h"
 #import "TeakLog.h"
@@ -16,13 +17,19 @@
 
 // Race-detection regression guard. Drives a real Teak type under concurrency and pins an invariant a
 // detector can observe, so a red run means a real regression — the fix it guards was reverted. Two
-// kinds of guard live here: deterministic CF-over-release crash repros (serverSessionId/countryCode/
-// userProfile) that carry signal on their own, and a ThreadSanitizer-only serialization guard (the
-// attribute-dict test) that needs the sanitizer to see the race at all. Both run every commit, just
-// on different lanes: the `test` lane skips this whole class to keep the fast per-commit signal
-// quick — the crash repros are too slow (up to 2M iterations) for it, and the serialization test
-// needs TSan anyway. The `test_race` lane runs all of them, every commit, with ThreadSanitizer
-// attached for the one test that needs it, and additionally gates tagged-build releases.
+// kinds of guard live here: deterministic CF-over-release crash repros (the nonatomic-strong,
+// freeable-pointee TeakSession properties — serverSessionId/countryCode/userProfile/
+// facebookAccessToken/additionalData/emailStatus/pushStatus/smsStatus) that carry signal on their
+// own, and a ThreadSanitizer-only serialization guard (the attribute-dict test) that needs the
+// sanitizer to see the race at all. Both run every commit, just on different lanes: the `test`
+// lane skips this whole class to keep the fast per-commit signal quick — the crash repros are too
+// slow (up to 2M iterations) for it, and the serialization test needs TSan anyway. The `test_race`
+// lane runs all of them, every commit, with ThreadSanitizer attached for the one test that needs
+// it, and additionally gates tagged-build releases.
+//
+// launchDataOperation is atomic+capture-to-local too (see TeakSession.m), but its pointee never
+// frees — see the comment near testAdditionalDataIsAtomicUnderConcurrency below — so it's pinned
+// as a static atomic-declaration assertion in TeakSessionLockingTests.m instead.
 //
 // See Automated/RACE_TESTING.md for the race-testing methodology — which detector catches which
 // race class, and why some classes (e.g. lock-inversion deadlocks) get no in-process guard here.
@@ -54,14 +61,19 @@
 @property (strong, nonatomic) NSMutableDictionary* stringAttributes;
 @end
 
-// countryCode/serverSessionId are private (declared only in TeakSession.m's class extension);
-// userProfile is public but readonly there. Re-declared here for full read-write access, per the
-// project convention of redeclaring internal properties in the test file rather than importing
-// Teak+Internal.h.
+// countryCode/serverSessionId/facebookAccessToken are private (declared only in TeakSession.m's
+// class extension); userProfile/additionalData/emailStatus/pushStatus/smsStatus are public but
+// readonly there. Re-declared here for full read-write access, per the project convention of
+// redeclaring internal properties in the test file rather than importing Teak+Internal.h.
 @interface TeakSession (RaceTripwire)
 @property (strong, atomic) NSString* countryCode;
 @property (strong, atomic) NSString* serverSessionId;
+@property (strong, atomic) NSString* facebookAccessToken;
 @property (strong, atomic, readwrite) TeakUserProfile* userProfile;
+@property (strong, atomic, readwrite) NSDictionary* additionalData;
+@property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull emailStatus;
+@property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull pushStatus;
+@property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull smsStatus;
 @end
 
 // A profile whose send is a no-op: the tripwire drives a bare-alloc profile that has no backing
@@ -176,6 +188,106 @@ static NSMutableArray* keepAliveBareSessions;
                 TeakUserProfile* p = session.userProfile;
                 (void)NSStringFromClass([p class]).length;
                 (void)p.stringAttributes.count;
+              }
+            }];
+}
+
+// facebookAccessToken is reassigned lock-free in -handleEvent: (the Facebook SDK's own callback,
+// an arbitrary thread) while sendUserIdentifier reads it under @synchronized(self) — that lock
+// doesn't cover the writer. Same CFString-backed repro as countryCode/serverSessionId above.
+- (void)testFacebookAccessTokenIsAtomicUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 200000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      session.facebookAccessToken = [[NSString alloc] initWithFormat:@"race-facebookaccesstoken-value-%d", i];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSString* s = session.facebookAccessToken;
+                (void)s.length;
+              }
+            }];
+}
+
+// launchDataOperation has no dynamic crash repro here: TeakLaunchDataOperation is an
+// NSInvocationOperation subclass that targets itself in its own initializer, and
+// -[NSInvocationOperation retainArguments] retains that target — every instance is a permanent
+// operation→invocation→operation retain cycle that ARC can't break, so the pointee never frees
+// and there's no dealloc-during-read window to catch. It's pinned as a static atomic-declaration
+// assertion in TeakSessionLockingTests.m instead (same treatment as currentState/previousState).
+
+// additionalData's pointee is an NSDictionary, not a CFString. A single non-empty entry forces a
+// real heap-allocated dictionary — an empty dictionary literal returns a shared singleton that
+// never deallocates and would false-green this test.
+- (void)testAdditionalDataIsAtomicUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 2000000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      session.additionalData = @{@"seed" : [[NSString alloc] initWithFormat:@"race-additionaldata-value-%d", i]};
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                NSDictionary* d = session.additionalData;
+                (void)NSStringFromClass([d class]).length;
+                (void)d.count;
+              }
+            }];
+}
+
+// emailStatus/pushStatus/smsStatus are plain TeakChannelStatus objects — same isa-touch technique
+// as userProfile above. +unknown is a dispatch_once singleton that never deallocates; -[TeakChannelStatus
+// initWithDictionary:] with a recognized state string gives a genuine fresh alloc on every call instead.
+- (void)testEmailStatusIsAtomicUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 2000000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      session.emailStatus = [[TeakChannelStatus alloc] initWithDictionary:@{@"state" : TeakChannelStateOptIn}];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                TeakChannelStatus* status = session.emailStatus;
+                (void)NSStringFromClass([status class]).length;
+                (void)status.state.length;
+              }
+            }];
+}
+
+- (void)testPushStatusIsAtomicUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 2000000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      session.pushStatus = [[TeakChannelStatus alloc] initWithDictionary:@{@"state" : TeakChannelStateOptIn}];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                TeakChannelStatus* status = session.pushStatus;
+                (void)NSStringFromClass([status class]).length;
+                (void)status.state.length;
+              }
+            }];
+}
+
+- (void)testSmsStatusIsAtomicUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 2000000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      session.smsStatus = [[TeakChannelStatus alloc] initWithDictionary:@{@"state" : TeakChannelStateOptIn}];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                TeakChannelStatus* status = session.smsStatus;
+                (void)NSStringFromClass([status class]).length;
+                (void)status.state.length;
               }
             }];
 }

--- a/Automated/AutomatedTests/TeakSessionLockingTests.m
+++ b/Automated/AutomatedTests/TeakSessionLockingTests.m
@@ -15,12 +15,18 @@
 //   - countryCode / userProfile / serverSessionId are reassigned in the identify-reply request
 //     callback while read cross-thread by the heartbeat queue and the duration-report background
 //     block. See RaceTripwireTests.m for the dynamic use-after-free repro backing these three.
+//   - launchDataOperation is reassigned in the same identify-reply callback while read from
+//     several call sites. See RaceTripwireTests.m for why it has no dynamic repro: its pointee
+//     (a TeakLaunchDataOperation, an NSInvocationOperation subclass) targets itself in its own
+//     initializer, so it self-retains and never deallocates — no dealloc-during-read window for a
+//     crash repro to catch. This static pin is its only regression guard.
 //
-// A behavioral race test for currentState/previousState/reportDurationBlock isn't feasible — on
-// ARM64 aligned pointer reads don't actually tear, so the race is formal (UB / TSan-detectable)
-// rather than observable, and these tests instead pin the declarations to atomic via the
-// Objective-C runtime, failing if any reverts. countryCode/userProfile/serverSessionId get the
-// same static pin here as a cheap permanent guard, on top of the dynamic repro.
+// A behavioral race test for currentState/previousState/reportDurationBlock/launchDataOperation
+// isn't feasible — on ARM64 aligned pointer reads don't actually tear, so the race is formal (UB /
+// TSan-detectable) rather than observable (or, for launchDataOperation, there's no free-then-reuse
+// window at all) — and these tests instead pin the declarations to atomic via the Objective-C
+// runtime, failing if any reverts. countryCode/userProfile/serverSessionId get the same static pin
+// here as a cheap permanent guard, on top of the dynamic repro.
 @interface TeakSessionLockingTests : XCTestCase
 @end
 
@@ -64,6 +70,11 @@
 - (void)testServerSessionIdIsAtomic {
   XCTAssertFalse([self isNonatomicProperty:"serverSessionId"],
                  @"TeakSession.serverSessionId must stay atomic — reassigned in the identify-reply callback while read by the duration-report background block");
+}
+
+- (void)testLaunchDataOperationIsAtomic {
+  XCTAssertFalse([self isNonatomicProperty:"launchDataOperation"],
+                 @"TeakSession.launchDataOperation must stay atomic — reassigned in the identify-reply callback while read from sendUserIdentifier, identifyUserOperation, and processAttributionAndDispatchEvents");
 }
 
 @end

--- a/Teak/TeakSession.h
+++ b/Teak/TeakSession.h
@@ -27,10 +27,10 @@ typedef void (^UserIdReadyBlock)(TeakSession* _Nonnull);
 @property (strong, nonatomic, readonly) NSString* _Nonnull sessionId;
 @property (strong, atomic, readonly) TeakState* _Nonnull currentState;
 @property (strong, atomic, readonly) TeakUserProfile* _Nonnull userProfile;
-@property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull emailStatus;
-@property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull pushStatus;
-@property (strong, nonatomic, readonly) TeakChannelStatus* _Nonnull smsStatus;
-@property (strong, nonatomic, readonly) NSDictionary* _Nullable additionalData;
+@property (strong, atomic, readonly) TeakChannelStatus* _Nonnull emailStatus;
+@property (strong, atomic, readonly) TeakChannelStatus* _Nonnull pushStatus;
+@property (strong, atomic, readonly) TeakChannelStatus* _Nonnull smsStatus;
+@property (strong, atomic, readonly) NSDictionary* _Nullable additionalData;
 
 DeclareTeakState(Created);
 DeclareTeakState(Configured);

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -44,9 +44,13 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 @property (strong, atomic) NSString* countryCode;
 @property (strong, nonatomic) dispatch_queue_t heartbeatQueue;
 @property (strong, nonatomic) dispatch_source_t heartbeat;
-@property (strong, nonatomic) TeakLaunchDataOperation* launchDataOperation;
+// Same cross-thread reassignment race as countryCode above.
+@property (strong, atomic) TeakLaunchDataOperation* launchDataOperation;
 @property (nonatomic) BOOL launchAttributionProcessed;
-@property (strong, nonatomic) NSString* facebookAccessToken;
+// facebookAccessToken is reassigned lock-free in -handleEvent: (arbitrary thread, e.g. the
+// Facebook SDK's own callback) while sendUserIdentifier reads it under @synchronized(self) — that
+// lock doesn't cover the writer, so it's the same hazard as countryCode above.
+@property (strong, atomic) NSString* facebookAccessToken;
 
 @property (strong, nonatomic, readwrite) NSString* userId;
 @property (strong, nonatomic, readwrite) NSString* facebookId;
@@ -55,11 +59,13 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 @property (strong, nonatomic, readwrite) TeakDeviceConfiguration* deviceConfiguration;
 @property (strong, nonatomic, readwrite) TeakRemoteConfiguration* remoteConfiguration;
 
-@property (strong, nonatomic, readwrite) TeakChannelStatus* _Nonnull emailStatus;
-@property (strong, nonatomic, readwrite) TeakChannelStatus* _Nonnull pushStatus;
-@property (strong, nonatomic, readwrite) TeakChannelStatus* _Nonnull smsStatus;
+// Same cross-thread reassignment race as countryCode above.
+@property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull emailStatus;
+@property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull pushStatus;
+@property (strong, atomic, readwrite) TeakChannelStatus* _Nonnull smsStatus;
 
-@property (strong, nonatomic, readwrite) NSDictionary* additionalData;
+// Same cross-thread reassignment race as countryCode above.
+@property (strong, atomic, readwrite) NSDictionary* additionalData;
 
 // Same cross-thread reassignment race as countryCode above.
 @property (strong, atomic, readwrite) TeakUserProfile* userProfile;
@@ -276,12 +282,19 @@ DefineTeakState(Expired, (@[]));
 
     if (!self.appConfiguration.sdk5Behaviors) {
       if (dataCollectionConfiguration.enableFacebookAccessToken) {
-        if (self.facebookAccessToken == nil) {
-          self.facebookAccessToken = [FacebookAccessTokenEvent currentUserToken];
+        // Single read: facebookAccessToken is atomic but can still be reassigned between two
+        // reads (handleEvent: writes it lock-free off this method's thread), so the nil-check and
+        // the payload use below must see the same value as the lazy-init above. Without this, a
+        // reassignment to nil between the two live reads would insert nil into payload, which
+        // throws on NSMutableDictionary.
+        NSString* facebookAccessToken = self.facebookAccessToken;
+        if (facebookAccessToken == nil) {
+          facebookAccessToken = [FacebookAccessTokenEvent currentUserToken];
+          self.facebookAccessToken = facebookAccessToken;
         }
 
-        if (self.facebookAccessToken != nil) {
-          payload[@"access_token"] = self.facebookAccessToken;
+        if (facebookAccessToken != nil) {
+          payload[@"access_token"] = facebookAccessToken;
         }
       }
     }
@@ -291,9 +304,12 @@ DefineTeakState(Expired, (@[]));
     }
 
     // Then add the attribution, then send request
-    // The launchDataOperation is a dependency for this operation, so it should always be ready
-    if (self.launchDataOperation && self.launchDataOperation.isFinished) {
-      [payload addEntriesFromDictionary:[self.launchDataOperation.result sessionAttribution]];
+    // The launchDataOperation is a dependency for this operation, so it should always be ready.
+    // Single read: launchDataOperation is atomic but can still be reassigned between reads, so the
+    // nil-check, .isFinished, and .result use below must all see the same value.
+    TeakLaunchDataOperation* launchDataOperation = self.launchDataOperation;
+    if (launchDataOperation && launchDataOperation.isFinished) {
+      [payload addEntriesFromDictionary:[launchDataOperation.result sessionAttribution]];
     }
 
     TeakLog_i(@"session.identify_user", @{@"userId" : self.userId, @"timezone" : [NSString stringWithFormat:@"%f", timeZoneOffset], @"locale" : [[NSLocale preferredLanguages] objectAtIndex:0]});
@@ -469,18 +485,24 @@ DefineTeakState(Expired, (@[]));
 
 - (NSOperation*)identifyUserOperation {
   NSOperation* identifyUserOperation = [[NSInvocationOperation alloc] initWithTarget:self selector:@selector(sendUserIdentifier) object:nil];
-  if (self.launchDataOperation) {
-    [identifyUserOperation addDependency:self.launchDataOperation];
+  // Single read: launchDataOperation is atomic but can still be reassigned between the nil-check
+  // and the dependency add below.
+  TeakLaunchDataOperation* launchDataOperation = self.launchDataOperation;
+  if (launchDataOperation) {
+    [identifyUserOperation addDependency:launchDataOperation];
   }
   return identifyUserOperation;
 }
 
 - (void)processAttributionAndDispatchEvents {
-  if (self.launchDataOperation == nil || !self.launchDataOperation.finished || self.launchAttributionProcessed) return;
+  // Single read: launchDataOperation is atomic but can still be reassigned between reads, so the
+  // nil-check, .finished check, and .result use below must all see the same value.
+  TeakLaunchDataOperation* launchDataOperation = self.launchDataOperation;
+  if (launchDataOperation == nil || !launchDataOperation.finished || self.launchAttributionProcessed) return;
   self.launchAttributionProcessed = YES;
 
   // Grab the resolved launch data (it should never be nil, but let's still check)
-  TeakLaunchData* launchData = self.launchDataOperation.result;
+  TeakLaunchData* launchData = launchDataOperation.result;
   if (launchData == nil) return;
 
   if ([launchData isKindOfClass:[TeakAttributedLaunchData class]]) {


### PR DESCRIPTION
https://linear.app/teakio/issue/C-980

launchDataOperation, additionalData, emailStatus, pushStatus, smsStatus, and facebookAccessToken on `TeakSession` were nonatomic-strong and reassigned unsynchronized (mostly from the identify-reply network callback in `sendUserIdentifier`, plus facebookAccessToken from `handleEvent:`) while read elsewhere without matching locks — same freeable-pointee UAF class as C-955/956/965/971.

**Fix**: declared all six `atomic`, and captured to a local at every read site with a nil-check-then-use or multi-read sequence (launchDataOperation in `sendUserIdentifier`/`identifyUserOperation`/`processAttributionAndDispatchEvents`; facebookAccessToken in `sendUserIdentifier`). `TeakSession.m:325-328` (deep-link mutation in the same callback) is untouched — that's sdks-worker-c-973's rewrite target in a parallel PR.

**Tests**: a red→green dynamic crash-repro test per property in `RaceTripwireTests.m` for the five with freeable pointees. `launchDataOperation` instead gets a static atomic-declaration assertion in `TeakSessionLockingTests.m` — its pointee (`TeakLaunchDataOperation`, an `NSInvocationOperation` subclass) targets itself in its own initializer and never deallocates, so there's no dealloc-during-read window for a dynamic repro to catch. (That leak is real but out of scope here — raised separately as a follow-up candidate.)

Full 6-property revert-check (red on revert, green on restore) done via targeted `xcodebuild test`; full suite green (163/163).

**Proposed changelog entry** (4.3.14, skipping the yaml file per note):
> Fixed a rare multi-threaded crash (`EXC_BAD_ACCESS`) where `TeakSession`'s user-data properties (channel opt-in status, additional data, Facebook access token, launch data) could be read while being reassigned by the identify-reply callback on another thread.
