### PR TITLE
Bound the TeakLink route-registry race guard to kill its O(N²) runtime

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -607,7 +607,8 @@ static NSMutableArray* keepAliveBareSessions;
 // TSan sees it. This is a mutable-container race (the §2 sweet spot), NOT the objc_storeStrong-blind
 // nonatomic-strong class, so a green TSan run here genuinely means safe. Off TSan, the same
 // mid-enumeration mutation is what Foundation's enumeration guard traps as an NSGenericException in
-// production. Green now, red on revert (measured deterministic: 20/20 reverts red, all with the TSan report).
+// production. Green now, red on revert: 20/20 reverts red, all with the TSan report — effectively
+// deterministic, since it's a structural mutate-while-enumerate collision, not a probabilistic sampling window.
 //
 // What the guard needs is mutate-while-enumerate *pressure*, not registry *size*. A distinct route
 // per iteration would grow the registry unbounded, and every reader pass compiles a fresh regex per

--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -596,19 +596,34 @@ static NSMutableArray* keepAliveBareSessions;
             }];
 }
 
-// TeakLink route-registry serialization regression guard (ThreadSanitizer). registerRoute writes the
-// static route dictionary from any host thread with no threading contract, while handleDeepLink and
+// TeakLink route-registry serialization regression guard. registerRoute writes the static route
+// dictionary from any host thread with no threading contract, while handleDeepLink and
 // routeNamesAndDescriptions enumerate it — the real contention window is a host registering routes
-// lazily post-launch while the launch deep link resolves concurrently on the op queue. Each writer
-// iteration registers a distinct route (a real key insertion, not a same-key overwrite) while the
-// reader iterates the real handleDeepLink: and routeNamesAndDescriptions methods. The fix wraps the
-// write and a copy-then-enumerate snapshot of the read in @synchronized on the registry; remove
-// either side and TSan reports a race on the dictionary. Green now, red on revert.
+// lazily post-launch while the launch deep link resolves concurrently on the op queue. The fix wraps
+// the write and a copy-then-enumerate snapshot of the read in @synchronized on the registry; reverting
+// it lets the reader fast-enumerate the live dictionary while the writer mutates it. On the test_race
+// lane this reliably fires `ThreadSanitizer: race on NSMutableDictionary` — the reader's
+// countByEnumeratingWithState: against the writer's setObject:forKey:, both instrumented Foundation, so
+// TSan sees it. This is a mutable-container race (the §2 sweet spot), NOT the objc_storeStrong-blind
+// nonatomic-strong class, so a green TSan run here genuinely means safe. Off TSan, the same
+// mid-enumeration mutation is what Foundation's enumeration guard traps as an NSGenericException in
+// production. Green now, red on revert (measured deterministic: 20/20 reverts red, all with the TSan report).
+//
+// What the guard needs is mutate-while-enumerate *pressure*, not registry *size*. A distinct route
+// per iteration would grow the registry unbounded, and every reader pass compiles a fresh regex per
+// entry (handleDeepLink) — so an N-iteration reader over an N-entry registry is O(N²), which is why
+// the distinct-route form ran ~192s. Rotating a small fixed key set (route-%d over K) keeps the
+// registry bounded, so each reader pass stays O(K); re-registering an existing route still calls
+// setValue:forKey:, which bumps the dictionary's mutation counter and collides with a concurrent
+// enumeration exactly as a fresh insertion would (verified: an overwrite mid-enumeration throws the
+// same NSGenericException). Decoupling pressure from size keeps the guard fast while preserving the
+// exact collision it pins.
 - (void)testTeakLinkRouteRegistryIsSerializedUnderConcurrency {
-  const int N = 4000;
+  const int N = 2000;
+  const int K = 16;  // bound the registry: each reader pass is O(K) regex compiles, not O(N)
   [self raceBlockA:^{
     for (int i = 0; i < N; i++) {
-      [TeakLink registerRoute:[NSString stringWithFormat:@"/race-tripwire/route-%d", i]
+      [TeakLink registerRoute:[NSString stringWithFormat:@"/race-tripwire/route-%d", i % K]
                           name:@"race-tripwire"
                    description:@"race tripwire probe route"
                          block:^(NSDictionary* params){

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -52,6 +52,17 @@ reports `race on NSMutableDictionary`. Live template:
 with the serialization fix it stays green, and reverting the fix (removing the operationQueue hop)
 makes TSan fire. Open it as a starting point for a container-race test.
 
+The mutate-vs-*enumerate* shape is caught just as reliably as two setters, and this was measured:
+`testTeakLinkRouteRegistryIsSerializedUnderConcurrency` races the registry's `setObject:forKey:`
+against a concurrent `countByEnumeratingWithState:`; reverting its `@synchronized` fired `race on
+NSMutableDictionary` on 20/20 separate-process runs (deterministic). Both sides are instrumented
+Foundation, so TSan pairs them — even though the write lands deep in CoreFoundation's dictionary
+machinery. (Foundation's own "mutated while being enumerated" `NSGenericException` guard is the same
+bug's off-TSan face — the production crash — but on the TSan lane the race report is what surfaces
+first.) The lesson: reach for the container class in §1, not the load-bearing detail of two setters
+vs. a setter-and-enumerator — any mutation concurrent with any access to the same container is the
+sweet spot TSan sees.
+
 **It is blind to the nonatomic-strong use-after-free.** For a `nonatomic` strong property, the
 synthesized setter's store lands inside `objc_storeStrong` — libobjc, which is not instrumented.
 TSan sees the reader's instrumented load of the ivar but never the writer's store, so it never pairs

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -55,7 +55,8 @@ makes TSan fire. Open it as a starting point for a container-race test.
 The mutate-vs-*enumerate* shape is caught just as reliably as two setters, and this was measured:
 `testTeakLinkRouteRegistryIsSerializedUnderConcurrency` races the registry's `setObject:forKey:`
 against a concurrent `countByEnumeratingWithState:`; reverting its `@synchronized` fired `race on
-NSMutableDictionary` on 20/20 separate-process runs (deterministic). Both sides are instrumented
+NSMutableDictionary` on 20/20 separate-process runs — effectively deterministic (a structural collision,
+not a probabilistic sampling window). Both sides are instrumented
 Foundation, so TSan pairs them — even though the write lands deep in CoreFoundation's dictionary
 machinery. (Foundation's own "mutated while being enumerated" `NSGenericException` guard is the same
 bug's off-TSan face — the production crash — but on the TSan lane the race report is what surfaces


### PR DESCRIPTION
`testTeakLinkRouteRegistryIsSerializedUnderConcurrency` registered N=4000 *distinct* routes while the reader ran `handleDeepLink:`, which compiles a fresh `NSRegularExpression` per registry entry — an N-iteration reader over an N-entry registry is ≈16M regex compiles, ~192s (≈88% of the race-guard suite).

The guard's subject is mutate-while-enumerate **pressure** on the shared registry dictionary, not registry **size**. Rotate a small fixed key set (`route-%d` over K=16) so the registry stays bounded and each reader pass is O(K); re-registering an existing route still calls `setValue:forKey:`, which bumps the dict's mutation counter and collides with the concurrent enumeration exactly as a fresh insert would. N cut 4000→2000.

**Result: whole `test_race` suite ~219s → 22.15s** (22 tests, 0 failures); the route test itself ~192s → ~0.47s isolated (median of 20 runs).

### Revert-check (20 separate-process runs each, under the TSan `test_race` lane)
- **Revert** the `@synchronized` fix in `TeakLink.m` → **20/20 red**, every run carrying `ThreadSanitizer: race on NSMutableDictionary` (reader `countByEnumeratingWithState:` vs writer `setObject:forKey:`) — verified in every log, not just the exit code.
- **Fix** in place → **20/20 green**, zero failure signals.

So the optimization preserves the guard with no reliability loss.

### Detector correction (measured)
This is a mutable-container race — both the enumerate and the `setObject:` are instrumented Foundation (the RACE_TESTING.md §2 sweet spot), so TSan fires reliably. It is **not** the `objc_storeStrong`-blind nonatomic-strong class. The Foundation "mutated while being enumerated" `NSGenericException` is the same bug's off-TSan production face. Corrected the test comment and added a §2 note in `RACE_TESTING.md`.

### Sweep
The only other O(N²)-shaped tripwire, `testProductRequestActiveRequestsIsSerializedUnderConcurrency` (array `removeObject:` linear-search + tail-shift), measures **0.374s** — below the followup threshold, so it's a structurally-different shape left as-is. The multi-second tripwires that remain are the CF over-release crash repros — O(N) with reliability-critical N (RACE_TESTING.md §3), deliberately untouched.

Linear: https://linear.app/teakio/issue/C-989
