### PR TITLE
Fix TeakBatchedRequest cancel/append/iterate race (silent event drop + off-lock enumerate)

### DIFF
--- a/Automated/Automated.xcodeproj/project.pbxproj
+++ b/Automated/Automated.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		97323CF5B3B2B4A49C9C8B78 /* UserDataEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */; };
 		97EDAA942157436DCC939EC2 /* LiveActivityUpdateCancellationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E3C947C03B892266BFC39FBA /* LiveActivityUpdateCancellationTests.m */; };
 		AB45EA094468C6D3E9E23B3E /* TeakRequestResponseParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 068757CAA89B4CEADFCD522C /* TeakRequestResponseParsingTests.m */; };
+		B5349939B6EA4ADBB1C2F337 /* TeakBatchedRequestRaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71FBE616F0BBB83E3D45ABC1 /* TeakBatchedRequestRaceTests.m */; };
 		B731D0BCE8646D60DCD428A5 /* Teak.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9225DEADC25983AF315554 /* Teak.framework */; };
 		B769F6EA7491B32A42FBB3E3 /* TeakDeviceConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12B44A19FD44C70C575E9A8B /* TeakDeviceConfigurationTests.m */; };
 		BF20EAD8B0CC8F23483B6FF0 /* Pods_AutomatedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9598B14D3B84355AFA2A5E3 /* Pods_AutomatedTests.framework */; };
@@ -149,6 +150,7 @@
 		6A2BD9B7EEAF70309185B446 /* UserDataEventTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = UserDataEventTests.m; sourceTree = "<group>"; };
 		6B7A960ECDD5D5D7E3CB6A8E /* Pods-AutomatedUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutomatedUITests.debug.xcconfig"; path = "Target Support Files/Pods-AutomatedUITests/Pods-AutomatedUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		6C6CFC4895D0BF30D04BAE1B /* TeakOperationTestDriver.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TeakOperationTestDriver.h; sourceTree = "<group>"; };
+		71FBE616F0BBB83E3D45ABC1 /* TeakBatchedRequestRaceTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakBatchedRequestRaceTests.m; sourceTree = "<group>"; };
 		741732706353CEBB41D0AE37 /* LiveActivityUpdateSchedulingTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = LiveActivityUpdateSchedulingTests.m; sourceTree = "<group>"; };
 		7520CCFA85F3D201187FC76C /* NotificationSettingsTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = NotificationSettingsTests.m; sourceTree = "<group>"; };
 		864427BAEA58D0DAC8B50E43 /* TeakAttributedLaunchDataEnrichmentTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TeakAttributedLaunchDataEnrichmentTests.m; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				2F0B163A675BB4810C732B49 /* RaceTripwireTests.m */,
 				978C851D0ADBB2D7302C5ECB /* TeakPushStateLockingTests.m */,
 				6783B8283D7F4FD5B97A7B99 /* TeakRewardTests.m */,
+				71FBE616F0BBB83E3D45ABC1 /* TeakBatchedRequestRaceTests.m */,
 			);
 			path = AutomatedTests;
 			sourceTree = "<group>";
@@ -635,6 +638,7 @@
 				01DF60A7FDB4617C18BBEAE2 /* RaceTripwireTests.m in Sources */,
 				05E383DCE5E6B6B673C33275 /* TeakPushStateLockingTests.m in Sources */,
 				F2AD9D4D58D654A460D3A443 /* TeakRewardTests.m in Sources */,
+				B5349939B6EA4ADBB1C2F337 /* TeakBatchedRequestRaceTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
+++ b/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
@@ -265,23 +265,59 @@ static NSMutableArray<NSArray*>* raceTest_sentBatchSnapshots;
 // outside those methods, which no production caller ever performs (.sent is
 // a private, nonatomic property; every real access already holds the
 // instance lock) and would race regardless of this fix. Green with the read
-// properly nested under the instance lock, red (TSan race report) if that
-// nesting is reverted.
+// properly nested under the instance lock, red (TSan race report or crash)
+// if that nesting is reverted.
+//
+// This also happens to be the only local repro we have for a second,
+// previously-unknown bug in the same method: `return currentBatch;` sits
+// OUTSIDE the @synchronized block, so the implicit ARC retain on return can
+// race a concurrent reassignment and retain-past-zero a freed instance. That
+// bug is pre-existing (not introduced by the .sent-locking fix above) and is
+// fixed by snapshotting the return value under the lock.
+//
+// Reliability: 8 concurrent threads (= physical performance-core count --
+// the largest safe without a busy-spin rendezvous oversubscribing the
+// machine under TSan overhead) x N=20000 iterations/thread reds at p=0.90
+// per round (18/20 independent single-round samples against the reverted
+// code; Wilson 95% CI lower bound ~0.70). ROUNDS=5 independent rounds in one
+// test method -> aggregate red-rate = 1-(1-p)^ROUNDS: 99.76% at the
+// conservative 0.70 floor, 99.999% at the measured 0.90 point estimate --
+// clears a >=99% target either way. halt_on_error=0 (see the test_race lane)
+// means a TSan report alone doesn't abort the process, but this bug's
+// downstream retain-past-zero crashes shortly after regardless, so one red
+// round is enough; a crash ends the test outright and a non-crashing report
+// still fails the run via Xcode's own TSan/XCTest integration.
 - (void)testCurrentBatchForSessionSentReadIsSerializedUnderConcurrency {
   TeakSession* session = [self makeMockSession];
-  const int N = 8000;
+  const int THREADS = 8;
+  const int N = 20000;
+  const int ROUNDS = 5;
 
-  [self raceBlockA:^{
-    for (int i = 0; i < N; i++) {
-      TeakTrackEventBatchedRequest* batch = [TeakTrackEventBatchedRequest currentBatchForSession:session];
-      [batch prepareAndSend];
+  for (int round = 0; round < ROUNDS; round++) {
+    dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+    dispatch_group_t group = dispatch_group_create();
+    for (int t = 0; t < THREADS; t++) {
+      BOOL constructor = (t % 2 == 0);
+      dispatch_group_async(group, q, ^{
+        for (int i = 0; i < N; i++) {
+          TeakTrackEventBatchedRequest* batch = [TeakTrackEventBatchedRequest currentBatchForSession:session];
+          if (constructor) {
+            [batch prepareAndSend];
+          }
+        }
+      });
     }
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+
+    // currentBatchForSession:'s backing store is a function-local static --
+    // not reachable from outside the method it's declared in, even from
+    // elsewhere in this file -- so it can't be reset directly between
+    // rounds. Force the round's live batch to .sent=YES instead, so the next
+    // round's first call reliably takes the construct path fresh rather than
+    // depending on whichever thread happened to touch it last.
+    TeakTrackEventBatchedRequest* trailingBatch = [TeakTrackEventBatchedRequest currentBatchForSession:session];
+    [trailingBatch prepareAndSend];
   }
-            blockB:^{
-              for (int i = 0; i < N; i++) {
-                [TeakTrackEventBatchedRequest currentBatchForSession:session];
-              }
-            }];
 }
 
 #pragma mark - S4: the reply callback loop must be serialized against addRequestIntoBatch:'s append

--- a/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
+++ b/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
@@ -254,6 +254,89 @@ static NSMutableArray<NSArray*>* raceTest_sentBatchSnapshots;
   XCTAssertEqual(transmitted.count, (NSUInteger)2, @"both payloads must be present in what was actually transmitted -- a dropped one means the cancel+append race reopened");
 }
 
+// Complementary to the append-wins ordering above: the opposite outcome,
+// where -sendNow wins the race and fully completes before
+// -addRequestIntoBatch: gets a chance to append. cancel() then correctly
+// returns NO, and the payload must not be dropped -- it re-routes into a
+// fresh batch via +batchRequestWithSession: instead. This is the literal "no
+// silent drop" guarantee for that branch, forced with the same
+// pause-after-cancel hook as the test above, this time armed on sendNow's own
+// internal -cancel call: while it's paused (already decided to proceed with
+// the send, but not yet done so), a concurrent -addRequestIntoBatch: call for
+// the same batch blocks on the batch's instance lock -- both hold it for
+// their entire operation, so append #2 can't even start evaluating its own
+// cancel() until sendNow's paused thread releases. Only once the pause
+// resolves and sendNow finishes (setting .sent) does append #2 get the lock,
+// see the batch already sent, and take the reroute path.
+- (void)testAddRequestIntoBatchReroutesPayloadWhenSendNowWinsRace {
+  TeakSession* session = [self makeMockSession];
+
+  // currentBatchForSession:'s backing store is a function-local static shared
+  // across every test in this file (see the S2 test below) -- force whatever
+  // it's currently holding to a sent state so the reroute this test drives is
+  // guaranteed to construct a fresh batch, independent of test run order.
+  [[TeakTrackEventBatchedRequest currentBatchForSession:session] prepareAndSend];
+  [raceTest_sentBatchSnapshots removeAllObjects];
+
+  TeakTrackEventBatchedRequest* batch = [[TeakTrackEventBatchedRequest alloc] initWithSession:session];
+
+  [TeakTrackEventBatchedRequest addRequestIntoBatch:batch
+                                         withSession:session
+                                         forEndpoint:@"/me/events"
+                                         withPayload:@{@"action_type" : @"race", @"object_type" : @"first"}
+                                         andCallback:nil];
+  XCTAssertFalse(batch.sent, @"first append should only schedule, not send immediately");
+
+  __block TeakBatchedRequest* result;
+  __block BOOL callbackInvoked = NO;
+  XCTestExpectation* sendNowDone = [self expectationWithDescription:@"sendNow completed"];
+  XCTestExpectation* appendDone = [self expectationWithDescription:@"append #2 completed"];
+
+  [TeakBatchedRequest raceTest_armPauseAfterNextCancel];
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [batch sendNow];
+    [sendNowDone fulfill];
+  });
+
+  long cancelHappened = dispatch_semaphore_wait(raceTest_cancelHappenedSem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)));
+  XCTAssertEqual(cancelHappened, 0L, @"sendNow's -cancel should have run and signalled by now");
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    result = [TeakTrackEventBatchedRequest addRequestIntoBatch:batch
+                                                     withSession:session
+                                                     forEndpoint:@"/me/events"
+                                                     withPayload:@{@"action_type" : @"race", @"object_type" : @"second"}
+                                                     andCallback:^(NSDictionary* reply) {
+                                                       callbackInvoked = YES;
+                                                     }];
+    [appendDone fulfill];
+  });
+
+  // append #2 needs the same instance lock sendNow is holding while paused --
+  // it must still be blocked (not even returned) a moment later. Red here
+  // (result already set) means the two are NOT mutually exclusive.
+  usleep(200000);
+  XCTAssertNil(result, @"append #2 must stay blocked on the batch's lock while sendNow is atomically in-flight");
+
+  dispatch_semaphore_signal(raceTest_proceedSem);
+
+  [self waitForExpectations:@[sendNowDone, appendDone] timeout:5.0];
+
+  XCTAssertTrue(batch.sent, @"sendNow should have completed the send");
+  XCTAssertNotNil(result, @"payload must land somewhere, not be silently dropped when sendNow wins the race");
+  XCTAssertNotEqual(result, (TeakBatchedRequest*)batch, @"the already-sent batch cannot accept the new payload -- a fresh batch must be returned");
+  XCTAssertFalse(result.sent, @"the fresh, rerouted batch should only schedule, not send immediately");
+
+  [result sendNow];
+  result.callback(@{});
+
+  XCTAssertEqual(raceTest_sentBatchSnapshots.count, (NSUInteger)2, @"both the original send and the rerouted payload's batch should transmit, exactly once each");
+  NSArray* reroutedTransmitted = raceTest_sentBatchSnapshots.lastObject;
+  XCTAssertEqual(reroutedTransmitted.count, (NSUInteger)1, @"the rerouted payload must be present, alone, in what was actually transmitted");
+  XCTAssertTrue(callbackInvoked, @"the callback registered on the rerouted call must still fire");
+}
+
 #pragma mark - S2: currentBatchForSession:'s .sent read must be serialized against -prepareAndSend's write
 
 // .sent is written under the instance lock (-prepareAndSend) but was read

--- a/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
+++ b/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
@@ -32,6 +32,7 @@ extern NSDictionary* TeakVersionDict;
 - (BOOL)cancel;
 - (void)sendNow;
 - (void)prepareAndSend;
+- (void)reallyActuallySend;
 
 + (nullable TeakBatchedRequest*)addRequestIntoBatch:(nonnull TeakBatchedRequest*)batchedRequest
                                          withSession:(nonnull TeakSession*)session

--- a/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
+++ b/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
@@ -1,0 +1,317 @@
+#import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+#import <stdatomic.h>
+
+#import "TeakAppConfiguration.h"
+#import "TeakDeviceConfiguration.h"
+#import "TeakRemoteConfiguration.h"
+#import "TeakRequest.h"
+#import "TeakSession.h"
+#import <Teak/Teak.h>
+
+@import OCHamcrest;
+@import OCMockito;
+
+// Set by Teak.m's +initForApplicationId:... flow; TeakRequest's common-payload
+// construction reads it directly (extern, not via a session/config object), and
+// a bare unit test never runs that flow. Declared here so -setUp can seed it --
+// leaving it nil would make -initWithSession:... throw (nil value in a
+// dictionary literal) the first time this file runs before anything else in
+// the process has triggered that flow.
+extern NSDictionary* TeakVersionDict;
+
+// TeakBatchedRequest / TeakTrackEventBatchedRequest are private classes declared
+// only inside TeakRequest.m; re-declare their shape here so the test can drive
+// the real class/instance methods directly, per the project convention (see
+// RaceTripwireTests.m's TeakRavenReport re-declaration).
+@interface TeakBatchedRequest : TeakRequest
+@property (nonatomic) BOOL sent;
+@property (strong, nonatomic) NSMutableArray* callbacks;
+@property (strong, nonatomic) NSMutableArray* batchContents;
+
+- (BOOL)cancel;
+- (void)sendNow;
+- (void)prepareAndSend;
+
++ (nullable TeakBatchedRequest*)addRequestIntoBatch:(nonnull TeakBatchedRequest*)batchedRequest
+                                         withSession:(nonnull TeakSession*)session
+                                         forEndpoint:(nonnull NSString*)endpoint
+                                         withPayload:(nonnull NSDictionary*)payload
+                                         andCallback:(nullable TeakRequestResponse)callback;
+@end
+
+@interface TeakTrackEventBatchedRequest : TeakBatchedRequest
+- (nonnull TeakBatchedRequest*)initWithSession:(nonnull TeakSession*)session;
++ (nonnull TeakTrackEventBatchedRequest*)currentBatchForSession:(nonnull TeakSession*)session;
+@end
+
+// Test-only swizzles on the real (production) -cancel and -reallyActuallySend.
+//
+// -cancel: when armed via +raceTest_armPauseAfterNextCancel, the NEXT call
+// (and only that one) signals raceTest_cancelHappenedSem right after running
+// the real cancel logic, then blocks (bounded) on raceTest_proceedSem. This
+// forces a real second thread's call into the exact window a standalone
+// -cancel-then-later-@synchronized gap would leave open, without needing two
+// copies of the source to compare -- the same test runs red against the old
+// shape and green against the fix.
+//
+// -reallyActuallySend: captures an immutable snapshot of what was actually
+// about to transmit (self.payload[@"batch"], copied at this exact synchronous
+// point, before any further mutation) instead of hitting the network. Reading
+// batchContents.count after the fact can't tell late-appended-but-dropped
+// apart from actually-sent, since payload["batch"] aliases the same array;
+// this is the one point where "about to send" is unambiguous.
+static dispatch_semaphore_t raceTest_cancelHappenedSem;
+static dispatch_semaphore_t raceTest_proceedSem;
+static BOOL raceTest_pauseArmed;
+static NSMutableArray<NSArray*>* raceTest_sentBatchSnapshots;
+
+@interface TeakBatchedRequest (RaceTest)
++ (void)raceTest_armPauseAfterNextCancel;
+- (BOOL)raceTest_cancel;
+- (void)raceTest_reallyActuallySend;
+@end
+
+@implementation TeakBatchedRequest (RaceTest)
+
++ (void)raceTest_armPauseAfterNextCancel {
+  raceTest_pauseArmed = YES;
+}
+
+- (BOOL)raceTest_cancel {
+  // Post-swizzle, this selector is the ORIGINAL -cancel implementation.
+  BOOL result = [self raceTest_cancel];
+  if (raceTest_pauseArmed) {
+    raceTest_pauseArmed = NO;
+    dispatch_semaphore_signal(raceTest_cancelHappenedSem);
+    dispatch_semaphore_wait(raceTest_proceedSem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)));
+  }
+  return result;
+}
+
+- (void)raceTest_reallyActuallySend {
+  NSArray* snapshot = [self.payload[@"batch"] copy];
+  @synchronized(raceTest_sentBatchSnapshots) {
+    [raceTest_sentBatchSnapshots addObject:snapshot];
+  }
+  // Deliberately do not call through -- no real network traffic from this test.
+}
+
+@end
+
+@interface TeakBatchedRequestRaceTests : XCTestCase
+@end
+
+@implementation TeakBatchedRequestRaceTests
+
+#pragma mark - Swizzle install/remove
+
++ (void)swizzleSelector:(SEL)a withSelector:(SEL)b onClass:(Class)cls {
+  Method ma = class_getInstanceMethod(cls, a);
+  Method mb = class_getInstanceMethod(cls, b);
+  method_exchangeImplementations(ma, mb);
+}
+
+- (void)setUp {
+  TeakVersionDict = @{@"sdk_version" : @"4.3.13-test"};
+  raceTest_cancelHappenedSem = dispatch_semaphore_create(0);
+  raceTest_proceedSem = dispatch_semaphore_create(0);
+  raceTest_pauseArmed = NO;
+  raceTest_sentBatchSnapshots = [NSMutableArray array];
+
+  Class cls = NSClassFromString(@"TeakBatchedRequest");
+  [TeakBatchedRequestRaceTests swizzleSelector:@selector(cancel) withSelector:@selector(raceTest_cancel) onClass:cls];
+  [TeakBatchedRequestRaceTests swizzleSelector:@selector(reallyActuallySend) withSelector:@selector(raceTest_reallyActuallySend) onClass:cls];
+}
+
+- (void)tearDown {
+  Class cls = NSClassFromString(@"TeakBatchedRequest");
+  [TeakBatchedRequestRaceTests swizzleSelector:@selector(cancel) withSelector:@selector(raceTest_cancel) onClass:cls];
+  [TeakBatchedRequestRaceTests swizzleSelector:@selector(reallyActuallySend) withSelector:@selector(raceTest_reallyActuallySend) onClass:cls];
+}
+
+#pragma mark - Fixtures
+
+// A batch large enough (count) and slow enough (time) that appends in these
+// tests schedule rather than send immediately -- only an explicit -sendNow or
+// hitting the count limit triggers a real -prepareAndSend.
+- (TeakSession*)makeMockSession {
+  TeakAppConfiguration* appConfig = mock([TeakAppConfiguration class]);
+  [given([appConfig appId]) willReturn:@"test-app-id"];
+  [given([appConfig appVersion]) willReturn:@"1"];
+  [given([appConfig appVersionName]) willReturn:@"1.0.0"];
+  [given([appConfig bundleId]) willReturn:@"io.teak.test"];
+  [given([appConfig isProduction]) willReturn:@NO];
+
+  TeakDeviceConfiguration* deviceConfig = mock([TeakDeviceConfiguration class]);
+  [given([deviceConfig platformString]) willReturn:@"iOS"];
+  [given([deviceConfig deviceModel]) willReturn:@"iPhone-test"];
+  [given([deviceConfig deviceId]) willReturn:@"test-device-id"];
+
+  TeakRemoteConfiguration* remoteConfig = mock([TeakRemoteConfiguration class]);
+  NSDictionary* endpointConfigurations = @{
+    @"gocarrot.com" : @{
+      @"/me/events" : @{
+        @"batch" : @{@"count" : @100000, @"time" : @60.0}
+      }
+    }
+  };
+  [given([remoteConfig endpointConfigurations]) willReturn:endpointConfigurations];
+  [given([remoteConfig dynamicParameters]) willReturn:@{}];
+
+  TeakSession* session = mock([TeakSession class]);
+  [given([session appConfiguration]) willReturn:appConfig];
+  [given([session deviceConfiguration]) willReturn:deviceConfig];
+  [given([session remoteConfiguration]) willReturn:remoteConfig];
+  [given([session userId]) willReturn:nil];
+
+  return session;
+}
+
+// Spin-barrier rendezvous (same technique as RaceTripwireTests.m's
+// raceBlockA:blockB:): both blocks arrive, then bust out together so short
+// loops still overlap for their full duration.
+- (void)raceBlockA:(void (^)(void))a blockB:(void (^)(void))b {
+  dispatch_queue_t q = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+  dispatch_group_t group = dispatch_group_create();
+  _Atomic(int)* ready = calloc(1, sizeof(_Atomic(int)));
+  void (^rendezvous)(void) = ^{
+    atomic_fetch_add(ready, 1);
+    while (atomic_load(ready) < 2) {
+    }
+  };
+  dispatch_group_async(group, q, ^{ rendezvous(); a(); });
+  dispatch_group_async(group, q, ^{ rendezvous(); b(); });
+  dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+  free(ready);
+}
+
+#pragma mark - S1: addRequestIntoBatch: cancel+append must be atomic vs. a concurrent sendNow
+
+// Forced-interleaving repro for the cancel/append/sendNow race (dropped-request
+// ordering bug -- no crash/TSan signal per RACE_TESTING.md, so this drives the
+// real -cancel/-addRequestIntoBatch:/-sendNow and forces the exact old gap with
+// a test-only pause rather than hoping a hammer loop hits the window.
+//
+// Sequence: append payload #1 normally (schedules a real dispatch_after send).
+// Arm the pause, then on a background thread append payload #2 -- its -cancel
+// call (real production code) fires, then blocks. While it's blocked, drive
+// -sendNow (the exact call the KVO currentState observer makes) on a second
+// thread and confirm it does NOT complete while payload #2's append is
+// in-flight -- that's the atomicity the fix provides. Release the pause, let
+// both finish, then assert the transmitted snapshot (captured by the
+// -reallyActuallySend swizzle, immune to the batchContents/payload aliasing
+// that would otherwise hide a late, too-late append) contains both payloads.
+- (void)testAddRequestIntoBatchDoesNotDropPayloadRacingSendNow {
+  TeakSession* session = [self makeMockSession];
+  TeakTrackEventBatchedRequest* batch = [[TeakTrackEventBatchedRequest alloc] initWithSession:session];
+
+  [TeakTrackEventBatchedRequest addRequestIntoBatch:batch
+                                         withSession:session
+                                         forEndpoint:@"/me/events"
+                                         withPayload:@{@"action_type" : @"race", @"object_type" : @"first"}
+                                         andCallback:nil];
+  XCTAssertFalse(batch.sent, @"first append should only schedule, not send immediately");
+
+  __block BOOL sendNowReturned = NO;
+  XCTestExpectation* appendDone = [self expectationWithDescription:@"append #2 completed"];
+  XCTestExpectation* sendNowDone = [self expectationWithDescription:@"sendNow completed"];
+
+  [TeakBatchedRequest raceTest_armPauseAfterNextCancel];
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [TeakTrackEventBatchedRequest addRequestIntoBatch:batch
+                                           withSession:session
+                                           forEndpoint:@"/me/events"
+                                           withPayload:@{@"action_type" : @"race", @"object_type" : @"second"}
+                                           andCallback:nil];
+    [appendDone fulfill];
+  });
+
+  long cancelHappened = dispatch_semaphore_wait(raceTest_cancelHappenedSem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)));
+  XCTAssertEqual(cancelHappened, 0L, @"append #2's -cancel should have run and signalled by now");
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [batch sendNow];
+    sendNowReturned = YES;
+    [sendNowDone fulfill];
+  });
+
+  // sendNow needs the same instance lock append #2 is holding while paused --
+  // it must still be blocked a moment later. This is the structural proof:
+  // red here (sendNowReturned already true) means the two are NOT mutually
+  // exclusive and the fix's atomicity has regressed.
+  usleep(200000);
+  XCTAssertFalse(sendNowReturned, @"sendNow must stay blocked while append #2's cancel+append is atomically in-flight");
+
+  dispatch_semaphore_signal(raceTest_proceedSem);
+
+  [self waitForExpectations:@[appendDone, sendNowDone] timeout:5.0];
+
+  NSArray* transmitted = raceTest_sentBatchSnapshots.firstObject;
+  XCTAssertEqual(raceTest_sentBatchSnapshots.count, (NSUInteger)1, @"batch should transmit exactly once");
+  XCTAssertEqual(transmitted.count, (NSUInteger)2, @"both payloads must be present in what was actually transmitted -- a dropped one means the cancel+append race reopened");
+}
+
+#pragma mark - S2: currentBatchForSession:'s .sent read must be serialized against -prepareAndSend's write
+
+// .sent is written under the instance lock (-prepareAndSend) but was read
+// under the class mutex alone in currentBatchForSession: -- a cross-lock-domain
+// race TSan can see directly (a plain BOOL field access, not an ARC-managed
+// pointer route through libobjc). Both blocks drive only the real
+// currentBatchForSession:/-prepareAndSend production methods, so the race
+// under test is exactly currentBatchForSession:'s own internal .sent check
+// against prepareAndSend's write -- not an extra ad hoc .sent read from
+// outside those methods, which no production caller ever performs (.sent is
+// a private, nonatomic property; every real access already holds the
+// instance lock) and would race regardless of this fix. Green with the read
+// properly nested under the instance lock, red (TSan race report) if that
+// nesting is reverted.
+- (void)testCurrentBatchForSessionSentReadIsSerializedUnderConcurrency {
+  TeakSession* session = [self makeMockSession];
+  const int N = 8000;
+
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      TeakTrackEventBatchedRequest* batch = [TeakTrackEventBatchedRequest currentBatchForSession:session];
+      [batch prepareAndSend];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                [TeakTrackEventBatchedRequest currentBatchForSession:session];
+              }
+            }];
+}
+
+#pragma mark - S4: the reply callback loop must be serialized against addRequestIntoBatch:'s append
+
+// self.callbacks is an NSMutableArray mutated under @synchronized(batchedRequest)
+// by -addRequestIntoBatch: and, pre-fix, iterated with no lock at all by the
+// reply callback -- the mutable-container race class TSan is squarely built to
+// catch. Drives the real -addRequestIntoBatch: append path concurrently with
+// the real reply callback block (batch.callback, the exact block
+// -initWithSession: installs) instead of a hand-rolled loop over the array.
+- (void)testReplyCallbackIterationIsSerializedAgainstAppend {
+  TeakSession* session = [self makeMockSession];
+  TeakTrackEventBatchedRequest* batch = [[TeakTrackEventBatchedRequest alloc] initWithSession:session];
+  const int N = 8000;
+
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      [TeakTrackEventBatchedRequest addRequestIntoBatch:batch
+                                             withSession:session
+                                             forEndpoint:@"/me/events"
+                                             withPayload:@{@"action_type" : @"race", @"object_type" : [NSString stringWithFormat:@"o-%d", i]}
+                                             andCallback:^(NSDictionary* reply){
+                                             }];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                batch.callback(@{});
+              }
+            }];
+}
+
+@end

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -83,6 +83,28 @@ thousands of iterations produced **zero** TSan output, even though the code is u
 > whose release lives in libobjc. Never read a green TSan as proof that a freeable-pointer property
 > is race-free.
 
+**A related but distinct case: TSan partially sees it, and the report rate tracks the crash rate.**
+Not every nonatomic-strong write is fully invisible to TSan — it depends on what's on each side of
+the race. `+[TeakTrackEventBatchedRequest currentBatchForSession:]` returned a `static` strong
+variable outside the `@synchronized` block that guards it — a plain function-local static, not a
+synthesized property getter. Here TSan *does* sometimes report the race, but "sometimes" is doing
+real work: measured against the reverted code, the TSan-report rate and the crash rate were the same
+(~90% per 8-thread/20000-iteration round, drawn from the identical set of runs). A single TSan run,
+or even a handful, is not a reliable "is this fixed" signal either way — treat a report the same as a
+crash (strong evidence of a real bug), but don't read its *absence* as proof there isn't one.
+
+When the crash rate is already high enough per attempt, amplify reliability with independent rounds
+instead of building a dynamic crash-repro harness (§3): measure the per-round red rate `p`
+empirically (15-20+ samples — 4-6 swings too widely to pin down), pick the smallest `M` clearing your
+reliability target via `aggregate = 1-(1-p)^M`, then **validate the actual shipped M-round design end
+to end**. The formula assumes independent rounds, but in-process rounds share heap layout and
+scheduler state and could in principle correlate — don't trust the math alone; run ~20 reverted and
+~20 fixed invocations of the real test and confirm the observed rates hold. Document `p`, `M`, and
+the resulting aggregate directly in the test's source comment — a probabilistic guard is only honest
+if the reliability it claims is visible next to the code, not buried in a PR thread. Live example:
+`testCurrentBatchForSessionSentReadIsSerializedUnderConcurrency` in
+`Automated/AutomatedTests/TeakBatchedRequestRaceTests.m`.
+
 ## 3. The dynamic crash repro (for the class TSan can't see)
 
 The nonatomic-strong UAF has no TSan signal, but it is not undetectable: CoreFoundation's
@@ -214,6 +236,7 @@ check still applies: drop the flag or the detach call and watch the structural a
 |---|---|---|---|
 | Mutable container (dict/array) | ThreadSanitizer | `race on NSMutableDictionary` | `userProfile` string-attributes dict |
 | nonatomic-strong, freeable pointee | Dynamic crash repro (CF over-release trap) | `SIGTRAP` in `_CFRelease` | `TeakSession.serverSessionId` |
+| static/ivar strong pointer, return outside lock | ThreadSanitizer (partial) + measured rounds multiplier | race report **or** crash, rate ≈ crash rate | `TeakTrackEventBatchedRequest.currentBatch` |
 | Immortal scalar/pointer | Static atomic-declaration assertion | assertion red | state-machine fields |
 | Cross-object KVO add/remove (shared observee) | Structural assertion (idempotent removal + detached-at-replacement) | assertion red | `TeakSession` deviceConfiguration observers |
 | Scalar read-modify-write (`foo++` from >1 thread) | Ticket-set/final-count assertion | duplicate/missing ticket or wrong final count | `TeakSession.sessionVectorClock` |

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -468,6 +468,7 @@ static NSString* TeakTrackEventBatchedRequestMutex = @"io.teak.sdk.trackEventBat
 
 + (TeakTrackEventBatchedRequest*)currentBatchForSession:(TeakSession*)session {
   static TeakTrackEventBatchedRequest* currentBatch = nil;
+  TeakTrackEventBatchedRequest* result;
   @synchronized(TeakTrackEventBatchedRequestMutex) {
     // .sent is written under the instance lock (-prepareAndSend), so it must be
     // read under that same lock here too -- otherwise this class-mutex-only
@@ -482,8 +483,12 @@ static NSString* TeakTrackEventBatchedRequestMutex = @"io.teak.sdk.trackEventBat
     if (needsNewBatch) {
       currentBatch = [[TeakTrackEventBatchedRequest alloc] initWithSession:session];
     }
+    // Snapshot the return value here, still under the lock -- returning
+    // `currentBatch` directly after this block closes would re-read the
+    // static var unsynchronized, racing a concurrent call's locked write.
+    result = currentBatch;
   }
-  return currentBatch;
+  return result;
 }
 
 - (void)prepareAndSend {

--- a/Teak/TeakRequest.m
+++ b/Teak/TeakRequest.m
@@ -451,8 +451,14 @@ static NSString* TeakTrackEventBatchedRequestMutex = @"io.teak.sdk.trackEventBat
                     withPayload:@{}
                          method:TeakRequest_POST
                        callback:^(NSDictionary* reply) {
-                         // Trigger any callbacks
-                         for (TeakRequestResponse callback in self.callbacks) {
+                         // Snapshot under the same lock -addRequestIntoBatch: appends
+                         // callbacks under, then invoke outside the lock so an
+                         // arbitrary host-app callback can't deadlock against it.
+                         NSArray* callbacksSnapshot;
+                         @synchronized(self) {
+                           callbacksSnapshot = [self.callbacks copy];
+                         }
+                         for (TeakRequestResponse callback in callbacksSnapshot) {
                            callback(reply);
                          }
                        }
@@ -463,7 +469,17 @@ static NSString* TeakTrackEventBatchedRequestMutex = @"io.teak.sdk.trackEventBat
 + (TeakTrackEventBatchedRequest*)currentBatchForSession:(TeakSession*)session {
   static TeakTrackEventBatchedRequest* currentBatch = nil;
   @synchronized(TeakTrackEventBatchedRequestMutex) {
-    if (currentBatch == nil || currentBatch.sent) {
+    // .sent is written under the instance lock (-prepareAndSend), so it must be
+    // read under that same lock here too -- otherwise this class-mutex-only
+    // read can go stale against a concurrent send and hand out an
+    // already-sent batch.
+    BOOL needsNewBatch = currentBatch == nil;
+    if (!needsNewBatch) {
+      @synchronized(currentBatch) {
+        needsNewBatch = currentBatch.sent;
+      }
+    }
+    if (needsNewBatch) {
       currentBatch = [[TeakTrackEventBatchedRequest alloc] initWithSession:session];
     }
   }
@@ -547,88 +563,109 @@ KeyValueObserverFor(TeakBatchedRequest, TeakSession, currentState) {
 }
 
 - (void)sendNow {
-  if ([self cancel]) {
-    [self prepareAndSend];
+  @synchronized(self) {
+    if ([self cancel]) {
+      [self prepareAndSend];
+    }
   }
 }
 
 + (nullable TeakBatchedRequest*)addRequestIntoBatch:(nonnull TeakBatchedRequest*)batchedRequest withSession:(TeakSession*)session forEndpoint:(nonnull NSString*)endpoint withPayload:(nonnull NSDictionary*)payload andCallback:(nullable TeakRequestResponse)callback {
   if (payload == nil || endpoint == nil || batchedRequest == nil) return batchedRequest;
 
-  if (![batchedRequest cancel]) {
-    // Future-Pat, don't forget about this reassignment and move the @synchronized
-    batchedRequest = [batchedRequest.class batchRequestWithSession:session
-                                                       forEndpoint:endpoint
-                                                       withPayload:payload
-                                                       andCallback:callback];
-    if (batchedRequest == nil) return nil;
+  // -cancel and the append below run as one atomic step under this lock. A
+  // KVO-driven sendNow (see currentState below) cancels+sends under this same
+  // lock; if it ran between a standalone -cancel call and a later, separate
+  // @synchronized block here, it could transmit the batch before this payload
+  // was appended -- silently dropping it. didAppend stays false (and nothing
+  // below runs) when the batch turns out to already be sent, so this thread
+  // never holds this lock while also reaching for the currentBatchForSession:
+  // class mutex -- see the didAppend branch below for why that ordering matters.
+  BOOL didAppend = NO;
+  @synchronized(batchedRequest) {
+    didAppend = [batchedRequest cancel];
+    if (didAppend) {
+      // Check for black-holed requests
+      if (batchedRequest.blackhole) {
+        return batchedRequest;
+      }
+
+      if (callback != nil) {
+        [batchedRequest.callbacks addObject:[callback copy]];
+      }
+
+      // If this is a TrackEvent batch, see if the payload can be folded in to an
+      // existing payload item.
+      BOOL payloadAddedViaIncrement = NO;
+      if ([@"/me/events" isEqualToString:endpoint]) {
+        for (NSUInteger i = 0; i < batchedRequest.batchContents.count; i++) {
+          // If the payloads are equal, smash them together
+          NSDictionary* batchEntry = batchedRequest.batchContents[i];
+          if ([TeakTrackEventBatchedRequest payload:payload isEqualToPayload:batchEntry]) {
+            NSMutableDictionary* summedEntry = [batchEntry mutableCopy];
+
+            summedEntry[@"duration"] = NSNumber_UnsignedLongLong_SafeSumOrExisting(summedEntry[@"duration"], payload[@"duration"]);
+            summedEntry[@"count"] = NSNumber_UnsignedLongLong_SafeSumOrExisting(summedEntry[@"count"], payload[@"count"]);
+            if ([summedEntry[@"sum_of_squares"] isKindOfClass:[TeakMPInt class]]) {
+              [summedEntry[@"sum_of_squares"] sumWith:payload[@"sum_of_squares"]];
+            }
+
+            [batchedRequest.batchContents replaceObjectAtIndex:i
+                                                    withObject:summedEntry];
+            payloadAddedViaIncrement = YES;
+            break;
+          }
+        }
+      }
+
+      // It couldn't be folded in, so append it
+      if (!payloadAddedViaIncrement) {
+        [batchedRequest.batchContents addObject:payload];
+      }
+
+      // If we've hit the limit, or delay time is 0.0, send now; otherwise schedule
+      if (batchedRequest.batchContents.count >= batchedRequest.batch.count || batchedRequest.batch.time == 0.0f) {
+        [batchedRequest prepareAndSend];
+      } else {
+        batchedRequest.scheduledBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
+          [batchedRequest prepareAndSend];
+        });
+
+        dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, batchedRequest.batch.time * NSEC_PER_SEC);
+        dispatch_after(delayTime, dispatch_get_main_queue(), batchedRequest.scheduledBlock);
+
+        // If this is the first request added to the batch, set up the first add time
+        if (batchedRequest.firstAddTime == nil) {
+          batchedRequest.firstAddTime = [NSDate date];
+
+          // If the batch configuration specifies a maximum wait time, schedule
+          if (batchedRequest.batch.maximumWaitTime > 0.0f) {
+            // We can't use batchedRequest.scheduledBlock because there is no difference between
+            // the blocks when cancel is called.
+            dispatch_time_t maxDelayTime = dispatch_time(DISPATCH_TIME_NOW, batchedRequest.batch.maximumWaitTime * NSEC_PER_SEC);
+            dispatch_after(maxDelayTime, dispatch_get_main_queue(), dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
+                             [batchedRequest prepareAndSend];
+                           }));
+          }
+        }
+      }
+    }
   }
 
-  @synchronized(batchedRequest) {
-    // Check for black-holed requests
-    if (batchedRequest.blackhole) {
-      return batchedRequest;
-    }
-
-    if (callback != nil) {
-      [batchedRequest.callbacks addObject:[callback copy]];
-    }
-
-    // If this is a TrackEvent batch, see if the payload can be folded in to an
-    // existing payload item.
-    BOOL payloadAddedViaIncrement = NO;
-    if ([@"/me/events" isEqualToString:endpoint]) {
-      for (NSUInteger i = 0; i < batchedRequest.batchContents.count; i++) {
-        // If the payloads are equal, smash them together
-        NSDictionary* batchEntry = batchedRequest.batchContents[i];
-        if ([TeakTrackEventBatchedRequest payload:payload isEqualToPayload:batchEntry]) {
-          NSMutableDictionary* summedEntry = [batchEntry mutableCopy];
-
-          summedEntry[@"duration"] = NSNumber_UnsignedLongLong_SafeSumOrExisting(summedEntry[@"duration"], payload[@"duration"]);
-          summedEntry[@"count"] = NSNumber_UnsignedLongLong_SafeSumOrExisting(summedEntry[@"count"], payload[@"count"]);
-          if ([summedEntry[@"sum_of_squares"] isKindOfClass:[TeakMPInt class]]) {
-            [summedEntry[@"sum_of_squares"] sumWith:payload[@"sum_of_squares"]];
-          }
-
-          [batchedRequest.batchContents replaceObjectAtIndex:i
-                                                  withObject:summedEntry];
-          payloadAddedViaIncrement = YES;
-          break;
-        }
-      }
-    }
-
-    // It couldn't be folded in, so append it
-    if (!payloadAddedViaIncrement) {
-      [batchedRequest.batchContents addObject:payload];
-    }
-
-    // If we've hit the limit, or delay time is 0.0, send now; otherwise schedule
-    if (batchedRequest.batchContents.count >= batchedRequest.batch.count || batchedRequest.batch.time == 0.0f) {
-      [batchedRequest prepareAndSend];
-    } else {
-      batchedRequest.scheduledBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
-        [batchedRequest prepareAndSend];
-      });
-
-      dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, batchedRequest.batch.time * NSEC_PER_SEC);
-      dispatch_after(delayTime, dispatch_get_main_queue(), batchedRequest.scheduledBlock);
-
-      // If this is the first request added to the batch, set up the first add time
-      if (batchedRequest.firstAddTime == nil) {
-        batchedRequest.firstAddTime = [NSDate date];
-
-        // If the batch configuration specifies a maximum wait time, schedule
-        if (batchedRequest.batch.maximumWaitTime > 0.0f) {
-          // We can't use batchedRequest.scheduledBlock because there is no difference between
-          // the blocks when cancel is called.
-          dispatch_time_t maxDelayTime = dispatch_time(DISPATCH_TIME_NOW, batchedRequest.batch.maximumWaitTime * NSEC_PER_SEC);
-          dispatch_after(maxDelayTime, dispatch_get_main_queue(), dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
-                           [batchedRequest prepareAndSend];
-                         }));
-        }
-      }
-    }
+  if (!didAppend) {
+    // batchedRequest was already sent -- e.g. cancel lost a race with a
+    // concurrent sendNow, or currentBatchForSession: handed out a stale
+    // reference -- so it can no longer accept this payload. Fetch a fresh
+    // batch and append into it instead of dropping the payload. This runs
+    // with batchedRequest's lock already released: batchRequestWithSession:
+    // reaches into currentBatchForSession:'s class mutex, and taking that
+    // mutex while still holding an instance lock here would invert the lock
+    // order against currentBatchForSession:'s own (mutex, then instance lock)
+    // nesting, deadlocking against a concurrent call on the same batch.
+    return [batchedRequest.class batchRequestWithSession:session
+                                              forEndpoint:endpoint
+                                              withPayload:payload
+                                              andCallback:callback];
   }
 
   return batchedRequest;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,7 @@ platform :ios do
       workspace: 'Automated/Automated.xcworkspace',
       scheme: 'Automated',
       thread_sanitizer: true,
-      only_testing: ['AutomatedTests/RaceTripwireTests'],
+      only_testing: ['AutomatedTests/RaceTripwireTests', 'AutomatedTests/TeakBatchedRequestRaceTests'],
       output_directory: 'test_output/race',
       output_files: 'race.xml',
       output_types: 'junit'


### PR DESCRIPTION
Fixes three related races in `TeakBatchedRequest`/`TeakTrackEventBatchedRequest` found in a concurrency audit:

- **S1**: `addRequestIntoBatch:` called `-cancel` before taking the batch's lock — a KVO-driven `sendNow` could send the batch in the gap before the new payload was appended, silently dropping it. Cancel and append now run as one atomic step under the batch's lock. As a side effect of restructuring the cancel-failed fallback path (see below), this also retires a latent, pre-existing double-count: the old code re-fetched a batch via `batchRequestWithSession:` (which already appends the payload + registers the callback) and then fell through to append + register a second time, folding/duplicating the payload and firing the callback twice. The new path returns the re-fetch result directly — exactly one append.
- **S2**: `currentBatchForSession:` read `.sent` under only the class mutex while `prepareAndSend` writes it under the instance lock — a stale read could hand out an already-sent batch. The read is now nested under the same instance lock. While chasing this fix's `test_race` CI failure, local TSan reproduction turned up a second, pre-existing bug in the same method (not introduced by this fix): `return currentBatch;` sat outside the `@synchronized` block, so the implicit ARC retain on return could race a concurrent reassignment and retain-past-zero a freed batch. Fixed by snapshotting the return value under the lock. Both are covered by the same test.
- **S4**: the reply-callback loop iterated `self.callbacks` unlocked while `addRequestIntoBatch:` mutates the same array under lock. The loop now snapshots under the lock and invokes outside it.

`sendNow` also gained the same atomic cancel+send step for symmetry, and the cancel-failed fallback path in `addRequestIntoBatch:` was restructured (via a `didAppend` flag) so it never holds the batch's instance lock while reaching into `currentBatchForSession:`'s class mutex — avoiding an AB-BA lock-order inversion between the S1 and S2 fixes.

`TeakBatchedRequestRaceTests` drives the real production methods (via runtime swizzles + OCMockito mocks):
- S1: forced-interleave repros for both orderings of the cancel/append/sendNow race — append-wins (the original dropped-request scenario) and sendNow-wins (cancel correctly fails, payload must re-route into a fresh batch rather than drop). Dropped-request ordering bugs have no crash/TSan signal, hence forced interleaving rather than a hammer loop.
- S2/S4: TSan-based tests. S2's test runs 5 independent in-process rounds (8 threads x 20000 iterations each) — measured and empirically validated to red ≥99% of the time against the reverted code and never false-red on the fix (20/20 each way); math and measurement documented in the test's source comment.

All tests confirmed red-on-revert (real production failure reproduced, not a proxy) / green-on-fix. Registered in the `test_race` fastlane lane.

Linear: https://linear.app/teakio/issue/C-975/teakbatchedrequest-cancelappenditerate-silent-event-drop-off-lock
