### PR TITLE
Fix wrong auto-create claim in TeakNotification.h doc comment

### DIFF
--- a/Teak/TeakNotification.h
+++ b/Teak/TeakNotification.h
@@ -11,7 +11,7 @@
 /**
  * Schedule a notification for this user at a time in the future.
  *
- * @param creativeId                      The identifier of the notification in the Teak dashboard (will create if not found).
+ * @param creativeId                      The identifier of the notification in the Teak dashboard, this must already exist.
  * @param delay                                 The delay in seconds from now to send the notification.
  * @param personalizationData Optional dictionary of addiontal information which can be used for templating.
  */

--- a/Teak/TeakNotification.h
+++ b/Teak/TeakNotification.h
@@ -13,7 +13,7 @@
  *
  * @param creativeId                      The identifier of the notification in the Teak dashboard, this must already exist.
  * @param delay                                 The delay in seconds from now to send the notification.
- * @param personalizationData Optional dictionary of addiontal information which can be used for templating.
+ * @param personalizationData Optional dictionary of additional information which can be used for templating.
  */
 + (nullable TeakOperation*)scheduleNotificationForCreative:(nonnull NSString*)creativeId secondsFromNow:(int64_t)delay personalizationData:(nullable NSDictionary*)personalizationData;
 


### PR DESCRIPTION
https://linear.app/teakio/issue/C-1167

TeakNotification.h:14's doc comment claimed the `personalizationData` variant of `scheduleNotificationForCreative:secondsFromNow:personalizationData:` auto-creates a creative on the dashboard if not found. Only the deprecated `withMessage:` variant (line 110) does that; this variant requires the creative to already exist. Reworded to match the `forUserIds` variant's existing correct phrasing at line 119.

Verified against carrot: `BusinessProcess::SetupLocalNotification#fill_in_content` runs regardless of message presence when the notification group is new, but raises an explicit "is not configured on the dashboard" error when `message.blank?` — so the personalizationData path fails loudly rather than silently creating or silently no-oping.

Comment-only change, no test needed.