### PR TITLE
Bound the two slow batched-request race tests' iteration counts

### DIFF
--- a/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
+++ b/Automated/AutomatedTests/TeakBatchedRequestRaceTests.m
@@ -361,20 +361,24 @@ static NSMutableArray<NSArray*>* raceTest_sentBatchSnapshots;
 //
 // Reliability: 8 concurrent threads (= physical performance-core count --
 // the largest safe without a busy-spin rendezvous oversubscribing the
-// machine under TSan overhead) x N=20000 iterations/thread reds at p=0.90
-// per round (18/20 independent single-round samples against the reverted
-// code; Wilson 95% CI lower bound ~0.70). ROUNDS=5 independent rounds in one
-// test method -> aggregate red-rate = 1-(1-p)^ROUNDS: 99.76% at the
-// conservative 0.70 floor, 99.999% at the measured 0.90 point estimate --
-// clears a >=99% target either way. halt_on_error=0 (see the test_race lane)
-// means a TSan report alone doesn't abort the process, but this bug's
-// downstream retain-past-zero crashes shortly after regardless, so one red
-// round is enough; a crash ends the test outright and a non-crashing report
-// still fails the run via Xcode's own TSan/XCTest integration.
+// machine under TSan overhead) x N=250 iterations/thread, ROUNDS=5. The two
+// sub-races differ in strength: the unsynchronized .sent read is a plain
+// cross-lock BOOL access that reds on any thread overlap (deterministic at
+// this N), while the return-path retain reds ~0.95 per round. ROUNDS runs the
+// whole race five independent times in one method, so the weaker half's
+// aggregate clears well past 99.9%. Validated end-to-end, fresh-process x50 at
+// exactly this (N, ROUNDS): reverting either sub-fix alone reds 50/50, the
+// fixed code is green 50/50 with zero false-reds. N sits well above the
+// single-thread overlap floor, so a faster or fewer-core CI box keeps the same
+// margin; the method runs in ~2s (was ~118s at N=20000). halt_on_error=0 (see
+// the test_race lane) means a TSan report alone doesn't abort the process, but
+// the return-path bug's retain-past-zero crashes shortly after regardless; a
+// crash ends the test outright and a non-crashing report still fails the run
+// via Xcode's own TSan/XCTest integration.
 - (void)testCurrentBatchForSessionSentReadIsSerializedUnderConcurrency {
   TeakSession* session = [self makeMockSession];
   const int THREADS = 8;
-  const int N = 20000;
+  const int N = 250;
   const int ROUNDS = 5;
 
   for (int round = 0; round < ROUNDS; round++) {
@@ -412,10 +416,19 @@ static NSMutableArray<NSArray*>* raceTest_sentBatchSnapshots;
 // catch. Drives the real -addRequestIntoBatch: append path concurrently with
 // the real reply callback block (batch.callback, the exact block
 // -initWithSession: installs) instead of a hand-rolled loop over the array.
+//
+// Reliability: a mutate-while-enumerate reds on any overlap of the two blocks,
+// so it's deterministic well below this N (50/50 red at N=100, no rounds
+// needed). N=1000 sits an order of magnitude above that overlap floor so a
+// faster or fewer-core CI box keeps the margin. Validated end-to-end,
+// fresh-process x50 at N=1000: reverting the snapshot-copy fix reds 50/50 (a
+// TSan NSMutableArray report and/or a mutated-while-enumerated crash), the
+// fixed code is green 50/50 with zero false-reds. Runs in ~0.4s (was ~16s at
+// N=8000).
 - (void)testReplyCallbackIterationIsSerializedAgainstAppend {
   TeakSession* session = [self makeMockSession];
   TeakTrackEventBatchedRequest* batch = [[TeakTrackEventBatchedRequest alloc] initWithSession:session];
-  const int N = 8000;
+  const int N = 1000;
 
   [self raceBlockA:^{
     for (int i = 0; i < N; i++) {

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -89,10 +89,13 @@ the race. `+[TeakTrackEventBatchedRequest currentBatchForSession:]` returned a `
 variable outside the `@synchronized` block that guards it — a plain function-local static, not a
 synthesized property getter. Here TSan *does* sometimes report the race, but "sometimes" is doing
 real work: measured against the reverted code, the TSan-report rate and the crash rate track each
-other, drawn from the identical set of runs (~0.95 per 8-thread round at the test's shipped N; see the
-test's own source comment for the validated per-round and end-to-end rates). A single TSan run, or
-even a handful, is not a reliable "is this fixed" signal either way — treat a report the same as a
-crash (strong evidence of a real bug), but don't read its *absence* as proof there isn't one.
+other, drawn from the identical set of runs (~0.95 per fresh-process 8-thread round at the test's
+shipped N=250). An earlier ~0.90 figure here was an in-process pooled-rounds average — later rounds
+run weaker as the heap warms, which is exactly why the shipped multi-round design is validated
+end-to-end rather than trusted from the `1-(1-p)^M` formula (see the test's own source comment for
+those validated rates). A single TSan run, or even a handful, is not a reliable "is this fixed" signal
+either way — treat a report the same as a crash (strong evidence of a real bug), but don't read its
+*absence* as proof there isn't one.
 
 When the crash rate is already high enough per attempt, amplify reliability with independent rounds
 instead of building a dynamic crash-repro harness (§3): measure the per-round red rate `p`

--- a/Automated/RACE_TESTING.md
+++ b/Automated/RACE_TESTING.md
@@ -88,9 +88,10 @@ Not every nonatomic-strong write is fully invisible to TSan — it depends on wh
 the race. `+[TeakTrackEventBatchedRequest currentBatchForSession:]` returned a `static` strong
 variable outside the `@synchronized` block that guards it — a plain function-local static, not a
 synthesized property getter. Here TSan *does* sometimes report the race, but "sometimes" is doing
-real work: measured against the reverted code, the TSan-report rate and the crash rate were the same
-(~90% per 8-thread/20000-iteration round, drawn from the identical set of runs). A single TSan run,
-or even a handful, is not a reliable "is this fixed" signal either way — treat a report the same as a
+real work: measured against the reverted code, the TSan-report rate and the crash rate track each
+other, drawn from the identical set of runs (~0.95 per 8-thread round at the test's shipped N; see the
+test's own source comment for the validated per-round and end-to-end rates). A single TSan run, or
+even a handful, is not a reliable "is this fixed" signal either way — treat a report the same as a
 crash (strong evidence of a real bug), but don't read its *absence* as proof there isn't one.
 
 When the crash rate is already high enough per attempt, amplify reliability with independent rounds


### PR DESCRIPTION
Bounds the two slowest TSan race tests' iteration counts. Both were padded well past what their reverted-code red-rate needs.

- `testCurrentBatchForSessionSentReadIsSerializedUnderConcurrency`: N 20000→250 (ROUNDS held at 5). ~118s → ~2s.
- `testReplyCallbackIterationIsSerializedAgainstAppend`: N 8000→1000. ~16s → ~0.4s.

**How the counts were chosen:** both costs are pure iteration-count, not per-iteration signal. Each design was validated end-to-end, fresh-process ×50 at exactly the shipped (N, ROUNDS):

- Test [1] has two independent sub-fixes; reverting **either** alone reds 50/50 (return-snapshot half and .sent-nesting half checked separately), fully-fixed is green 50/50.
- Test [2] reverting the snapshot-copy fix reds 50/50, fully-fixed green 50/50.
- Zero false-reds on the fixed builds. Red detection is keyed to each race's own TSan signature so incidental noise can't count as covered.

N is held above the single-thread overlap floor (deterministic red sits far lower — 50/50 at N=100 for both) so a faster or fewer-core CI box keeps the same margin.

Production code is untouched — this is purely the test iteration-count change.

https://linear.app/teakio/issue/992
