### PR TITLE
Fix TeakSession sessionVectorClock/reportDurationSent data race

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -102,7 +102,7 @@ extern NSString* const currentSessionMutex;
 // The macro-generated currentState KVO handler. A bare-alloc session never registers the observer
 // (-init does), so the lock-order guard invokes the real handler directly to exercise its body.
 - (void)_TeakSession_currentState_ChangedFrom:(id)oldValue to:(id)newValue;
-@property (nonatomic) volatile atomic_int sessionVectorClock;
+@property (nonatomic) atomic_int sessionVectorClock;
 - (int)incrementSessionVectorClock;
 - (int)markReportDurationSentAndIncrementSessionVectorClock;
 @end

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -102,6 +102,9 @@ extern NSString* const currentSessionMutex;
 // The macro-generated currentState KVO handler. A bare-alloc session never registers the observer
 // (-init does), so the lock-order guard invokes the real handler directly to exercise its body.
 - (void)_TeakSession_currentState_ChangedFrom:(id)oldValue to:(id)newValue;
+@property (nonatomic) volatile atomic_int sessionVectorClock;
+- (int)incrementSessionVectorClock;
+- (int)markReportDurationSentAndIncrementSessionVectorClock;
 @end
 
 // pushToken/liveActivityPushToStartToken/advertisingIdentifier/notificationDisplayEnabled are
@@ -408,6 +411,39 @@ static NSMutableArray* keepAliveBareSessions;
                 (void)status.state.length;
               }
             }];
+}
+
+// sessionVectorClock lost-update repro (scalar read-modify-write, see RACE_TESTING.md §3a/§1's
+// fourth class). Unlike the UAF tests above, the pointee here can't be freed and the aligned
+// load/store can't tear — the danger is the `++` itself: two threads can read the same
+// pre-increment value and each write back the same post-increment value, silently dropping an
+// update. Both real increment helpers are driven concurrently (the KVO-observer resume path and
+// the duration-report background block both call one of these two), and every value each thread's
+// call *returns* is collected into that thread's own set. No lost/duplicate update means the union
+// of both sets has exactly one entry per call, and the field's final value equals the total call
+// count. Reverting either helper to a bare `self.sessionVectorClock++` on the same atomic-typed
+// property still drops tickets reliably at this iteration count.
+- (void)testSessionVectorClockDoesNotLoseIncrementsUnderConcurrency {
+  TeakSession* session = [self bareSessionKeptAlive];
+  const int N = 200000;
+  NSMutableSet<NSNumber*>* ticketsA = [NSMutableSet setWithCapacity:N];
+  NSMutableSet<NSNumber*>* ticketsB = [NSMutableSet setWithCapacity:N];
+
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      [ticketsA addObject:@([session incrementSessionVectorClock])];
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                [ticketsB addObject:@([session markReportDurationSentAndIncrementSessionVectorClock])];
+              }
+            }];
+
+  NSMutableSet<NSNumber*>* allTickets = [ticketsA mutableCopy];
+  [allTickets unionSet:ticketsB];
+  XCTAssertEqual(allTickets.count, (NSUInteger)(2 * N), @"every increment should return a unique ticket — a duplicate means a lost update");
+  XCTAssertEqual(session.sessionVectorClock, 2 * N, @"final count should equal the total number of increments across both threads");
 }
 
 // Builds a real TeakRaven the same way TeakRavenTests.m does: a fully-stubbed Teak mock so

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -6,7 +6,7 @@ racing, so start by classifying that.
 
 ## 1. Classify the shared state first
 
-The detector that will actually fire depends on what's being shared. Three cases cover almost
+The detector that will actually fire depends on what's being shared. Four cases cover almost
 everything here:
 
 - **Immortal scalar or pointer** — the slot is written concurrently but the pointee is never freed
@@ -22,6 +22,12 @@ everything here:
   (e.g. the `userProfile` string-attributes dict). The container's internal backing buffer
   reallocates on mutation, so a concurrent access touches freed/moved memory. Atomicity of the
   pointer to the container does nothing here; the access itself must be serialized.
+- **Scalar under a compound read-modify-write** — a counter incremented (`self.foo++`) from more
+  than one thread (e.g. `TeakSession.sessionVectorClock`). The pointee can't be freed and the
+  aligned load/store can't tear, so this isn't the UAF case — but a plain atomic property is still
+  not enough, because the increment is a separate atomic get then a separate atomic set, and two
+  threads can race between them and drop an update. The fix is a true atomic RMW (`atomic_fetch_add`
+  on an `_Atomic`-qualified scalar); see §3a for the detector.
 
 The class tells you which tool below will fire — and, just as important, which will stay silent
 while the bug is still there.
@@ -140,6 +146,27 @@ production code regardless of whether init ran.
 Then apply the **revert check**: run it against the unfixed property and watch it crash; apply the
 fix (§4) and watch the crash vanish. Red→green.
 
+## 3a. The lost-update counter repro (scalar read-modify-write)
+
+The scalar-RMW case from §1 doesn't fit either detector above: no crash to trap (the pointee can't
+be freed), and TSan is commonly blind to it for the same reason it's blind to the nonatomic-strong
+UAF — the increment's load and store typically resolve through the same kind of uninstrumented
+runtime call. The repro instead drives the real increment method from two threads and asserts an
+invariant that only holds if every single increment landed:
+
+- **Ticket-set uniqueness** — have each thread collect the value its own increment call *returns*
+  into its own set, union the two sets after both finish, and assert the union's size equals the
+  total number of calls. A lost update surfaces as a missing or duplicate ticket.
+- **Final-count check** — assert the field's value once both threads are done equals the total
+  number of increments made across both.
+
+`testSessionVectorClockDoesNotLoseIncrementsUnderConcurrency` in `RaceTripwireTests.m` does both,
+driving `TeakSession`'s real `-incrementSessionVectorClock` /
+`-markReportDurationSentAndIncrementSessionVectorClock` (each an `atomic_fetch_add` on the same
+underlying `atomic_int`). No crash needed — reverting either method to a bare
+`self.sessionVectorClock++` on the same atomic-typed property still reliably drops tickets at a few
+hundred thousand iterations, same revert-check bar as everything else in this doc.
+
 ## 4. Why `atomic` fixes the nonatomic-strong UAF
 
 Declaring the property `atomic` (strong) routes reads through `objc_getProperty`, which **retains
@@ -189,6 +216,7 @@ check still applies: drop the flag or the detach call and watch the structural a
 | nonatomic-strong, freeable pointee | Dynamic crash repro (CF over-release trap) | `SIGTRAP` in `_CFRelease` | `TeakSession.serverSessionId` |
 | Immortal scalar/pointer | Static atomic-declaration assertion | assertion red | state-machine fields |
 | Cross-object KVO add/remove (shared observee) | Structural assertion (idempotent removal + detached-at-replacement) | assertion red | `TeakSession` deviceConfiguration observers |
+| Scalar read-modify-write (`foo++` from >1 thread) | Ticket-set/final-count assertion | duplicate/missing ticket or wrong final count | `TeakSession.sessionVectorClock` |
 | Deadlock / dropped-order | No in-process race signal | case-by-case: watchdog, barrier, structural | — |
 
 Whatever the technique, it isn't a guard until you've run the **revert check** and watched it fail.

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -15,6 +15,8 @@
 #import "TeakHelpers.h"
 #import "TeakKVOHelpers.h"
 
+#import <stdatomic.h>
+
 NSTimeInterval TeakSameSessionDeltaSeconds = 120.0;
 
 TeakSession* currentSession;
@@ -96,11 +98,20 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 // resetReportDurationBlock cancels and frees it under the lock. atomic accessors keep that
 // lock-free read from retaining a pointer the setter is releasing out from under it.
 @property (strong, atomic) dispatch_block_t reportDurationBlock;
-@property (nonatomic) BOOL reportDurationSent;
+// reportDurationSent/sessionVectorClock are C11 atomics, not ObjC `atomic` properties: the
+// duration-report background block writes both lock-free (see the block body below), while
+// sessionVectorClock is also incremented from the currentState observer's @synchronized(self).
+// A plain assignment (identify-reply reset-to-0, init) is already a safe atomic store on this
+// type. sessionVectorClock's `++` is a compound read-modify-write that neither a plain store nor
+// an ObjC `atomic` property qualifier makes safe on its own — every increment site goes through
+// -incrementSessionVectorClock/-markReportDurationSentAndIncrementSessionVectorClock below, which
+// use atomic_fetch_add. reportDurationSent never participates in a read-modify-write of its own
+// prior value, so plain atomic load/store fully covers it.
+@property (nonatomic) volatile atomic_bool reportDurationSent;
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundUpdateTask;
 // Same cross-thread reassignment race as countryCode above.
 @property (strong, atomic) NSString* serverSessionId;
-@property int sessionVectorClock;
+@property (nonatomic) volatile atomic_int sessionVectorClock;
 
 // Set once, under deviceConfigurationObserverMutex, when this session's observers on the shared
 // deviceConfiguration are removed, so the removal happens exactly once whether it comes from session
@@ -940,13 +951,15 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
       if (oldValue == [TeakSession Expiring]) {
         // Cancel any pending duration report
         if ([self resetReportDurationBlock]) {
-          // The report duration got sent, so send a resume
-          self.sessionVectorClock++;
+          // The report duration got sent, so send a resume. sessionVectorClock++ is a
+          // read-modify-write the duration-report block's own increment can race with, so it
+          // goes through the atomic-fetch-add helper rather than the property's `++` sugar.
+          int vectorClock = [self incrementSessionVectorClock];
           // Single read: same nil-check-then-use hazard as sendHeartbeat's countryCode above.
           NSString* serverSessionId = self.serverSessionId;
           NSDictionary* payload = @{
             @"session_id" : serverSessionId == nil ? @"null" : TeakURLEscapedString(serverSessionId),
-            @"session_vector_clock": [NSNumber numberWithLong:self.sessionVectorClock]
+            @"session_vector_clock": [NSNumber numberWithLong:vectorClock]
           };
 
           TeakRequest* request = [TeakRequest requestWithSession:self
@@ -1001,14 +1014,16 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
           dispatch_block_t canceledCheckBlock = blockSelf.reportDurationBlock;
           NSString* serverSessionId = blockSelf.serverSessionId;
           if (canceledCheckBlock != nil && !dispatch_block_testcancel(canceledCheckBlock) && serverSessionId != nil) {
-            blockSelf.reportDurationSent = YES;
-            blockSelf.sessionVectorClock++;
+            // reportDurationSent/sessionVectorClock are atomic-typed (see the class extension), so
+            // this store and fetch-add are each safe against the KVO observer's resume-path
+            // increment on another thread without taking any lock here.
+            int vectorClock = [blockSelf markReportDurationSentAndIncrementSessionVectorClock];
 
             // Send request for "if you don't hear back from me, this session ended now"
             NSDictionary* payload = @{
               @"session_id" : TeakURLEscapedString(serverSessionId),
               @"session_duration_ms" : [NSNumber numberWithLong:[blockSelf.endDate timeIntervalSinceDate:blockSelf.startDate] * 1000],
-              @"session_vector_clock": [NSNumber numberWithLong:blockSelf.sessionVectorClock]
+              @"session_vector_clock": [NSNumber numberWithLong:vectorClock]
             };
 
             TeakRequest* request = [TeakRequest requestWithSession:blockSelf
@@ -1028,6 +1043,25 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
     } else if (newValue == [TeakSession Expired]) {
     }
   }
+}
+
+// sessionVectorClock++ is a read-modify-write; the KVO observer's resume-path increment and the
+// duration-report background block's increment can run concurrently on two different threads, so
+// a plain atomic property (safe for single loads/stores, not for compound RMW) isn't enough. Every
+// increment site goes through this or -markReportDurationSentAndIncrementSessionVectorClock, both
+// of which use atomic_fetch_add on the underlying atomic_int. Returns the new (post-increment)
+// value so callers don't need a second, separately-racy read of the property for their payload.
+- (int)incrementSessionVectorClock {
+  return atomic_fetch_add(&_sessionVectorClock, 1) + 1;
+}
+
+// Same atomicity requirement as -incrementSessionVectorClock, for the one call site that also
+// needs to mark the duration report sent in the same breath. reportDurationSent itself never
+// participates in a read-modify-write of its own prior value (resetReportDurationBlock's reset to
+// NO is unconditional), so it doesn't need fetch-add — a plain atomic store below is sufficient.
+- (int)markReportDurationSentAndIncrementSessionVectorClock {
+  self.reportDurationSent = YES;
+  return atomic_fetch_add(&_sessionVectorClock, 1) + 1;
 }
 
 - (BOOL)resetReportDurationBlock {

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -1061,7 +1061,7 @@ KeyValueObserverFor(TeakSession, TeakSession, currentState) {
 // NO is unconditional), so it doesn't need fetch-add — a plain atomic store below is sufficient.
 - (int)markReportDurationSentAndIncrementSessionVectorClock {
   self.reportDurationSent = YES;
-  return atomic_fetch_add(&_sessionVectorClock, 1) + 1;
+  return [self incrementSessionVectorClock];
 }
 
 - (BOOL)resetReportDurationBlock {

--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -107,11 +107,11 @@ extern BOOL TeakLink_WillHandleDeepLink(NSURL* deepLink);
 // -incrementSessionVectorClock/-markReportDurationSentAndIncrementSessionVectorClock below, which
 // use atomic_fetch_add. reportDurationSent never participates in a read-modify-write of its own
 // prior value, so plain atomic load/store fully covers it.
-@property (nonatomic) volatile atomic_bool reportDurationSent;
+@property (nonatomic) atomic_bool reportDurationSent;
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundUpdateTask;
 // Same cross-thread reassignment race as countryCode above.
 @property (strong, atomic) NSString* serverSessionId;
-@property (nonatomic) volatile atomic_int sessionVectorClock;
+@property (nonatomic) atomic_int sessionVectorClock;
 
 // Set once, under deviceConfigurationObserverMutex, when this session's observers on the shared
 // deviceConfiguration are removed, so the removal happens exactly once whether it comes from session


### PR DESCRIPTION
Follow-on from C-956 (deliberately scoped out to keep that PR focused). `reportDurationSent`/`sessionVectorClock` were plain ivars mutated unlocked from both the duration-report background block and the KVO-observer resume path — `sessionVectorClock`'s `++` is a compound read-modify-write racing across those two sites, so a plain store or an ObjC `atomic` property qualifier alone isn't sufficient.

Converts both fields to C11 atomics (`stdatomic.h`) rather than adding a lock: no reader needs the flag and clock observed together as a correlated pair, so two independent atomics fully cover it. `sessionVectorClock`'s two increment sites now go through `atomic_fetch_add`-backed helpers. The KVO-observer resume path keeps its enclosing `@synchronized(self)` — that lock co-guards the state transition, not the clock.

Adds a lost-update regression test (ticket-set + final-count assertions, 400k increments) with a confirmed red→green revert-check, and documents the scalar-read-modify-write race class in `RACE_TESTING.md` as a 4th classification.

Linear: https://linear.app/teakio/issue/C-957

## Changelog
- Fix: `TeakSession.sessionVectorClock`/`reportDurationSent` unlocked data race on the duration-report background queue

## Test plan
- [x] New regression test `testSessionVectorClockDoesNotLoseIncrementsUnderConcurrency` — confirmed RED with fix reverted (~25,700/400,000 lost updates), GREEN with fix applied
- [x] Full suite green (162/162) via `bundle exec fastlane test_race`