### PR TITLE
Document scheduleNotificationForCreative:secondsFromNow:forUserIds: (cross-user scheduling)

### DIFF
--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -257,7 +257,7 @@ let notif = TeakNotification.scheduleNotification(forCreative: "my_creative_id",
                                                     forUserIds: ["user1", "user2"])
 ----
 
-This returns a ``TeakNotification`` that completes asynchronously -- check ``notif.completed`` before reading ``notif.status``. ``notif.teakNotifId`` is a JSON-encoded array of scheduled-notification ids rather than a single id.
+This returns a ``TeakNotification`` that completes asynchronously -- check ``notif.completed`` before reading ``notif.status``. ``notif.teakNotifId`` is a JSON-encoded array of the delivery ids that were created, not a single id -- it isn't positionally matched to ``userIds`` and may contain fewer entries, for example if one of the user ids you passed doesn't resolve to a player in your game.
 
 === Canceling a Scheduled Notification
 

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -237,6 +237,28 @@ if let op = op {
 OperationQueue().addOperation(whenDone)
 ----
 
+=== Scheduling a Notification for Other Players
+
+Use ``<<scheduleNotificationForCreative:secondsFromNow:forUserIds:>>`` to schedule a notification for other players -- for example, telling a friend they've been sent a gift.
+
+.Example (Objective-C)
+[source,objc]
+----
+TeakNotification* notif = [TeakNotification scheduleNotificationForCreative:@"my_creative_id"
+                                                              secondsFromNow:5
+                                                                  forUserIds:@[ @"user1", @"user2" ]];
+----
+
+.Example (Swift)
+[source,swift]
+----
+let notif = TeakNotification.scheduleNotification(forCreative: "my_creative_id",
+                                                    secondsFromNow: 5,
+                                                    forUserIds: ["user1", "user2"])
+----
+
+This returns a ``TeakNotification`` that completes asynchronously -- check ``notif.completed`` before reading ``notif.status``. Because this schedules one notification per target user, ``notif.teakNotifId`` is a JSON-encoded array of ids rather than a single id.
+
 === Canceling a Scheduled Notification
 
 To cancel a notification that you've scheduled from the client use ``<<cancelScheduledNotification:>>``.

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -239,7 +239,7 @@ OperationQueue().addOperation(whenDone)
 
 === Scheduling a Notification for Other Players
 
-Use ``<<scheduleNotificationForCreative:secondsFromNow:forUserIds:>>`` to schedule a notification for other players -- for example, telling a friend they've been sent a gift.
+Use ``<<scheduleNotificationForCreative:secondsFromNow:forUserIds:>>`` to schedule a notification for other players -- for example, telling a friend they've been sent a gift. The creative must already exist on the dashboard; this call won't create one.
 
 .Example (Objective-C)
 [source,objc]

--- a/docs/modules/ROOT/pages/working-with-teak.adoc
+++ b/docs/modules/ROOT/pages/working-with-teak.adoc
@@ -257,7 +257,7 @@ let notif = TeakNotification.scheduleNotification(forCreative: "my_creative_id",
                                                     forUserIds: ["user1", "user2"])
 ----
 
-This returns a ``TeakNotification`` that completes asynchronously -- check ``notif.completed`` before reading ``notif.status``. Because this schedules one notification per target user, ``notif.teakNotifId`` is a JSON-encoded array of ids rather than a single id.
+This returns a ``TeakNotification`` that completes asynchronously -- check ``notif.completed`` before reading ``notif.status``. ``notif.teakNotifId`` is a JSON-encoded array of scheduled-notification ids rather than a single id.
 
 === Canceling a Scheduled Notification
 


### PR DESCRIPTION
## Summary

`scheduleNotificationForCreative:secondsFromNow:forUserIds:` is a live, non-deprecated 4.3.x API on `TeakNotification` that schedules a creative for other players (by game-assigned user id), but it wasn't in the shipped docs -- it was drafted once in #157 and deliberately cut to keep that PR scoped to the personalizationData variant.

Adds a "Scheduling a Notification for Other Players" subsection to `working-with-teak.adoc`, matching the conventions that section settled on after the #157 cut (paired Objective-C/Swift examples, no C bridge signatures, no defensive framing). Both example snippets were compiled (`clang -fsyntax-only` / `swiftc -typecheck`) against the real prebuilt `Teak.xcframework`, not hand-derived.

Notes the behavioral gotchas, both confirmed against source (not the header comments):
- The returned `TeakNotification` completes asynchronously -- check `.completed` before `.status`.
- The creative must already exist on the dashboard -- confirmed by @alex: only the deprecated `withMessage:` variants auto-create one.
- `.teakNotifId` is a JSON-encoded array of the delivery ids that were created, not a single id, and it's **not** positionally matched to `userIds` -- confirmed against `BulkNotificationScheduleController#schedule_from_device` in carrot: the array comes back in ApiKey query order, and any user id with no matching player in-game is silently dropped, so it can be shorter than the input.

Docs-only change, no code touched, no changelog entry (not a behavior change).

A separate follow-up (C-1167) was filed for an unrelated, pre-existing header-comment inaccuracy this PR's discussion surfaced (`TeakNotification.h:14`, the personalizationData variant) -- out of scope here, doesn't touch this diff.

Linear: https://linear.app/teakio/issue/935

## Test plan
- [x] Both example snippets compiled clean against `../teak-ios-framework`'s `Teak.xcframework` (ObjC + Swift)
- [x] Xref target (`scheduleNotificationForCreative:secondsFromNow:forUserIds:`) verified against fresh `npm run docs` doxygen output -- exact anchor match
- [x] Both deferred server-behavior questions confirmed and folded into the prose
- [x] Reviewer pass