### PR TITLE
Hold outgoing session's monitor across didLaunchWithData teardown

### DIFF
--- a/Teak/TeakSession.m
+++ b/Teak/TeakSession.m
@@ -732,9 +732,20 @@ DefineTeakState(Expired, (@[]));
       TeakSession* oldSession = currentSession;
       currentSession = [[TeakSession alloc] initWithSession:oldSession];
 
-      [oldSession detachDeviceConfigurationObservers];
-      [oldSession setState:[TeakSession Expiring]];
-      [oldSession setState:[TeakSession Expired]];
+      // Hold the outgoing session's own monitor across its teardown. The two -setState: calls each
+      // self-synchronize individually, but only locking the session across the pair keeps a concurrent
+      // @synchronized(self) -setState: from interleaving a legal Expiring->Configured between Expiring
+      // and Expired; the following Expired would then be rejected (Configured has no Expired successor),
+      // leaving the outgoing session stuck un-expired. On this path the interleave is not reachable
+      // today — the outgoing session is never in Created here, so its hostname observer (the only
+      // producer of -setState:Configured) is already detached — so this is defense-parity: kept
+      // symmetric with +logoutReusingCurrentSession:'s identical teardown so the asymmetry can't
+      // become a latent bug if that observer lifecycle ever changes.
+      @synchronized(oldSession) {
+        [oldSession detachDeviceConfigurationObservers];
+        [oldSession setState:[TeakSession Expiring]];
+        [oldSession setState:[TeakSession Expired]];
+      }
     }
 
     // Assign launch data


### PR DESCRIPTION
Linear: https://linear.app/teakio/issue/C-988

Wraps `didLaunchWithData:`'s outgoing-session teardown — `detach + setState:Expiring + setState:Expired` on `oldSession` — in `@synchronized(oldSession)`, nested inside the existing `@synchronized(currentSessionMutex)`. This mirrors the identical teardown already locked in `+logoutReusingCurrentSession:`.

### Why
Locking the outgoing session across the pair keeps a concurrent `@synchronized(self)` `-setState:` from interleaving a legal `Expiring->Configured` between the `Expiring` and `Expired` calls. If it did, the following `Expired` would be rejected (Configured has no Expired successor), leaving the outgoing session stuck un-expired (zombie session).

### Currently defense-parity, not a live fix
This teardown path excludes `Created`- and `Allocated`-state sessions. The only producer of `-setState:Configured` is the hostname KVO callback, whose observer is registered only while a session is in `Created` and torn down on leaving it. So on this path the outgoing session's hostname observer is already detached and the interleave is **unreachable today**. The value is symmetry with the logout teardown, so the asymmetry can't become a latent bug if that observer lifecycle ever changes.

### Why no test
A red->green test isn't achievable honestly here. There's no production call site that can generate the interleave (zero live path, above), and no seam in the `Expiring->Expired` gap to force a deterministic interleave — only a synthetic, probabilistic stress test driving `setState:Configured` directly would go red on revert. That would imply a live failure mode that doesn't exist on this path, so the inline comment is the honest record instead of a misleading test. (C-967's logout monitor lock shipped the same way — structural tests, no zombie-interleave repro.)

### Lock ordering
No new lock-ordering surface: same `currentSessionMutex -> session self-lock` acquisition order the lifecycle class methods already use, which C-968 proved deadlock-free (the currentState KVO handler hops off the self-lock before taking `currentSessionMutex`).
