### PR TITLE
Make TeakReward.onComplete atomic

### DIFF
--- a/Automated/AutomatedTests/RaceTripwireTests.m
+++ b/Automated/AutomatedTests/RaceTripwireTests.m
@@ -288,6 +288,36 @@ static NSMutableArray* keepAliveBareSessions;
             }];
 }
 
+// TeakReward.onComplete is the same host-settable block-UAF shape as logListener above: a public,
+// host-settable nonatomic-strong property whose pointee (the block) is a plain freeable object once
+// it captures data and escapes to the heap. The reward-click reply callback (TeakReward.m) reads it
+// into a single local before invoking, so this guards the property's atomicity itself, not a
+// check-then-call double-read. Confirmed both ways: crashes reliably with onComplete reverted to
+// nonatomic, clean with atomic restored.
+- (void)testOnCompleteIsAtomicUnderConcurrency {
+  TeakReward* reward = [[TeakReward alloc] init];
+  const int N = 2000000;
+  [self raceBlockA:^{
+    for (int i = 0; i < N; i++) {
+      NSString* tag = [[NSString alloc] initWithFormat:@"race-oncomplete-value-%d", i];
+      // Capturing tag is load-bearing: a captureless block literal is __NSGlobalBlock__
+      // (static, never heap-copied, never freed) and wouldn't reproduce the UAF at all.
+      reward.onComplete = ^{
+        (void)tag;
+      };
+    }
+  }
+            blockB:^{
+              for (int i = 0; i < N; i++) {
+                RewardCompleted completion = reward.onComplete;
+                if (completion) {
+                  (void)NSStringFromClass([completion class]).length;
+                  completion();
+                }
+              }
+            }];
+}
+
 // userProfile's pointee is a plain object, not a CFString — reading .stringAttributes.count alone
 // wasn't a reliable enough dereference to reproduce (freed memory quickly reused by the next
 // same-shaped allocation reads back as "valid"); touching the isa via NSStringFromClass forces a

--- a/Teak/TeakReward.h
+++ b/Teak/TeakReward.h
@@ -20,7 +20,7 @@ typedef void (^RewardCompletedWithReward)(TeakReward* _Nonnull reward);
 @property (atomic, readonly) BOOL completed;
 @property (nonatomic, readonly) int rewardStatus;
 @property (strong, nonatomic, readonly) NSDictionary* _Nonnull json;
-@property (nonatomic, copy) RewardCompleted _Nullable onComplete;
+@property (atomic, copy) RewardCompleted _Nullable onComplete;
 
 + (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId;
 + (nullable TeakReward*)rewardForRewardId:(nonnull NSString*)teakRewardId onComplete:(nullable RewardCompletedWithReward)onComplete;


### PR DESCRIPTION
https://linear.app/teakio/issue/995

`onComplete` was `nonatomic, copy` while read on the reward-click reply thread — the same host-settable block-UAF class fixed for `Teak.logListener` in b3122bd. Pulled forward from the C-982 breaking rework since the atomicity piece is non-breaking on its own.

- `Teak/TeakReward.h`: `onComplete` → `atomic, copy`. The reply callback in `TeakReward.m` already captures a single local read before invoking, so no check-then-call site needed touching.
- `Automated/AutomatedTests/RaceTripwireTests.m`: `testOnCompleteIsAtomicUnderConcurrency`, a dynamic crash-repro guard per `RACE_TESTING.md` (TSan is blind to nonatomic-strong UAFs). Revert-checked: crashes reliably on nonatomic, clean on atomic.