### PR TITLE
Add 4.3.14 changelog

### DIFF
--- a/docs/modules/changelog/versions/4.3.14.yaml
+++ b/docs/modules/changelog/versions/4.3.14.yaml
@@ -1,0 +1,7 @@
+enhancement:
+  - "Uncaught exceptions now emit an ``exception`` log event to registered log listeners."
+bug:
+  - "Fixed purchase and event timestamps being rejected by the server on devices set to certain non-Western locales (e.g. Arabic)."
+  - "Fixed reward attribution being dropped when a Teak link resolved without an iOS path, or when link resolution failed."
+  - "Network requests are now retried when the OS drops an idle connection, instead of failing silently."
+  - "Thread-safety hardening across the SDK: fixed a class of rare multi-threaded crashes, a potential deadlock, and dropped analytics and reward events under concurrent access."


### PR DESCRIPTION
4.3.14 release notes — everything on 4.3-stable since 4.3.13 (#148).

**enhancement:** uncaught-exception log event (#160)
**bug:** locale-independent timestamps (#151), reward attribution on absent iOS path (#154), socket-close retry (#155), and a single consolidated thread-safety-hardening line for the ~15-PR concurrency wave (#163-#182).

Race wave consolidated per alex — one integrator-facing line rather than 15 internal-hardening items.

[sdks-lead-pm]