### PR TITLE
Serialize TeakUserProfile's residual -send dict read on the TeakRequest retry ladder

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -73,6 +73,14 @@ extern NSString* const currentSessionMutex;
 
 @interface TeakUserProfile (RaceTripwire)
 @property (strong, nonatomic) NSMutableDictionary* stringAttributes;
+@property (strong, nonatomic) NSMutableDictionary* numberAttributes;
+@property (strong, nonatomic) NSString* context;
+@end
+
+// blackhole is readonly in the public header, readwrite in TeakRequest+Internal.h; re-exposed here
+// per the project convention so the tripwire can suppress the real network send.
+@interface TeakRequest (RaceTripwire)
+@property (nonatomic, readwrite) BOOL blackhole;
 @end
 
 // countryCode/serverSessionId/facebookAccessToken are private (declared only in TeakSession.m's
@@ -778,6 +786,36 @@ static NSMutableArray* keepAliveBareSessions;
   long timedOut = dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
   XCTAssertEqual(timedOut, 0,
                  @"AB-BA lock-order inversion: the currentState UserIdentified handler took currentSessionMutex while holding the session self-lock, deadlocking against a lifecycle mutex→self path");
+}
+
+// -send serialization regression guard (ThreadSanitizer). -send reads/copies the same
+// stringAttributes/numberAttributes dict the test above proves is write-serialized onto
+// operationQueue — but TeakRequest's retry ladder (TeakRequest.m's socket-error and
+// server-retry branches) can invoke -send directly on dispatch_get_main_queue() after a
+// delay, landing there if a new attribute has re-armed scheduledBlock in that window.
+// Thread A drives the real setter (a write, on operationQueue per the fix above); thread B
+// calls -send directly off-queue, standing in for the retry ladder's off-queue
+// re-invocation. The fix hops -send's whole body onto operationQueue too, so TSan stays
+// silent; reverting that hop puts the caller-queue read back in a race with the
+// operationQueue write and TSan reports it. Green now, red on revert.
+- (void)testUserProfileSendDefersDictReadToSerialQueueUnderConcurrency {
+  TeakUserProfile* profile = [[TeakUserProfile alloc] init];
+  profile.blackhole = YES;
+  profile.stringAttributes = [@{@"level" : @"seed"} mutableCopy];
+  profile.numberAttributes = [NSMutableDictionary dictionary];
+  profile.context = @"test";
+
+  [self raceBlockA:^{
+    for (int i = 0; i < 8000; i++) [profile setStringAttribute:[NSString stringWithFormat:@"a-%d", i] forKey:@"level"];
+  }
+            blockB:^{
+              for (int i = 0; i < 8000; i++) [profile send];
+            }];
+
+  // Drain the queued blocks (both the setter's scheduled sends and -send's own hop) so none
+  // outlive the test.
+  dispatch_sync([Teak operationQueue], ^{
+  });
 }
 
 @end

--- a/Teak/Core/TeakUserProfile.m
+++ b/Teak/Core/TeakUserProfile.m
@@ -65,24 +65,31 @@
 }
 
 - (void)send {
-  // No scheduledBlock means no pending update
-  if (self.scheduledBlock != nil) {
-    dispatch_block_cancel(self.scheduledBlock);
-    self.scheduledBlock = nil;
+  // TeakRequest's retry ladder can re-invoke -send from dispatch_get_main_queue() after a
+  // delay (socket-error and server-retry branches); if a new attribute has re-armed
+  // scheduledBlock in that window, this would read stringAttributes/numberAttributes off
+  // the serial operationQueue that setAttribute:forKey:inDictionary: mutates them on. Hop
+  // onto that same queue so this read is never concurrent with that write.
+  dispatch_async([Teak operationQueue], ^{
+    // No scheduledBlock means no pending update
+    if (self.scheduledBlock != nil) {
+      dispatch_block_cancel(self.scheduledBlock);
+      self.scheduledBlock = nil;
 
-    NSMutableDictionary* payload = [self.payload mutableCopy];
-    [payload addEntriesFromDictionary:@{
-      @"string_attributes" : [self.stringAttributes copy],
-      @"number_attributes" : [self.numberAttributes copy],
-      @"context" : [self.context copy],
-      @"ms_since_first_event" : [NSNumber numberWithDouble:[self.firstSetTime timeIntervalSinceNow] * -1000.0]
-    }];
-    self.payload = payload;
+      NSMutableDictionary* payload = [self.payload mutableCopy];
+      [payload addEntriesFromDictionary:@{
+        @"string_attributes" : [self.stringAttributes copy],
+        @"number_attributes" : [self.numberAttributes copy],
+        @"context" : [self.context copy],
+        @"ms_since_first_event" : [NSNumber numberWithDouble:[self.firstSetTime timeIntervalSinceNow] * -1000.0]
+      }];
+      self.payload = payload;
 
-    [super send];
+      [super send];
 
-    self.firstSetTime = nil;
-  }
+      self.firstSetTime = nil;
+    }
+  });
 }
 
 @end


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/C-959/teakuserprofile-serialize-residual-send-dict-read-on-teakrequest-retry

## What
C-955 (#163) moved `stringAttributes`/`numberAttributes` writes onto the serial `io.teak.sdk.operationQueue`, but `-send`'s own read of those dicts still ran on whatever queue invoked it. `TeakRequest`'s retry ladder (socket-error and server-retry branches, `TeakRequest.m:393`/`405`) re-invokes `[self send]` from `dispatch_get_main_queue()` after a delay — if a new attribute set call re-arms `scheduledBlock` in that window, `TeakUserProfile`'s `-send` override runs on the main queue and copies the same dicts the operationQueue writer can be mutating concurrently. Same mutable-container UAF class C-955 closed, reopened at a different entry point into `-send`.

## Fix
Wrap `-send`'s whole body in `dispatch_async([Teak operationQueue], ...)`, mirroring C-955's fix for the setter. Every call path (the batching `scheduledBlock`, `TeakSession`'s flush-on-Expiring, and the retry ladder) now serializes on `operationQueue` regardless of which queue invoked `-send`. All three callers are fire-and-forget — verified none depend on synchronous completion or ordering.

## Test
Adapted `testUserProfileAttributeDictIsSerializedUnderConcurrency`'s TSan template in `RaceTripwireTests.m`: one thread drives the real `setStringAttribute` (write, on operationQueue), the other calls `-send` directly off-queue (blackholed), standing in for the retry ladder's off-queue re-invocation. Revert-checked: reverting the `dispatch_async` hop reproduces `ThreadSanitizer: race on NSMutableDictionary` between the setter's write and `-send`'s read; restoring the fix is silent. Full regular suite also green (162/162).

## Changelog
No `4.3.14.yaml` entry per the current wave's protocol — changelog line below for whoever assembles it:

> Fixed a residual thread-safety issue in user profile attribute sending that could occur during request retries.

## Note for release scoping
This ticket's own body says "post-4.3.14 monitor-and-address" — it's included in this wave to complete the C-955 stack, not because it's in an observed crash family yet. Flagging as a candidate to defer out of 4.3.14 if desired.