### PR TITLE
Fix logListener/onComplete cross-thread race and reward-drop race

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		DDD903E4475B291CE2D4DD1E /* TeakResolvedLinkClassificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */; };
 		F05085BD353FDBF2763B09C7 /* LiveActivityTokenForwardingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AB391C763C6BB4A6052F1D21 /* LiveActivityTokenForwardingTests.m */; };
 		F10455A046CB359057A63D58 /* TeakOperationTestDriver.m in Sources */ = {isa = PBXBuildFile; fileRef = 49655D0CF74258D769DEA6F9 /* TeakOperationTestDriver.m */; };
+		F2AD9D4D58D654A460D3A443 /* TeakRewardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6783B8283D7F4FD5B97A7B99 /* TeakRewardTests.m */; };
 		F4B9E6A620B8C3BC50CCB7CE /* libPods-Automated.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EB6801CB2EE90121E8092CE8 /* libPods-Automated.a */; };
 /* End PBXBuildFile section */
 
@@ -143,6 +144,7 @@
 		58C2AA35CD060472CAC08059 /* Pods-Automated.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automated.debug.xcconfig"; path = "Target Support Files/Pods-Automated/Pods-Automated.debug.xcconfig"; sourceTree = "<group>"; };
 		58D653263F1ED05593381DCD /* SKPaymentObserverTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SKPaymentObserverTests.m; sourceTree = "<group>"; };
 		5B90C7BE82E8BE2920587249 /* TeakResolvedLinkClassificationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakResolvedLinkClassificationTests.m; sourceTree = "<group>"; };
+		6783B8283D7F4FD5B97A7B99 /* TeakRewardTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakRewardTests.m; sourceTree = "<group>"; };
 		688EF633CE0E126980722887 /* TeakLiveActivityLaunchDataTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakLiveActivityLaunchDataTests.m; sourceTree = "<group>"; };
 		6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UserDataEventTests.m; sourceTree = "<group>"; };
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 				A858CD24B4B5AADAD2CD7719 /* TeakUserProfileAttributeQueueTests.m */,
 				2F0B163A675BB4810C732B49 /* RaceTripwireTests.m */,
 				978C851D0ADBB2D7302C5ECB /* TeakPushStateLockingTests.m */,
+				6783B8283D7F4FD5B97A7B99 /* TeakRewardTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -631,6 +634,7 @@
 				137B2D87B7DFDBCC7B5DC85A /* TeakUserProfileAttributeQueueTests.m in Sources */,
 				01DF60A7FDB4617C18BBEAE2 /* RaceTripwireTests.m in Sources */,
 				05E383DCE5E6B6B673C33275 /* TeakPushStateLockingTests.m in Sources */,
+				F2AD9D4D58D654A460D3A443 /* TeakRewardTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -259,6 +259,8 @@ static NSMutableArray* keepAliveBareSessions;
   [self raceBlockA:^{
     for (int i = 0; i < N; i++) {
       NSString* tag = [[NSString alloc] initWithFormat:@"race-loglistener-value-%d", i];
+      // Capturing tag is load-bearing: a captureless block literal is __NSGlobalBlock__
+      // (static, never heap-copied, never freed) and wouldn't reproduce the UAF at all.
       teak.logListener = ^(NSString* event, NSString* level, NSDictionary* eventData) {
         (void)tag;
       };

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -245,6 +245,36 @@ static NSMutableArray* keepAliveBareSessions;
             }];
 }
 
+// logListener's pointee is a block — a plain object once it captures data and escapes to the heap,
+// freeable like any other Objective-C object. Host apps can reassign it from any thread at any time
+// (it's the public "active log listener" property) while every SDK log call reads and invokes it on
+// its own thread — the same nonatomic-strong freeable-pointee shape as userProfile below. Touching
+// the isa via NSStringFromClass forces the same reliable class-table-lookup trap that userProfile
+// needed; invoking the block is an additional dereference through its own invoke pointer. Confirmed
+// both ways: crashes reliably with logListener reverted to nonatomic (and/or TeakLog.m's read
+// reverted to calling the getter twice), clean with atomic + single-read capture restored.
+- (void)testLogListenerIsAtomicUnderConcurrency {
+  Teak* teak = [[Teak alloc] init];
+  const int N = 2000000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      NSString* tag = [[NSString alloc] initWithFormat:@"race-loglistener-value-%d", i];
+      teak.logListener = ^(NSString* event, NSString* level, NSDictionary* eventData) {
+        (void)tag;
+      };
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                TeakLogListener listener = teak.logListener;
+                if (listener) {
+                  (void)NSStringFromClass([listener class]).length;
+                  listener(@"race", @"INFO", nil);
+                }
+              }
+            }];
+}
+
 // userProfile's pointee is a plain object, not a CFString — reading .stringAttributes.count alone
 // wasn't a reliable enough dereference to reproduce (freed memory quickly reused by the next
 // same-shaped allocation reads back as "valid"); touching the isa via NSStringFromClass forces a

--- a/Automated/AutomatedTests/TeakRewardTests.m
+++ b/Automated/AutomatedTests/TeakRewardTests.m
@@ -33,11 +33,10 @@ extern TeakSession* currentSession;
   [super tearDown];
 }
 
-// Regression guard for C-974/C-976: onCompleteWithReward must already be set by the
-// time rewardForRewardId:onComplete: returns — assigned before whenUserIdIsReadyRun:
-// is even called, so there is no window for a fast network reply to beat the
-// assignment (the old +rewardForRewardId: + post-hoc `.onComplete =` pattern had
-// exactly that window).
+// onCompleteWithReward must already be set by the time rewardForRewardId:onComplete:
+// returns — assigned before whenUserIdIsReadyRun: is even called, so there is no
+// window for a fast network reply to beat the assignment (the old +rewardForRewardId:
+// + post-hoc `.onComplete =` pattern had exactly that window).
 - (void)testOnCompleteWithRewardIsAssignedBeforeAnyDispatch {
   __block BOOL fired = NO;
   TeakReward* reward = [TeakReward rewardForRewardId:@"reward-1"
@@ -70,13 +69,10 @@ extern TeakSession* currentSession;
   XCTAssertEqual(reward.rewardStatus, kTeakRewardStatusUnknown);
 }
 
-// The deprecated single-arg factory is kept for source/binary compatibility (TeakReward.h
+// The single-arg factory is kept for source/binary compatibility (TeakReward.h
 // is a shipped public header) and must keep working exactly as before.
-- (void)testDeprecatedRewardForRewardIdStillConstructsAReward {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (void)testLegacyRewardForRewardIdStillConstructsAReward {
   TeakReward* reward = [TeakReward rewardForRewardId:@"reward-1"];
-#pragma clang diagnostic pop
 
   XCTAssertNotNil(reward);
   XCTAssertFalse(reward.completed);

--- a/Automated/AutomatedTests/TeakRewardTests.m
+++ b/Automated/AutomatedTests/TeakRewardTests.m
@@ -1,0 +1,86 @@
+#import <XCTest/XCTest.h>
+
+#import "TeakReward.h"
+#import "TeakSession.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// The session pointer that whenUserIdIsReadyRun: reads. Kept nil here so
+// rewardForRewardId:onComplete:'s internal whenUserIdIsReadyRun: call only
+// enqueues its block instead of dispatching a real network request.
+extern TeakSession* currentSession;
+
+// onCompleteWithReward is private (declared only in TeakReward.m's class extension);
+// re-exposed here per the project convention of redeclaring internal properties in
+// the test file rather than importing Teak+Internal.h.
+@interface TeakReward (RewardTests)
+@property (nonatomic, copy, readonly) RewardCompletedWithReward onCompleteWithReward;
+@end
+
+@interface TeakRewardTests : XCTestCase
+@end
+
+@implementation TeakRewardTests
+
+- (void)setUp {
+  currentSession = nil;
+}
+
+- (void)tearDown {
+  currentSession = nil;
+  [super tearDown];
+}
+
+// Regression guard for C-974/C-976: onCompleteWithReward must already be set by the
+// time rewardForRewardId:onComplete: returns — assigned before whenUserIdIsReadyRun:
+// is even called, so there is no window for a fast network reply to beat the
+// assignment (the old +rewardForRewardId: + post-hoc `.onComplete =` pattern had
+// exactly that window).
+- (void)testOnCompleteWithRewardIsAssignedBeforeAnyDispatch {
+  __block BOOL fired = NO;
+  TeakReward* reward = [TeakReward rewardForRewardId:@"reward-1"
+                                           onComplete:^(TeakReward* r) {
+                                             fired = YES;
+                                           }];
+
+  XCTAssertNotNil(reward);
+  XCTAssertNotNil(reward.onCompleteWithReward,
+                  @"onCompleteWithReward must be assigned synchronously inside the factory");
+
+  reward.onCompleteWithReward(reward);
+  XCTAssertTrue(fired, @"the assigned callback must be the one passed in");
+}
+
+- (void)testRewardForRewardIdOnCompleteReturnsNilForNilRewardId {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+  XCTAssertNil([TeakReward rewardForRewardId:nil onComplete:nil]);
+#pragma clang diagnostic pop
+}
+
+- (void)testRewardForRewardIdOnCompleteReturnsNilForEmptyRewardId {
+  XCTAssertNil([TeakReward rewardForRewardId:@"" onComplete:nil]);
+}
+
+- (void)testRewardForRewardIdOnCompleteInitializesUnclaimedState {
+  TeakReward* reward = [TeakReward rewardForRewardId:@"reward-1" onComplete:nil];
+  XCTAssertFalse(reward.completed);
+  XCTAssertEqual(reward.rewardStatus, kTeakRewardStatusUnknown);
+}
+
+// The deprecated single-arg factory is kept for source/binary compatibility (TeakReward.h
+// is a shipped public header) and must keep working exactly as before.
+- (void)testDeprecatedRewardForRewardIdStillConstructsAReward {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  TeakReward* reward = [TeakReward rewardForRewardId:@"reward-1"];
+#pragma clang diagnostic pop
+
+  XCTAssertNotNil(reward);
+  XCTAssertFalse(reward.completed);
+  XCTAssertEqual(reward.rewardStatus, kTeakRewardStatusUnknown);
+}
+
+@end

--- a/Teak/Teak.h
+++ b/Teak/Teak.h
@@ -169,7 +169,7 @@ typedef void (^TeakLogListener)(NSString* _Nonnull event,
 /**
  * The active log listener
  */
-@property (copy, nonatomic) TeakLogListener _Nullable logListener;
+@property (copy, atomic) TeakLogListener _Nullable logListener;
 
 /**
  * Set up Teak in a single function call.

--- a/Teak/TeakLog.m
+++ b/Teak/TeakLog.m
@@ -187,8 +187,9 @@ __attribute__((overloadable)) void TeakLog_i(NSString* eventType, NSString* mess
   }
 
   // Log to the log listener
-  if (self.teak.logListener) {
-    self.teak.logListener(eventType, logLevel, payload);
+  TeakLogListener logListener = self.teak.logListener;
+  if (logListener) {
+    logListener(eventType, logLevel, payload);
   }
 
   // Log remotely

--- a/Teak/TeakReward.h
+++ b/Teak/TeakReward.h
@@ -13,11 +13,17 @@ typedef enum : int {
 
 typedef void (^RewardCompleted)(void);
 
+@class TeakReward;
+typedef void (^RewardCompletedWithReward)(TeakReward* _Nonnull reward);
+
 @interface TeakReward : NSObject
 @property (atomic, readonly) BOOL completed;
 @property (nonatomic, readonly) int rewardStatus;
 @property (strong, nonatomic, readonly) NSDictionary* _Nonnull json;
-@property (nonatomic, copy) RewardCompleted _Nullable onComplete;
+@property (nonatomic, copy) RewardCompleted _Nullable onComplete
+    __deprecated_msg("Assigning this after rewardForRewardId: returns races the network reply. Use rewardForRewardId:onComplete: instead.");
 
-+ (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId;
++ (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId
+    __deprecated_msg("Races onComplete assignment against the network reply. Use rewardForRewardId:onComplete: instead.");
++ (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId onComplete:(nullable RewardCompletedWithReward)onComplete;
 @end

--- a/Teak/TeakReward.h
+++ b/Teak/TeakReward.h
@@ -20,10 +20,8 @@ typedef void (^RewardCompletedWithReward)(TeakReward* _Nonnull reward);
 @property (atomic, readonly) BOOL completed;
 @property (nonatomic, readonly) int rewardStatus;
 @property (strong, nonatomic, readonly) NSDictionary* _Nonnull json;
-@property (nonatomic, copy) RewardCompleted _Nullable onComplete
-    __deprecated_msg("Assigning this after rewardForRewardId: returns races the network reply. Use rewardForRewardId:onComplete: instead.");
+@property (nonatomic, copy) RewardCompleted _Nullable onComplete;
 
-+ (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId
-    __deprecated_msg("Races onComplete assignment against the network reply. Use rewardForRewardId:onComplete: instead.");
++ (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId;
 + (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId onComplete:(nullable RewardCompletedWithReward)onComplete;
 @end

--- a/Teak/TeakReward.m
+++ b/Teak/TeakReward.m
@@ -9,6 +9,7 @@
 @property (atomic, readwrite) BOOL completed;
 @property (nonatomic, readwrite) int rewardStatus;
 @property (strong, nonatomic, readwrite) NSDictionary* json;
+@property (nonatomic, copy) RewardCompletedWithReward onCompleteWithReward;
 
 @end
 
@@ -23,6 +24,10 @@
 }
 
 + (TeakReward*)rewardForRewardId:(NSString*)teakRewardId {
+  return [self rewardForRewardId:teakRewardId onComplete:nil];
+}
+
++ (TeakReward*)rewardForRewardId:(NSString*)teakRewardId onComplete:(RewardCompletedWithReward)onComplete {
   if (teakRewardId == nil || teakRewardId.length == 0) {
     TeakLog_e(@"reward.error", @"teakRewardId must not be nil or empty");
     return nil;
@@ -31,6 +36,9 @@
   TeakReward* ret = [[TeakReward alloc] init];
   ret.completed = NO;
   ret.rewardStatus = kTeakRewardStatusUnknown;
+  // Assigned synchronously, before the request below is even dispatched, so there is
+  // no window for the network reply to beat this assignment (C-974/C-976).
+  ret.onCompleteWithReward = onComplete;
 
   [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
     NSString* urlString = [NSString stringWithFormat:@"/%@/clicks", teakRewardId];
@@ -83,8 +91,15 @@
 
                                                     ret.completed = YES;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                                                     if (ret.onComplete != nil) {
                                                       ret.onComplete();
+                                                    }
+#pragma clang diagnostic pop
+
+                                                    if (ret.onCompleteWithReward != nil) {
+                                                      ret.onCompleteWithReward(ret);
                                                     }
                                                   }];
     [request send];

--- a/Teak/TeakReward.m
+++ b/Teak/TeakReward.m
@@ -37,7 +37,7 @@
   ret.completed = NO;
   ret.rewardStatus = kTeakRewardStatusUnknown;
   // Assigned synchronously, before the request below is even dispatched, so there is
-  // no window for the network reply to beat this assignment (C-974/C-976).
+  // no window for the network reply to beat this assignment.
   ret.onCompleteWithReward = onComplete;
 
   [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
@@ -91,15 +91,14 @@
 
                                                     ret.completed = YES;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                                                    if (ret.onComplete != nil) {
-                                                      ret.onComplete();
+                                                    RewardCompleted legacyCompletion = ret.onComplete;
+                                                    if (legacyCompletion != nil) {
+                                                      legacyCompletion();
                                                     }
-#pragma clang diagnostic pop
 
-                                                    if (ret.onCompleteWithReward != nil) {
-                                                      ret.onCompleteWithReward(ret);
+                                                    RewardCompletedWithReward completionWithReward = ret.onCompleteWithReward;
+                                                    if (completionWithReward != nil) {
+                                                      completionWithReward(ret);
                                                     }
                                                   }];
     [request send];

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -781,23 +781,19 @@ DefineTeakState(Expired, (@[]));
 + (void)checkLaunchDataForRewardAndDispatchEvents:(nonnull TeakAttributedLaunchData*)launchData {
   if (launchData.rewardId == nil) return;
 
-  TeakReward* reward = [TeakReward rewardForRewardId:launchData.rewardId];
-  if (reward == nil) return;
+  [TeakReward rewardForRewardId:launchData.rewardId
+                     onComplete:^(TeakReward* reward) {
+                       if (reward.json != nil) {
+                         NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] initWithDictionary:[launchData to_h]];
+                         [userInfo addEntriesFromDictionary:reward.json];
 
-  __weak TeakReward* tempWeakReward = reward;
-  reward.onComplete = ^() {
-    __strong TeakReward* blockReward = tempWeakReward;
-    if (blockReward.json != nil) {
-      NSMutableDictionary* userInfo = [[NSMutableDictionary alloc] initWithDictionary:[launchData to_h]];
-      [userInfo addEntriesFromDictionary:blockReward.json];
-
-      [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:TeakOnReward
-                                                            object:session
-                                                          userInfo:userInfo];
-      }];
-    }
-  };
+                         [TeakSession whenUserIdIsReadyRun:^(TeakSession* session) {
+                           [[NSNotificationCenter defaultCenter] postNotificationName:TeakOnReward
+                                                                               object:session
+                                                                             userInfo:userInfo];
+                         }];
+                       }
+                     }];
 }
 
 + (void)checkLaunchDataForNotificationAndDispatchEvents:(nonnull TeakAttributedLaunchData*)launchData {


### PR DESCRIPTION
Fixes two related races in host-settable callback fields, both landing in one PR since they share a root cause.

https://linear.app/teakio/issue/C-974
https://linear.app/teakio/issue/C-976

## C-974: Teak.logListener cross-thread UAF
`logListener` is `nonatomic copy` but host-settable from any thread while every SDK log call reads it from arbitrary threads — a freeable-pointee UAF. Switched to `atomic` and closed the check-then-call gap in `TeakLog.m` by capturing the read into a single local.

## C-976: TeakReward.onComplete drops rewards
`+rewardForRewardId:` assigns `onComplete` *after* dispatching the network request, so a fast reply can beat the assignment and silently drop `TeakOnReward` (reward never shows). `TeakReward.h` is a shipped public header, so the existing signature can't change in a patch release. Added `+rewardForRewardId:onComplete:` (new `RewardCompletedWithReward` block, reward passed as a param) that assigns the completion synchronously before any async dispatch — no window for the reply to win. The reply handler fires whichever completion is set, each captured to a local before invoking (closes a check-then-call double-read in that path). `TeakSession` switched to the new method (and dropped its `__weak`/`__strong` dance, no longer needed since the reward now arrives as the block's own parameter).

`+rewardForRewardId:`, `onComplete`, and `RewardCompleted` are kept fully intact and undeprecated — no `__deprecated_msg`, since that would break a `-Werror=deprecated-declarations` host on a patch update. Formal deprecation is a minor-release concern, tracked separately.

**Conscious partial close:** `onComplete` itself stays `nonatomic copy` in this patch, so a host reassigning it concurrently is still a freeable-pointee UAF risk (the same class `logListener` fixes elsewhere in this PR) — just narrower, since it also requires hitting the reply-handler's read at the wrong moment. Fixing that fully means making `onComplete` atomic plus a dynamic crash-repro to verify it, which belongs with the broader `onComplete` API rework rather than this patch.

## Testing
- New `testLogListenerIsAtomicUnderConcurrency` (dynamic crash-repro race guard per `Automated/RACE_TESTING.md` — TSan is blind to nonatomic-strong UAFs). Revert-checked: red on nonatomic, green on atomic.
- New `TeakRewardTests.m`: assign-before-dispatch invariant, back-compat of the legacy factory.
- Full `fastlane test` passes clean.

## Proposed changelog entry (4.3.14)
Fix a rare race where a host-set reward or log-listener callback could be dropped or crash under concurrent access.
