### PR TITLE
Fix teakNotifId header doc and mistagged JSON-serialization error

### DIFF
--- a/Teak/TeakNotification.h
+++ b/Teak/TeakNotification.h
@@ -18,9 +18,9 @@
 + (nullable TeakOperation*)scheduleNotificationForCreative:(nonnull NSString*)creativeId secondsFromNow:(int64_t)delay personalizationData:(nullable NSDictionary*)personalizationData;
 
 /**
- * The identifier for the scheduled notification.
+ * The id of the notification this call created or canceled, or a JSON-encoded array of ids if it affected more than one.
  *
- * Also accessable via:
+ * Also accessible via:
  *
  * 	const char* TeakNotificationGetTeakNotifId(TeakNotification* notif)
  */
@@ -37,7 +37,7 @@
  * - error.parameter.delayInSeconds - delayInSeconds can not be negative, or greater than one month
  * - error.parameter.userIds - userIds can not be null or empty
  *
- * Also accessable via:
+ * Also accessible via:
  *
  * 	const char* TeakNotificationGetStatus(TeakNotification* notif)
  */
@@ -96,7 +96,7 @@
 /**
  * YES if the notification operation has completed.
  *
- * Also accessable via:
+ * Also accessible via:
  *
  * 	BOOL TeakNotificationIsCompleted(TeakNotification* notif)
  */

--- a/Teak/TeakNotification.m
+++ b/Teak/TeakNotification.m
@@ -231,7 +231,7 @@
                                                       NSError* error = nil;
                                                       NSData* jsonData = [NSJSONSerialization dataWithJSONObject:reply[@"ids"] options:0 error:&error];
                                                       if (error) {
-                                                        TeakLog_e(@"notification.cancel_all.error.json", @{@"value" : reply[@"ids"], @"error" : error});
+                                                        TeakLog_e(@"notification.schedule.error.json", @{@"value" : reply[@"ids"], @"error" : error});
                                                         ret.teakNotifId = @"[]";
                                                       } else {
                                                         ret.teakNotifId = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
https://linear.app/teakio/issue/C-1235/teak-ios-teaknotifid-header-doc-says-the-identifier-its-a-json-array
https://linear.app/teakio/issue/C-1236/teak-ios-schedule-path-logs-json-failure-under-the-cancel-all-tag

[teak-teak-ios-worker-c-1235]

Carries C-1236 too — same method, ten lines apart, not worth splitting.

- `TeakNotification.h` — `teakNotifId`'s doc said "The identifier for the scheduled notification" (singular). True for the single-user schedule/cancel paths, but `forUserIds:` and `cancelAll` both JSON-encode an array of ids into it. Reworded to one sentence covering both shapes instead of enumerating each writer (avoids the doc going stale again if a fifth writer shows up).
- `TeakNotification.m:234` — the `forUserIds:` JSON-serialization-failure log was tagged `notification.cancel_all.error.json`, copy-pasted from the `cancelAll` path. Retagged to `notification.schedule.error.json`, mirroring the existing `cancel_all.error`/`cancel_all.error.json` split so a serialization failure stays greppable apart from a server-rejected schedule. (Deviates from the issue's literal `notification.schedule.error` suggestion — confirmed with lead-pm.)

Doc-only + log-tag-only, no behavior change.

Checked teak-android/teak-unity for the same singular-doc defect: no match. Android's `teakNotifId` is an unrelated `long` (received-push platform id, not a schedule-operation result). Unity's equivalent (`Reply.Notifications`, a `List<Notification>`) already documents itself plural — it's already parsing this same iOS property as "sometimes an array" (`TeakNotification.cs:457-492`), which is corroborating evidence the iOS header was the thing that was wrong.
