### PR TITLE
Fix wrong auto-create claim in TeakNotification.h doc comment (4.3-stable)

### DIFF
--- a/Teak/TeakNotification.h
+++ b/Teak/TeakNotification.h
@@ -11,7 +11,7 @@
 /**
  * Schedule a notification for this user at a time in the future.
  *
- * @param creativeId                      The identifier of the notification in the Teak dashboard (will create if not found).
+ * @param creativeId                      The identifier of the notification in the Teak dashboard, this must already exist.
  * @param delay                                 The delay in seconds from now to send the notification.
  * @param personalizationData Optional dictionary of addiontal information which can be used for templating.
  */

--- a/Teak/TeakNotification.h
+++ b/Teak/TeakNotification.h
@@ -13,7 +13,7 @@
  *
  * @param creativeId                      The identifier of the notification in the Teak dashboard, this must already exist.
  * @param delay                                 The delay in seconds from now to send the notification.
- * @param personalizationData Optional dictionary of addiontal information which can be used for templating.
+ * @param personalizationData Optional dictionary of additional information which can be used for templating.
  */
 + (nullable TeakOperation*)scheduleNotificationForCreative:(nonnull NSString*)creativeId secondsFromNow:(int64_t)delay personalizationData:(nullable NSDictionary*)personalizationData;
 


### PR DESCRIPTION
https://linear.app/teakio/issue/C-1167

4.3-stable twin of #194 — same wrong "(will create if not found)" phrase exists verbatim on this branch. Cherry-picked from develop.

TeakNotification.h:14's doc comment claimed the `personalizationData` variant of `scheduleNotificationForCreative:secondsFromNow:personalizationData:` auto-creates a creative on the dashboard if not found. Only the deprecated `withMessage:` variant (line 110) does that; this variant requires the creative to already exist. Reworded to match the `forUserIds` variant's existing correct phrasing at line 119.

Comment-only change, no test needed.