### PR TITLE
Merge 4.3-stable into develop (C-1270 merge-back)

### DIFF
--- a/Teak/TeakNotification.h
+++ b/Teak/TeakNotification.h
@@ -11,9 +11,9 @@
 /**
  * Schedule a notification for this user at a time in the future.
  *
- * @param creativeId                      The identifier of the notification in the Teak dashboard (will create if not found).
+ * @param creativeId                      The identifier of the notification in the Teak dashboard, this must already exist.
  * @param delay                                 The delay in seconds from now to send the notification.
- * @param personalizationData Optional dictionary of addiontal information which can be used for templating.
+ * @param personalizationData Optional dictionary of additional information which can be used for templating.
  */
 + (nullable TeakOperation*)scheduleNotificationForCreative:(nonnull NSString*)creativeId secondsFromNow:(int64_t)delay personalizationData:(nullable NSDictionary*)personalizationData;
 

--- a/Teak/TeakNotification.h
+++ b/Teak/TeakNotification.h
@@ -18,9 +18,9 @@
 + (nullable TeakOperation*)scheduleNotificationForCreative:(nonnull NSString*)creativeId secondsFromNow:(int64_t)delay personalizationData:(nullable NSDictionary*)personalizationData;
 
 /**
- * The identifier for the scheduled notification.
+ * The id of the notification this call created or canceled, or a JSON-encoded array of ids if it affected more than one.
  *
- * Also accessable via:
+ * Also accessible via:
  *
  * 	const char* TeakNotificationGetTeakNotifId(TeakNotification* notif)
  */
@@ -37,7 +37,7 @@
  * - error.parameter.delayInSeconds - delayInSeconds can not be negative, or greater than one month
  * - error.parameter.userIds - userIds can not be null or empty
  *
- * Also accessable via:
+ * Also accessible via:
  *
  * 	const char* TeakNotificationGetStatus(TeakNotification* notif)
  */
@@ -96,7 +96,7 @@
 /**
  * YES if the notification operation has completed.
  *
- * Also accessable via:
+ * Also accessible via:
  *
  * 	BOOL TeakNotificationIsCompleted(TeakNotification* notif)
  */

--- a/Teak/TeakNotification.m
+++ b/Teak/TeakNotification.m
@@ -231,7 +231,7 @@
                                                       NSError* error = nil;
                                                       NSData* jsonData = [NSJSONSerialization dataWithJSONObject:reply[@"ids"] options:0 error:&error];
                                                       if (error) {
-                                                        TeakLog_e(@"notification.cancel_all.error.json", @{@"value" : reply[@"ids"], @"error" : error});
+                                                        TeakLog_e(@"notification.schedule.error.json", @{@"value" : reply[@"ids"], @"error" : error});
                                                         ret.teakNotifId = @"[]";
                                                       } else {
                                                         ret.teakNotifId = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
https://linear.app/teakio/issue/C-1270

Merges `4.3-stable` into `develop` to bring PR #196's doc/log-tag fixes across (the
merge-back this repo does per stable release). `develop..origin/4.3-stable` was exactly
3 commits (#195, #196's two); this closes that divergence rather than leaving them to be
replayed at the next routine merge.

Ports:
- `TeakNotification.h` — reworded the `teakNotifId` doc to cover the array-JSON-encoded
  case (`forUserIds:`/`cancelAll`), fixed 3x "accessable" -> "accessible" typo.
- `TeakNotification.m:234` — retagged the `forUserIds:` JSON-serialization-failure log
  from `notification.cancel_all.error.json` to `notification.schedule.error.json`,
  mirroring the existing `cancel_all.error`/`cancel_all.error.json` split. Line 308
  (the actual cancelAll path) is untouched.

Confirmed the merge diff is byte-identical to PR #196's delta before committing.
Doc/log-tag only, no behavior change.

Note: CI will show red here — `build` is currently broken on `develop` from an expired
Apple signing cert (C-1477), unrelated to this change.